### PR TITLE
Disable PNG crunching for reproducible builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,6 +42,7 @@ android {
     buildTypes {
         release {
             isMinifyEnabled = false
+            isCrunchPngs = false
             // Only apply signingConfig if storeFile is set
             if (signingConfigs.getByName("release").storeFile != null) {
                 signingConfig = signingConfigs.getByName("release")


### PR DESCRIPTION
## Description

Disables PNG crunching in release builds by setting \`isCrunchPngs = false\` on the release build type.

\`aapt\`'s PNG crunching is non-deterministic across build environments, which can prevent F-Droid from verifying that their independent build matches our GitHub release APK byte-for-byte. With crunching disabled, PNG assets are included as-is, ensuring identical output across builds.

Note: \`aaptOptions.cruncherEnabled\` is deprecated in AGP 8+ — \`isCrunchPngs\` per build type is the current replacement.

## Type of Change
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Chore (Non functional changes, documentation, etc.)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)