### PR TITLE
Force patched transitive deps to resolve 16 Dependabot security alerts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,6 +116,22 @@ tasks.named("preBuild") {
     dependsOn("downloadDataAssets")
 }
 
+// Force patched versions of vulnerable transitive dependencies.
+configurations.all {
+    resolutionStrategy.eachDependency {
+        val group = requested.group
+        val name  = requested.name
+        when {
+            group == "io.netty" -> useVersion("4.1.129.Final")
+            group == "com.google.protobuf" && name == "protobuf-kotlin" -> useVersion("3.25.5")
+            group == "com.google.protobuf" && name == "protobuf-java"   -> useVersion("3.25.5")
+            group == "org.bitbucket.b_c"   && name == "jose4j"          -> useVersion("0.9.6")
+            group == "org.jdom"            && name == "jdom2"            -> useVersion("2.0.6.1")
+            group == "org.apache.commons"  && name == "commons-compress" -> useVersion("1.26.0")
+        }
+    }
+}
+
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,3 +4,22 @@ plugins {
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.android) apply false
 }
+
+// Force patched versions of vulnerable transitive build-classpath dependencies.
+// These come from AGP's bundled gRPC/Netty stack and are build-time only (not shipped in the APK).
+buildscript {
+    configurations.all {
+        resolutionStrategy.eachDependency {
+            val group = requested.group
+            val name  = requested.name
+            when {
+                group == "io.netty" -> useVersion("4.1.129.Final")
+                group == "com.google.protobuf" && name == "protobuf-kotlin" -> useVersion("3.25.5")
+                group == "com.google.protobuf" && name == "protobuf-java"   -> useVersion("3.25.5")
+                group == "org.bitbucket.b_c"   && name == "jose4j"          -> useVersion("0.9.6")
+                group == "org.jdom"            && name == "jdom2"            -> useVersion("2.0.6.1")
+                group == "org.apache.commons"  && name == "commons-compress" -> useVersion("1.26.0")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Adds `resolutionStrategy.eachDependency` blocks in `build.gradle.kts` (build classpath — covers AGP's bundled gRPC/Netty stack) and `app/build.gradle.kts` (all app module configurations) to force minimum safe versions for all 16 open Dependabot security alerts.

All affected packages are build-time only — none are shipped in the APK. Root cause: AGP 8.13.2 bundles `grpc-netty:1.69.1` which pulls Netty `4.1.110.Final`, along with older jose4j, jdom2, and commons-compress via its build toolchain.

| Package | From | To | Alerts |
|---------|------|----|--------|
| `io.netty:*` | `4.1.110.Final` | `4.1.129.Final` | #1, #2, #7, #14–16, #18–20, #23 |
| `com.google.protobuf:protobuf-kotlin` | `3.24.4` | `3.25.5` | #25 |
| `org.bitbucket.b_c:jose4j` | `0.9.5` | `0.9.6` | #24 |
| `org.jdom:jdom2` | `2.0.6` | `2.0.6.1` | #21 |
| `org.apache.commons:commons-compress` | `1.21` | `1.26.0` | #5, #6 |
| `com.google.protobuf:protobuf-java` | `3.24.4` | `3.25.5` | #11 |

## Type of Change
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Chore (Non functional changes, documentation, etc.)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)