### PR TITLE
fix: use findByName for signingConfig to survive F-Droid build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,9 +43,11 @@ android {
         release {
             isMinifyEnabled = false
             isCrunchPngs = false
-            // Only apply signingConfig if storeFile is set
-            if (signingConfigs.getByName("release").storeFile != null) {
-                signingConfig = signingConfigs.getByName("release")
+            // Only apply signingConfig if it exists and storeFile is set.
+            // fdroidserver strips the signingConfigs block before building, so
+            // findByName (returns null) is used instead of getByName (throws).
+            signingConfigs.findByName("release")?.takeIf { it.storeFile != null }?.let {
+                signingConfig = it
             }
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),


### PR DESCRIPTION
## Summary

- `fdroidserver` strips the `signingConfigs { }` block from `build.gradle.kts` before building, but our `buildTypes.release` block called `signingConfigs.getByName("release")` in the `if` condition — this threw `SigningConfig with name 'release' not found` and broke the local `fdroid build` test
- Replaced `getByName` (throws if absent) with `findByName` (returns null if absent) so the condition safely resolves to `null` when fdroidserver has removed the signing config block

## Test plan
- [x] `fdroid build -v -l io.github.garemat.lunachron:20203` passes the signing-config cleanup step without exception
- [ ] Full F-Droid local build completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)