### PR TITLE
Fix versionCode/versionName for F-Droid reproducible builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,14 +69,13 @@ jobs:
         sed -i "s/        versionName = .*/        versionName = \"$VERSION_NAME\"/" app/build.gradle.kts
         echo "Version: $VERSION_NAME ($VERSION_CODE), tag: $NEW_TAG"
 
-    - name: Commit release files and create tag
+    - name: Create release commit and tag
       if: steps.bump_type.outputs.type != 'none'
       run: |
         git config user.name  "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add app/build.gradle.kts data.version
         git diff --staged --quiet || git commit -m "chore: release ${{ steps.version.outputs.new_tag }} [skip ci]"
-        git push origin HEAD:main
         git tag ${{ steps.version.outputs.new_tag }}
         git push origin ${{ steps.version.outputs.new_tag }}
 


### PR DESCRIPTION
## Description

F-Droid builds the app from source at the tagged commit without any CI env var injection. Previously `versionCode` and `versionName` were read from `VERSION_CODE`/`VERSION_NAME` env vars, meaning F-Droid would always build with the fallback values (`1` / `"1.0.0"`) and fail version verification.

**Fix:**
- Release workflow now computes the next semver version itself (replacing the `anothrNick/github-tag-action` dependency)
- Writes hardcoded `versionCode` and `versionName` into `build.gradle.kts` via `sed` before tagging
- Creates a local commit with `build.gradle.kts` + `data.version`, tags that commit, and pushes **only the tag** — avoids branch protection on main entirely since F-Droid only needs the values at the tagged commit
- `build.gradle.kts` simplified to plain defaults (`1` / `"1.0.0"`) since CI always overwrites them before tagging

## Type of Change
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Chore (Non functional changes, documentation, etc.)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)