### PR TITLE
Fix versionCode/versionName for F-Droid reproducible builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,14 +43,42 @@ jobs:
         echo "$DATA_TAG" > data.version
         echo "Pinned data release: $DATA_TAG"
 
-    - name: Create Tag
+    - name: Compute next version and write to build.gradle.kts
       if: steps.bump_type.outputs.type != 'none'
-      id: tag_version
-      uses: anothrNick/github-tag-action@1.75.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        DEFAULT_BUMP: ${{ steps.bump_type.outputs.type }}
-        WITH_V: true
+      id: version
+      run: |
+        LATEST_TAG=$(git tag --sort=-v:refname | grep '^v' | head -1)
+        LATEST="${LATEST_TAG#v}"
+        if [ -z "$LATEST" ]; then LATEST="0.0.0"; fi
+        IFS='.' read -r major minor patch <<< "$LATEST"
+        major=${major:-0}; minor=${minor:-0}; patch=${patch:-0}
+        case "${{ steps.bump_type.outputs.type }}" in
+          major) major=$((major+1)); minor=0; patch=0 ;;
+          minor) minor=$((minor+1)); patch=0 ;;
+          patch) patch=$((patch+1)) ;;
+        esac
+        VERSION_NAME="${major}.${minor}.${patch}"
+        VERSION_CODE=$(( major * 10000 + minor * 100 + patch ))
+        NEW_TAG="v${VERSION_NAME}"
+        echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
+        echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
+        echo "version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
+        # Write hardcoded values into build.gradle.kts so F-Droid can read them
+        # directly from the tagged commit without needing env var injection.
+        sed -i "s/        versionCode = .*/        versionCode = $VERSION_CODE/" app/build.gradle.kts
+        sed -i "s/        versionName = .*/        versionName = \"$VERSION_NAME\"/" app/build.gradle.kts
+        echo "Version: $VERSION_NAME ($VERSION_CODE), tag: $NEW_TAG"
+
+    - name: Commit release files and create tag
+      if: steps.bump_type.outputs.type != 'none'
+      run: |
+        git config user.name  "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add app/build.gradle.kts data.version
+        git diff --staged --quiet || git commit -m "chore: release ${{ steps.version.outputs.new_tag }} [skip ci]"
+        git push origin HEAD:main
+        git tag ${{ steps.version.outputs.new_tag }}
+        git push origin ${{ steps.version.outputs.new_tag }}
 
     - name: set up JDK 17
       if: steps.bump_type.outputs.type != 'none'
@@ -69,17 +97,6 @@ jobs:
       run: |
         echo "${{ secrets.RELEASE_KEYSTORE }}" | base64 --decode > app/release.keystore
 
-    - name: Compute version code and name
-      if: steps.bump_type.outputs.type != 'none'
-      run: |
-        TAG="${{ steps.tag_version.outputs.new_tag }}"
-        VERSION_NAME="${TAG#v}"
-        IFS='.' read -r major minor patch <<< "$VERSION_NAME"
-        VERSION_CODE=$(( ${major:-0} * 10000 + ${minor:-0} * 100 + ${patch:-0} ))
-        echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_ENV
-        echo "VERSION_NAME=$VERSION_NAME" >> $GITHUB_ENV
-        echo "Version: $VERSION_NAME ($VERSION_CODE)"
-
     - name: Build Release APK
       if: steps.bump_type.outputs.type != 'none'
       env:
@@ -87,30 +104,15 @@ jobs:
         KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
         KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
         KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
-        VERSION_CODE: ${{ env.VERSION_CODE }}
-        VERSION_NAME: ${{ env.VERSION_NAME }}
       run: ./gradlew assembleRelease
 
     - name: Create GitHub Release
       if: steps.bump_type.outputs.type != 'none'
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: ${{ steps.tag_version.outputs.new_tag }}
+        tag_name: ${{ steps.version.outputs.new_tag }}
         files: app/build/outputs/apk/release/app-release.apk
-        name: Release ${{ steps.tag_version.outputs.new_tag }}
+        name: Release ${{ steps.version.outputs.new_tag }}
         generate_release_notes: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Commit pinned data.version to main
-      if: steps.bump_type.outputs.type != 'none'
-      run: |
-        git config user.name  "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add data.version
-        if ! git diff --staged --quiet; then
-          git commit -m "chore: pin data.version to ${{ steps.pin_data.outputs.data_tag }} for release ${{ steps.tag_version.outputs.new_tag }} [skip ci]"
-          git push origin HEAD:main
-        else
-          echo "data.version unchanged, skipping commit"
-        fi

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "io.github.garemat.lunachron"
         minSdk = 24
         targetSdk = 36
-        versionCode = System.getenv("VERSION_CODE")?.toIntOrNull() ?: 1
-        versionName = System.getenv("VERSION_NAME") ?: "1.0.0"
+        versionCode = 1
+        versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Description

F-Droid builds the app from source at the tagged commit without any CI env var injection. Previously \`versionCode\` and \`versionName\` were read from \`VERSION_CODE\`/\`VERSION_NAME\` env vars, meaning F-Droid would always build with the fallback values (\`1\` / \`"1.0.0"\`) and fail version verification.

**Fix:** the release workflow now:
1. Computes the next semver version itself (replacing the \`anothrNick/github-tag-action\` dependency)
2. Writes the hardcoded \`versionCode\` and \`versionName\` into \`build.gradle.kts\` via \`sed\` before tagging
3. Commits \`build.gradle.kts\` + \`data.version\` to main, then tags that commit

This ensures the tagged commit always has the correct values baked in for F-Droid to read directly. Also consolidates the previously separate "Commit pinned data.version" step into the single release commit.

## Type of Change
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Chore (Non functional changes, documentation, etc.)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)