### PR TITLE
feat: settings UI improvements

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
@@ -75,6 +75,9 @@ sealed interface CharacterEvent {
     data object CheckForAppUpdate : CharacterEvent
     data object DismissAppUpdate : CharacterEvent
 
+    // Sync / auto-update (collapses news, data, and portrait checks into one toggle)
+    data class SetAutoSynchronise(val enabled: Boolean) : CharacterEvent
+
     // Image download events
     data class SetImageDownloadPreference(val pref: ImageDownloadPreference) : CharacterEvent
     data object DownloadCharacterImages : CharacterEvent

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
@@ -172,13 +172,16 @@ data class CharacterState(
     val activeCampaign: Campaign? = null,
 
     // Data / image update state
-    val autoCheckDataUpdates: Boolean = true,
+    val autoCheckDataUpdates: Boolean = false,
     val installedDataVersion: String = "",
     val pendingDataUpdate: GitHubRelease? = null,
     val isInstallingDataUpdate: Boolean = false,
     val imageDownloadPreference: ImageDownloadPreference = ImageDownloadPreference.PROMPT,
     val pendingImageUpdate: String? = null,
     val isDownloadingImages: Boolean = false,
+    val imageDownloadedBytes: Long = 0L,
+    val imageTotalBytes: Long = -1L,
+    val imageDownloadSpeedBps: Long = 0L,
 
     // App update state (opt-in, off by default — F-Droid manages updates for F-Droid installs)
     val autoCheckAppUpdates: Boolean = false,

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -466,6 +466,17 @@ class CharacterViewModel(
             }
             CharacterEvent.DismissAppUpdate -> _state.update { it.copy(pendingAppUpdate = null) }
 
+            // Sync toggle — collapses news, data, and portrait auto-update into one setting
+            is CharacterEvent.SetAutoSynchronise -> {
+                val enabled = event.enabled
+                val pref = if (enabled) ImageDownloadPreference.ENABLED else ImageDownloadPreference.DISABLED
+                _state.update { it.copy(autoFetchNews = enabled, autoCheckDataUpdates = enabled, imageDownloadPreference = pref) }
+                prefs.edit { putBoolean("auto_fetch_news", enabled) }
+                dataUpdateRepository.persistAutoCheck(enabled)
+                dataUpdateRepository.persistImagePreference(pref)
+                if (enabled) fetchNews()
+            }
+
             // Data update events
             is CharacterEvent.SetAutoCheckDataUpdates -> {
                 _state.update { it.copy(autoCheckDataUpdates = event.enabled) }
@@ -503,7 +514,7 @@ class CharacterViewModel(
             }
             CharacterEvent.DownloadCharacterImages -> {
                 viewModelScope.launch(Dispatchers.IO) {
-                    _state.update { it.copy(isDownloadingImages = true) }
+                    _state.update { it.copy(isDownloadingImages = true, imageDownloadedBytes = 0L, imageTotalBytes = -1L, imageDownloadSpeedBps = 0L) }
                     try {
                         val tag = _state.value.pendingImageUpdate?.takeIf { it != "FIRST_LAUNCH" }
                             ?: dataUpdateRepository.checkForImageUpdate()
@@ -512,13 +523,21 @@ class CharacterViewModel(
                                 dataUpdateRepository.checkForDataUpdate()?.tagName
                             }
                         if (tag != null) {
-                            dataUpdateRepository.downloadImages(tag)
+                            dataUpdateRepository.downloadImages(tag) { downloaded, total, speedBps ->
+                                _state.update { s ->
+                                    s.copy(
+                                        imageDownloadedBytes = downloaded,
+                                        imageTotalBytes = total,
+                                        imageDownloadSpeedBps = if (speedBps >= 0L) speedBps else s.imageDownloadSpeedBps
+                                    )
+                                }
+                            }
                         }
                         _state.update { it.copy(pendingImageUpdate = null) }
                     } catch (e: Exception) {
                         _state.update { it.copy(errorMessage = "Image download failed: ${e.message}") }
                     } finally {
-                        _state.update { it.copy(isDownloadingImages = false) }
+                        _state.update { it.copy(isDownloadingImages = false, imageDownloadedBytes = 0L, imageTotalBytes = -1L, imageDownloadSpeedBps = 0L) }
                     }
                 }
             }

--- a/app/src/main/java/io/github/garemat/lunachron/DataUpdateRepository.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/DataUpdateRepository.kt
@@ -11,6 +11,8 @@ import io.ktor.client.engine.android.Android
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
+import io.ktor.http.HttpHeaders
+import io.ktor.utils.io.readAvailable
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -106,17 +108,50 @@ class DataUpdateRepository(
         Log.d(TAG, "applyDataUpdate: complete, version now ${release.tagName}")
     }
 
-    suspend fun downloadImages(releaseTag: String) {
+    suspend fun downloadImages(
+        releaseTag: String,
+        onProgress: (downloaded: Long, total: Long, speedBps: Long) -> Unit = { _, _, _ -> }
+    ) {
         val url = "https://api.github.com/repos/$DATA_REPO/releases/tags/$releaseTag"
         val body = client.get(url).bodyAsText()
         val release = json.decodeFromString<ApiRelease>(body)
         val zipAsset = release.assets.firstOrNull { it.name == "character_images.zip" }
             ?: throw IllegalStateException("character_images.zip not found in release $releaseTag")
 
-        val zipBytes = client.get(zipAsset.browserDownloadUrl).readBytes()
-        val imagesDir = File(context.filesDir, "images").also { it.mkdirs() }
+        val response = client.get(zipAsset.browserDownloadUrl)
+        val contentLength = response.headers[HttpHeaders.ContentLength]?.toLongOrNull() ?: -1L
+        val channel = response.bodyAsChannel()
 
-        ZipInputStream(zipBytes.inputStream()).use { zis ->
+        val tempZip = File(context.cacheDir, "portraits_temp.zip")
+        var downloaded = 0L
+        var speedWindowStart = System.currentTimeMillis()
+        var speedWindowBytes = 0L
+        val readBuffer = ByteArray(DEFAULT_BUFFER_SIZE)
+
+        tempZip.outputStream().use { out ->
+            while (!channel.isClosedForRead) {
+                val read = channel.readAvailable(readBuffer)
+                if (read <= 0) break
+                out.write(readBuffer, 0, read)
+                downloaded += read
+                speedWindowBytes += read
+                val now = System.currentTimeMillis()
+                val elapsed = now - speedWindowStart
+                val speedBps = if (elapsed >= 500L) {
+                    val bps = speedWindowBytes * 1000L / elapsed
+                    speedWindowStart = now
+                    speedWindowBytes = 0L
+                    bps
+                } else -1L // sentinel: don't update speed yet
+                onProgress(downloaded, contentLength, speedBps)
+            }
+        }
+
+        // Report 100% before extracting
+        onProgress(downloaded, contentLength, 0L)
+
+        val imagesDir = File(context.filesDir, "images").also { it.mkdirs() }
+        ZipInputStream(tempZip.inputStream()).use { zis ->
             var entry = zis.nextEntry
             while (entry != null) {
                 if (!entry.isDirectory) {
@@ -126,6 +161,7 @@ class DataUpdateRepository(
                 entry = zis.nextEntry
             }
         }
+        tempZip.delete()
         prefs.edit { putString(KEY_IMAGE_VERSION, releaseTag) }
     }
 

--- a/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
@@ -159,12 +159,12 @@ class MainActivity : ComponentActivity() {
                                 )
                             )
                             NavigationDrawerItem(
-                                icon = { Icon(Icons.Default.Settings, contentDescription = null) },
-                                label = { Text("Settings", style = theme.headerStyle.copy(fontSize = 18.sp)) },
+                                icon = { Icon(Icons.Default.BarChart, contentDescription = null) },
+                                label = { Text("Stats", style = theme.headerStyle.copy(fontSize = 18.sp)) },
                                 selected = false,
                                 onClick = {
                                     scope.launch { drawerState.close() }
-                                    navController.navigate(Screen.Settings.route)
+                                    navController.navigate(Screen.Stats.route)
                                 },
                                 shape = theme.navItemShape,
                                 colors = NavigationDrawerItemDefaults.colors(
@@ -172,13 +172,15 @@ class MainActivity : ComponentActivity() {
                                     unselectedTextColor = MaterialTheme.colorScheme.primary
                                 )
                             )
-                             NavigationDrawerItem(
-                                icon = { Icon(Icons.Default.BarChart, contentDescription = null) },
-                                label = { Text("Stats", style = theme.headerStyle.copy(fontSize = 18.sp)) },
+                            Spacer(Modifier.weight(1f))
+                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                            NavigationDrawerItem(
+                                icon = { Icon(Icons.Default.Settings, contentDescription = null) },
+                                label = { Text("Settings", style = theme.headerStyle.copy(fontSize = 18.sp)) },
                                 selected = false,
                                 onClick = {
                                     scope.launch { drawerState.close() }
-                                    navController.navigate(Screen.Stats.route)
+                                    navController.navigate(Screen.Settings.route)
                                 },
                                 shape = theme.navItemShape,
                                 colors = NavigationDrawerItemDefaults.colors(
@@ -729,7 +731,12 @@ private fun DataUpdateDialogs(
                     shape = theme.cardShape
                 ) {
                     if (state.isDownloadingImages) {
-                        CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
+                        PortraitDownloadProgress(
+                            downloaded = state.imageDownloadedBytes,
+                            total = state.imageTotalBytes,
+                            speedBps = state.imageDownloadSpeedBps,
+                            tintOnPrimary = true
+                        )
                     } else {
                         Text("Download")
                     }
@@ -764,7 +771,12 @@ private fun DataUpdateDialogs(
                     shape = theme.cardShape
                 ) {
                     if (state.isDownloadingImages) {
-                        CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
+                        PortraitDownloadProgress(
+                            downloaded = state.imageDownloadedBytes,
+                            total = state.imageTotalBytes,
+                            speedBps = state.imageDownloadSpeedBps,
+                            tintOnPrimary = true
+                        )
                     } else {
                         Text("Download")
                     }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -914,3 +914,43 @@ fun CharacterFilterHeader(searchQuery: String, onSearchQueryChange: (String) -> 
         }
     }
 }
+
+/**
+ * Inline progress indicator shown inside the "Download portraits" button while
+ * a portrait download is in progress. Displays downloaded/total MB, current
+ * speed, and an estimated time to completion.
+ *
+ * @param tintOnPrimary When true, colours the spinner and text with
+ *   [MaterialTheme.colorScheme.onPrimary] (suitable for use inside a [Button]).
+ */
+@Composable
+fun PortraitDownloadProgress(
+    downloaded: Long,
+    total: Long,
+    speedBps: Long,
+    tintOnPrimary: Boolean = false
+) {
+    val tint = if (tintOnPrimary) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface
+    val downloadedMb = downloaded / (1024f * 1024f)
+    val totalMb = if (total > 0) total / (1024f * 1024f) else null
+    val speedMbps = speedBps / (1024f * 1024f)
+
+    val progressText = buildString {
+        append("%.1f MB".format(downloadedMb))
+        if (totalMb != null) append(" / %.1f MB".format(totalMb))
+        if (speedBps > 0) {
+            append("  •  %.2f MB/s".format(speedMbps))
+            if (totalMb != null) {
+                val remaining = (total - downloaded).coerceAtLeast(0L)
+                val etaSecs = remaining / speedBps
+                val eta = if (etaSecs < 60) "${etaSecs}s" else "${etaSecs / 60}m ${etaSecs % 60}s"
+                append("  •  $eta")
+            }
+        }
+    }
+
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp, color = tint)
+        Text(progressText, style = MaterialTheme.typography.bodySmall, color = tint)
+    }
+}

--- a/app/src/main/java/io/github/garemat/lunachron/ui/SettingsScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/SettingsScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -36,6 +37,10 @@ fun SettingsScreen(
     val context = LocalContext.current
     val availableThemes = remember(context) { ThemeRepository(context).listAvailable() }
 
+    val autoSynchronise = state.autoFetchNews &&
+            state.autoCheckDataUpdates &&
+            state.imageDownloadPreference == ImageDownloadPreference.ENABLED
+
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
@@ -50,6 +55,13 @@ fun SettingsScreen(
                     titleContentColor = MaterialTheme.colorScheme.primary,
                     navigationIconContentColor = MaterialTheme.colorScheme.primary
                 )
+            )
+        },
+        floatingActionButton = {
+            ExtendedFloatingActionButton(
+                onClick = { onEvent(CharacterEvent.UpdateUserName(name)); onNavigateBack() },
+                icon = { Icon(Icons.Default.Check, contentDescription = null) },
+                text = { Text("Save", style = theme.buttonTextStyle) }
             )
         }
     ) { padding ->
@@ -70,14 +82,14 @@ fun SettingsScreen(
                 singleLine = true,
                 shape = theme.cardShape
             )
-            
+
             Spacer(modifier = Modifier.height(theme.verticalSpacing))
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
             Spacer(modifier = Modifier.height(theme.verticalSpacing))
-            
+
             Text("App Theme", style = theme.titleStyle.copy(fontSize = 20.sp), color = MaterialTheme.colorScheme.primary)
             Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
-            
+
             Column {
                 availableThemes.forEach { definition ->
                     ThemeOption(
@@ -154,20 +166,27 @@ fun SettingsScreen(
             Text("Game View", style = theme.titleStyle.copy(fontSize = 20.sp), color = MaterialTheme.colorScheme.primary)
             Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
 
-            Column {
-                SelectionOption(
-                    title = "No tracking",
-                    selected = state.gameTrackingMode == GameTrackingMode.LOW_DETAIL,
-                    onSelect = { onEvent(CharacterEvent.ChangeGameTrackingMode(GameTrackingMode.LOW_DETAIL)) },
-                    theme = theme,
-                    subtitle = "Stats at a glance, track resources physically"
-                )
-                SelectionOption(
-                    title = "Track Resources in App",
-                    selected = state.gameTrackingMode == GameTrackingMode.FULL_TRACKING,
-                    onSelect = { onEvent(CharacterEvent.ChangeGameTrackingMode(GameTrackingMode.FULL_TRACKING)) },
-                    theme = theme,
-                    subtitle = "Energy, moonstones, and ability used markers"
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        val newMode = if (state.gameTrackingMode == GameTrackingMode.FULL_TRACKING)
+                            GameTrackingMode.LOW_DETAIL else GameTrackingMode.FULL_TRACKING
+                        onEvent(CharacterEvent.ChangeGameTrackingMode(newMode))
+                    }
+                    .padding(vertical = theme.verticalSpacing / 4),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Enable resource tracking", style = theme.headerStyle.copy(fontSize = 18.sp))
+                    Text("Track energy, moonstones, and ability used markers in the app.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                Switch(
+                    checked = state.gameTrackingMode == GameTrackingMode.FULL_TRACKING,
+                    onCheckedChange = { enabled ->
+                        onEvent(CharacterEvent.ChangeGameTrackingMode(if (enabled) GameTrackingMode.FULL_TRACKING else GameTrackingMode.LOW_DETAIL))
+                    }
                 )
             }
 
@@ -193,27 +212,6 @@ fun SettingsScreen(
                     theme = theme,
                     subtitle = "Single column, expandable cards with full stats"
                 )
-            }
-
-            Spacer(modifier = Modifier.height(theme.verticalSpacing))
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-            Spacer(modifier = Modifier.height(theme.verticalSpacing))
-
-            Text("News", style = theme.titleStyle.copy(fontSize = 20.sp), color = MaterialTheme.colorScheme.primary)
-            Spacer(modifier = Modifier.height(theme.verticalSpacing / 4))
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onEvent(CharacterEvent.SetAutoFetchNews(!state.autoFetchNews)) }
-                    .padding(vertical = theme.verticalSpacing / 4),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text("Auto-fetch news", style = theme.headerStyle.copy(fontSize = 18.sp))
-                    Text("Load the latest Moonstone news on startup.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                }
-                Switch(checked = state.autoFetchNews, onCheckedChange = { onEvent(CharacterEvent.SetAutoFetchNews(it)) })
             }
 
             Spacer(modifier = Modifier.height(theme.verticalSpacing))
@@ -263,10 +261,10 @@ fun SettingsScreen(
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
             Spacer(modifier = Modifier.height(theme.verticalSpacing))
 
-            Text("Data Updates", style = theme.titleStyle.copy(fontSize = 20.sp), color = MaterialTheme.colorScheme.primary)
+            Text("Sync & Updates", style = theme.titleStyle.copy(fontSize = 20.sp), color = MaterialTheme.colorScheme.primary)
             Spacer(modifier = Modifier.height(theme.verticalSpacing / 4))
             Text(
-                text = "Installed version: ${state.installedDataVersion.ifEmpty { "bundled" }}",
+                text = "Game data version: ${state.installedDataVersion.ifEmpty { "bundled" }}",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -275,16 +273,16 @@ fun SettingsScreen(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable { onEvent(CharacterEvent.SetAutoCheckDataUpdates(!state.autoCheckDataUpdates)) }
+                    .clickable { onEvent(CharacterEvent.SetAutoSynchronise(!autoSynchronise)) }
                     .padding(vertical = theme.verticalSpacing / 4),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 Column(modifier = Modifier.weight(1f)) {
-                    Text("Auto-check for updates", style = theme.headerStyle.copy(fontSize = 18.sp))
-                    Text("Check for new game data on startup.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("Synchronise updates", style = theme.headerStyle.copy(fontSize = 18.sp))
+                    Text("Auto-check for news, game data, and portrait updates on startup.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
-                Switch(checked = state.autoCheckDataUpdates, onCheckedChange = { onEvent(CharacterEvent.SetAutoCheckDataUpdates(it)) })
+                Switch(checked = autoSynchronise, onCheckedChange = { onEvent(CharacterEvent.SetAutoSynchronise(it)) })
             }
 
             Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
@@ -297,57 +295,31 @@ fun SettingsScreen(
                 Text("Check for updates now", style = theme.buttonTextStyle)
             }
 
-            Spacer(modifier = Modifier.height(theme.verticalSpacing))
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable {
-                        val newPref = if (state.imageDownloadPreference == ImageDownloadPreference.ENABLED)
-                            ImageDownloadPreference.DISABLED else ImageDownloadPreference.ENABLED
-                        onEvent(CharacterEvent.SetImageDownloadPreference(newPref))
-                    }
-                    .padding(vertical = theme.verticalSpacing / 4),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text("Download character portraits", style = theme.headerStyle.copy(fontSize = 18.sp))
-                    Text("Automatically check for new portrait images.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                }
-                Switch(
-                    checked = state.imageDownloadPreference == ImageDownloadPreference.ENABLED,
-                    onCheckedChange = { enabled ->
-                        onEvent(CharacterEvent.SetImageDownloadPreference(if (enabled) ImageDownloadPreference.ENABLED else ImageDownloadPreference.DISABLED))
-                    }
-                )
-            }
-
             Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
 
             OutlinedButton(
                 onClick = { onEvent(CharacterEvent.DownloadCharacterImages) },
+                enabled = !state.isDownloadingImages,
                 modifier = Modifier.fillMaxWidth(),
                 shape = theme.cardShape
             ) {
-                Text("Download portraits now", style = theme.buttonTextStyle)
+                if (state.isDownloadingImages) {
+                    PortraitDownloadProgress(
+                        downloaded = state.imageDownloadedBytes,
+                        total = state.imageTotalBytes,
+                        speedBps = state.imageDownloadSpeedBps
+                    )
+                } else {
+                    Text("Download portraits now", style = theme.buttonTextStyle)
+                }
             }
 
-            Spacer(modifier = Modifier.height(theme.verticalSpacing * 2))
-
-            Button(
-                onClick = { onEvent(CharacterEvent.UpdateUserName(name)); onNavigateBack() },
-                modifier = Modifier.fillMaxWidth().height(56.dp),
-                shape = theme.cardShape
-            ) {
-                Text(
-                    text = "Save Settings",
-                    style = theme.buttonTextStyle
-                )
-            }
+            // Extra bottom padding so the FAB never covers the last item
+            Spacer(modifier = Modifier.height(88.dp))
         }
     }
 }
+
 
 @Composable
 fun SelectionOption(title: String, selected: Boolean, onSelect: () -> Unit, theme: io.github.garemat.lunachron.ui.theme.AppThemeProperties, subtitle: String? = null) {


### PR DESCRIPTION
## Description

Several UI improvements to the Settings screen and side drawer:

- **FAB for Save** — replaced the bottom scroll button with an `ExtendedFloatingActionButton` (checkmark + "Save"), so users can save without scrolling to the bottom
- **"Synchronise updates" toggle** — collapsed the separate News, Data Updates, and portrait download toggles into a single switch (off by default); enabling it also immediately triggers a news fetch
- **Portrait download progress** — `downloadImages` now streams the ZIP in chunks and reports `downloaded / total MB • speed MB/s • ETA`; shown inline in the button in both Settings and the first-launch/update dialogs
- **Single resource-tracking toggle** — replaced the two radio buttons (No tracking / Track Resources) with a single "Enable resource tracking" switch
- **Settings pinned to drawer bottom** — Settings item moved to the bottom of the side drawer, separated by a divider, with a `weight(1f)` spacer pushing it down

## Type of Change
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Chore (Non functional changes, documentation, etc.)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)