### PR TITLE
fix: use findByName for signingConfig to survive F-Droid build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,9 +43,11 @@ android {
         release {
             isMinifyEnabled = false
             isCrunchPngs = false
-            // Only apply signingConfig if storeFile is set
-            if (signingConfigs.getByName("release").storeFile != null) {
-                signingConfig = signingConfigs.getByName("release")
+            // Only apply signingConfig if it exists and storeFile is set.
+            // fdroidserver strips the signingConfigs block before building, so
+            // findByName (returns null) is used instead of getByName (throws).
+            signingConfigs.findByName("release")?.takeIf { it.storeFile != null }?.let {
+                signingConfig = it
             }
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),


### PR DESCRIPTION
## Description
`fdroidserver` strips the `signingConfigs { }` block from `build.gradle.kts` before building. Our `buildTypes.release` block called `signingConfigs.getByName("release")` in the `if` condition, which threw `SigningConfig with name 'release' not found` and failed the local `fdroid build` test. Replaced with `findByName` which returns `null` safely when the config has been removed.

## Type of Change
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Chore (Non functional changes, documentation, etc.)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)