### PR TITLE
fix: replace ML Kit barcode scanning with ZXing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -169,7 +169,6 @@ dependencies {
     implementation(libs.androidx.camera.camera2)
     implementation(libs.androidx.camera.lifecycle)
     implementation(libs.androidx.camera.view)
-    implementation(libs.mlkit.barcode.scanning)
 
     implementation(libs.jsoup)
     implementation(libs.ktor.client.core)

--- a/app/src/main/java/io/github/garemat/lunachron/ui/AddEditTroupeScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/AddEditTroupeScreen.kt
@@ -1,6 +1,11 @@
 package io.github.garemat.lunachron.ui
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -27,8 +32,10 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.core.content.ContextCompat
 import io.github.garemat.lunachron.*
 import io.github.garemat.lunachron.ui.theme.LocalAppThemeProperties
 import kotlinx.coroutines.launch
@@ -314,9 +321,25 @@ private fun ImportTroupeTab(
     onBack: () -> Unit,
     onImportSuccess: () -> Unit
 ) {
+    val context = LocalContext.current
     var importCode by remember { mutableStateOf("") }
     var importError by remember { mutableStateOf(false) }
     var showScanner by remember { mutableStateOf(false) }
+
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) showScanner = true
+        else Toast.makeText(context, "Camera permission is required to scan QR codes", Toast.LENGTH_SHORT).show()
+    }
+
+    fun requestScan() {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED) {
+            showScanner = true
+        } else {
+            cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+        }
+    }
 
     fun tryImport(code: String) {
         val troupe = viewModel.importTroupe(code.trim(), state.characters, state.upgradeCards)
@@ -342,7 +365,7 @@ private fun ImportTroupeTab(
         Spacer(modifier = Modifier.height(16.dp))
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
             OutlinedButton(
-                onClick = { showScanner = true },
+                onClick = { requestScan() },
                 modifier = Modifier.weight(1f),
                 shape = theme.cardShape
             ) {

--- a/app/src/main/java/io/github/garemat/lunachron/ui/QrScanner.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/QrScanner.kt
@@ -16,9 +16,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
-import com.google.mlkit.vision.barcode.BarcodeScanning
-import com.google.mlkit.vision.barcode.common.Barcode
-import com.google.mlkit.vision.common.InputImage
+import com.google.zxing.BinaryBitmap
+import com.google.zxing.MultiFormatReader
+import com.google.zxing.NotFoundException
+import com.google.zxing.PlanarYUVLuminanceSource
+import com.google.zxing.common.HybridBinarizer
 import java.util.concurrent.Executors
 
 @OptIn(ExperimentalGetImage::class)
@@ -29,7 +31,7 @@ fun QrScanner(
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val cameraProviderFuture = remember { ProcessCameraProvider.getInstance(context) }
-    
+
     var isScanningComplete by remember { mutableStateOf(false) }
 
     AndroidView(
@@ -48,34 +50,60 @@ fun QrScanner(
                     it.setSurfaceProvider(previewView.surfaceProvider)
                 }
 
-                val scanner = BarcodeScanning.getClient()
+                val reader = MultiFormatReader()
+                val mainExecutor = ContextCompat.getMainExecutor(ctx)
                 val imageAnalysis = ImageAnalysis.Builder()
                     .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
                     .build()
 
                 imageAnalysis.setAnalyzer(Executors.newSingleThreadExecutor()) { imageProxy ->
-                    val mediaImage = imageProxy.image
-                    if (mediaImage != null && !isScanningComplete) {
-                        val image = InputImage.fromMediaImage(mediaImage, imageProxy.imageInfo.rotationDegrees)
-                        scanner.process(image)
-                            .addOnSuccessListener { barcodes ->
-                                for (barcode in barcodes) {
-                                    if (barcode.valueType == Barcode.TYPE_TEXT || barcode.valueType == Barcode.TYPE_URL) {
-                                        barcode.rawValue?.let { value ->
-                                            if (!isScanningComplete) {
-                                                isScanningComplete = true
-                                                onResult(value)
-                                            }
-                                        }
-                                    }
+                    if (!isScanningComplete) {
+                        val mediaImage = imageProxy.image
+                        if (mediaImage != null) {
+                            // Extract Y (luminance) plane, stripping any row-stride padding
+                            val plane = mediaImage.planes[0]
+                            val buffer = plane.buffer
+                            val rowStride = plane.rowStride
+                            val width = mediaImage.width
+                            val height = mediaImage.height
+                            val yBytes = ByteArray(width * height)
+                            if (rowStride == width) {
+                                buffer.get(yBytes)
+                            } else {
+                                val rowData = ByteArray(rowStride)
+                                for (row in 0 until height) {
+                                    buffer.get(rowData, 0, rowStride)
+                                    rowData.copyInto(yBytes, row * width, 0, width)
                                 }
                             }
-                            .addOnCompleteListener {
-                                imageProxy.close()
+
+                            // Rotate Y-plane bytes to match display orientation.
+                            // PlanarYUVLuminanceSource.rotateCounterClockwise() is not overridden
+                            // in ZXing 3.x, so we rotate the raw bytes instead.
+                            val (rotatedBytes, rotatedWidth, rotatedHeight) = rotateYCW(
+                                yBytes, width, height, imageProxy.imageInfo.rotationDegrees
+                            )
+
+                            val source = PlanarYUVLuminanceSource(
+                                rotatedBytes, rotatedWidth, rotatedHeight,
+                                0, 0, rotatedWidth, rotatedHeight, false
+                            )
+
+                            try {
+                                val result = reader.decode(BinaryBitmap(HybridBinarizer(source)))
+                                // Dispatch to main thread: onResult may trigger navigation
+                                mainExecutor.execute {
+                                    isScanningComplete = true
+                                    onResult(result.text)
+                                }
+                            } catch (_: NotFoundException) {
+                                // No barcode in this frame — keep scanning
+                            } finally {
+                                reader.reset()
                             }
-                    } else {
-                        imageProxy.close()
+                        }
                     }
+                    imageProxy.close()
                 }
 
                 val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
@@ -97,4 +125,30 @@ fun QrScanner(
         },
         modifier = Modifier.fillMaxSize()
     )
+}
+
+/**
+ * Rotates a flat Y-plane byte array clockwise by [degrees] (0/90/180/270).
+ * Returns the rotated bytes plus the new width and height.
+ */
+private fun rotateYCW(
+    data: ByteArray,
+    width: Int,
+    height: Int,
+    degrees: Int,
+): Triple<ByteArray, Int, Int> {
+    if (degrees == 0) return Triple(data, width, height)
+    var src = data; var w = width; var h = height
+    repeat((degrees / 90) % 4) {
+        val dst = ByteArray(src.size)
+        for (y in 0 until h) {
+            for (x in 0 until w) {
+                // 90° clockwise: dst[x][h-1-y] = src[y][x]
+                dst[x * h + (h - 1 - y)] = src[y * w + x]
+            }
+        }
+        val newW = h; h = w; w = newW
+        src = dst
+    }
+    return Triple(src, w, h)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,6 @@ serialization = "1.10.0"
 navigationCompose = "2.9.7"
 zxing = "3.5.4"
 cameraX = "1.5.3"
-mlkitBarcodeScanning = "17.3.0"
 jsoup = "1.22.1"
 ktor = "3.0.1"
 coil = "2.7.0"
@@ -44,7 +43,6 @@ androidx-camera-core = { group = "androidx.camera", name = "camera-core", versio
 androidx-camera-camera2 = { group = "androidx.camera", name = "camera-camera2", version.ref = "cameraX" }
 androidx-camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "cameraX" }
 androidx-camera-view = { group = "androidx.camera", name = "camera-view", version.ref = "cameraX" }
-mlkit-barcode-scanning = { group = "com.google.mlkit", name = "barcode-scanning", version.ref = "mlkitBarcodeScanning" }
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
 ktor-client-android = { group = "io.ktor", name = "ktor-client-android", version.ref = "ktor" }


### PR DESCRIPTION
## Description
`com.google.mlkit` (barcode-scanning) is a non-free proprietary Google library flagged by the F-Droid scanner, blocking the app's inclusion in F-Droid. ZXing (`com.google.zxing:core`, Apache-2.0) was already a dependency and provides identical QR/barcode decoding.

Changes:
- `QrScanner.kt` rewritten to use `MultiFormatReader` fed from the Y-plane of each `ImageProxy` (YUV_420_888) — no Bitmap allocation per frame. Row-stride padding is stripped. Display rotation is applied by rotating the raw luminance bytes manually (`PlanarYUVLuminanceSource.rotateCounterClockwise()` is not overridden in ZXing 3.x and throws `UnsupportedOperationException`). `onResult` is now dispatched to the main executor — previously it fired from the background analyzer thread, crashing `NavController.popBackStack()`.
- `AddEditTroupeScreen` now requests `CAMERA` permission before opening the scanner dialog, matching existing behaviour in `GameSetupScreen`.
- `mlkit-barcode-scanning` removed from `build.gradle.kts` and `libs.versions.toml`.

After this change, the dependency tree contains no non-free or proprietary Google libraries.

## Type of Change
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Chore (Non functional changes, documentation, etc.)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)