### PR TITLE
Fix release pipeline PR body escaping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,9 @@ jobs:
 
     - name: Determine Version Bump
       id: bump_type
+      env:
+        BODY: ${{ github.event.pull_request.body }}
       run: |
-        BODY="${{ github.event.pull_request.body }}"
         if [[ "$BODY" == *"[x] 💥 Breaking change"* ]]; then
           echo "type=major" >> $GITHUB_OUTPUT
         elif [[ "$BODY" == *"[x] ✨ New feature"* ]]; then


### PR DESCRIPTION
## Description

The version bump detection step was failing when PR descriptions contained backticks (e.g. inline code like \`MainActivity.kt\`). Bash was interpreting them as command substitution because the PR body was inlined directly via \`\${{ github.event.pull_request.body }}\` in the \`run:\` block.

Fix: pass the body via \`env:\` instead. GitHub Actions escapes the value before the shell sees it, so backticks and special characters are treated as literals.

## Type of Change
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Chore (Non functional changes, documentation, etc.)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)