### PR TITLE
Fix release pipeline failing when data.version is unchanged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,5 +108,9 @@ jobs:
         git config user.name  "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add data.version
-        git commit -m "chore: pin data.version to ${{ steps.pin_data.outputs.data_tag }} for release ${{ steps.tag_version.outputs.new_tag }} [skip ci]"
-        git push origin HEAD:main
+        if ! git diff --staged --quiet; then
+          git commit -m "chore: pin data.version to ${{ steps.pin_data.outputs.data_tag }} for release ${{ steps.tag_version.outputs.new_tag }} [skip ci]"
+          git push origin HEAD:main
+        else
+          echo "data.version unchanged, skipping commit"
+        fi


### PR DESCRIPTION
## Description

When the latest lunachron-data release tag matches the already-committed \`data.version\`, the "Commit pinned data.version to main" step was failing with "nothing to commit" (exit code 1), breaking the release pipeline.

Fix: check whether \`data.version\` actually changed after staging it (\`git diff --staged --quiet\`), and only commit and push if it did. Logs a skip message otherwise.

## Type of Change
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Chore (Non functional changes, documentation, etc.)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)