### PR TITLE
feat: local game setup flow, favourite troupes, and home Quick Start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Themes can now specify preferred game layout and tracking modes; switching themes applies the theme's preference unless you've already customised those settings under that theme.
+- Favourite troupes: tap the star on any troupe card to mark it as a favourite. Favourites appear in a Quick Start bar at the top of the Home screen for one-tap game launch.
+- Quick Start bar auto-hides when scrolling through the news feed and reappears when you scroll back to the top.
+- New local game setup flow: Player Count → Troupe Selection → Ready to Play. Troupe selection uses a bottom sheet with character portrait previews. Troupes with more characters than the game size allows show an inline character picker for trimming the roster.
 
 ### Changed
-- Bumped Ktor from 3.0.1 to 3.4.1
-- Bumped Kotlin from 2.3.10 to 2.3.20
+- Game setup entry point redesigned: "Local Game" is the primary hero card; multiplayer and tournament modes are secondary.
+- Removed "Skip Game Mode Selection" and "Only track 1 player" settings — the new setup flow handles this inline.
+- Multiplayer and tournament mode buttons now show an "upcoming update" notice instead of launching the (work-in-progress) flow.
 
 ## [2.2.7] - 2026-03-19
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,32 @@ Side drawer: Rules, Tutorial Help, Settings, Local Tournament, Stats
 Compendium sub-screens: Characters list, Upgrades list, Campaign Cards list
 Campaign screens: CampaignManagement → CampaignDetails / AddEditCampaign / EditCampaign
 
+### Home Screen
+
+`HomeScreen.kt` shows a "Quick Start" section above the news feed when the user has at least one favourite troupe. Tapping a Quick Start card calls `onQuickStartTroupe(troupe)` which is wired in `MainActivity.kt` to call `viewModel.startNewGame(listOf(troupe))` and navigate directly to `ActiveGame`.
+
+The Quick Start section auto-hides with `AnimatedVisibility` when the user scrolls more than ~80px into the news `LazyColumn` (`derivedStateOf` on `LazyListState.firstVisibleItemScrollOffset`). It reappears when they scroll back to the top.
+
+### Game Setup Flow
+
+The Play tab (`GameSetupScreen.kt`) shows:
+1. **`GameModeHeroUI`** (entry point, `SetupCommonUI.kt`) — a hero card for "Local Game" with animated faction-colour cycling gradient background. Three secondary mode rows (Host Game, Join Game, Local Tournament) are deliberately deprecated and show a "getting improved in an upcoming update" Toast when tapped.
+2. **`OfflineSetupUI`** (`OfflineSetupUI.kt`) — a 3-step flow triggered by "Local Game":
+   - **Step 1 — Player Count**: 1–4 player cards with per-count character limits and a visual shape indicator. `maxCharsForCount()`: 1–2 players → 6, 3 → 4, 4 → 3.
+   - **Step 2 — Troupe Selection**: N slot cards (`TroupeSlotCard`). Each slot has a "Browse" button that opens `TroupeBrowseSheet` (a `ModalBottomSheet` listing saved troupes with overlapping character portrait circles). If a selected troupe has more characters than the game allows, the slot enters an amber "trimming" state with an inline `CharacterPickerRow` for the player to select the characters they'll play with.
+   - **Step 3 — Ready**: Summary of all troupes/characters before starting.
+   - Key types: `SlotData(troupe, selectedCharIds, pickerOpen)`, `LocalSetupStep` enum, `slotStatus()` helper returning `"empty"/"trimming"/"confirmed"`.
+
+### Troupe Favourites
+
+`Troupe.isFavourite: Boolean = false` field (added in `Character.kt`). `UserDatabase` is at **version 3** with `MIGRATION_2_3` adding the `isFavourite` column. Toggle via `CharacterEvent.ToggleTroupeFavourite(troupeId)`. Star button shown on `TroupeListItem` when not in selection mode — gold filled star (`Color(0xFFFFC107)`) when favourite, outlined star at 50% alpha otherwise.
+
+**Bug to avoid:** `ToggleTroupeFavourite` must look up the troupe in `state.value.troupes` (the combined `StateFlow`), **not** `_state.value.troupes` (the internal `MutableStateFlow` whose `.troupes` is always empty).
+
+### Settings
+
+The "Gameplay" section (previously contained "Skip Game Mode Selection" and "Only track 1 player" toggles) has been removed. The setup flow now always starts at `GameModeHeroUI` and the player count / single-player behaviour is configured inline in the new setup steps. The underlying `useLocalModeByDefault` and `useSinglePlayerMode` state fields are retained but no longer exposed in Settings UI.
+
 ### Data / Assets
 
 Game data (characters, upgrades, campaign cards) is sourced from the `lunachron-data` repo and bundled as consolidated JSON files in `app/src/main/assets/`:
@@ -147,27 +173,42 @@ ThemedCard(containerColor = Color.DarkGray, modifier = ...) { ... }            /
 - `selectionMode = true` — shows edit button instead of share; also pass `characters` to display the character list below the header
 - `showDelete = false` — hides the delete button (used in solo troupe select)
 - `characters: List<Character>?` — when non-null, renders a name list below the card header; omit faction suffix (redundant — all members share the troupe faction)
+- `onToggleFavourite: (() -> Unit)?` — when non-null (only in normal list mode, not selection mode), renders a star icon button; gold filled when `troupe.isFavourite`, outlined at 50% alpha otherwise
 
 `TroupeListScreen` automatically passes `characters` to `TroupeListItem` when `selectionMode = true`, so campaign and tournament selection get the character list for free. `SoloTroupeSelectScreen` calls `TroupeListItem` directly with `showDelete = false`.
 
 ### Active Game Screen
 
-`ActiveGameScreen.kt` supports two layout modes controlled by `GameLayoutMode` (persisted in SharedPreferences):
-- `COMPACT_GRID` — 2-column `LazyVerticalGrid` with `GameCharacterGridCard`
-- `DETAILED_LIST` — single-column `LazyColumn` with `FrontSide` (full card)
+`ActiveGameScreen.kt` uses a single unified portrait-grid layout. `GameLayoutMode` has been removed entirely.
 
-`GameCharacterGridCard` layout (top to bottom):
-1. Character name + signature move in italics (`Name - *Signature Move*`)
-2. Portrait | stats (melee/evade/damage modifiers) — side by side
-3. Trackable resources row (FULL_TRACKING only): energy `−/E:n/+` then compact circle toggles for each `oncePerTurn`/`oncePerGame` ability
-4. Moonstones
-5. `HealthPipsChunked`
-6. `SummonerIndicator`
+**Layout:**
+- **`RosterStrip`** — sticky `LazyRow` below the top bar; 36dp portrait circles for every character across all players. Tap to scroll the grid to that character and open their card modal. Players are separated by thin dividers.
+- **`LazyVerticalGrid`** — adaptive column count based on total characters: ≤6→3 cols/80dp portraits, ≤10→4 cols/66dp, 11+→5 cols/54dp. Section headers (`GamePlayerSectionHeader`) span the full row between player groups (only shown for >1 player).
+- **`CharacterPortraitCell`** — grid cell: portrait circle + stat line (`⚔ +melee  range"  ✦ +arcane  💨 +evade`) + character name. Stat values ≥ 0 display with a `+` prefix. The `💨` glyph is used for Evade.
 
-Two tracking modes controlled by `GameTrackingMode` (persisted in SharedPreferences):
-- `LOW_DETAIL` — health pips only; energy/moonstones/abilities tracked physically
-- `FULL_TRACKING` — energy counters, moonstone drag-and-drop, ability used markers, collapsible resource pool bar
+**Tracking badges (FULL_TRACKING only):**
+- Bottom-left green circle = current HP. Tap → HP − 1.
+- Bottom-right blue circle = current Energy. Tap → Energy − 1.
+- Top-centre gold triangle = Moonstones held. Tap → Moonstones + 1.
+- Death (HP = 0): portrait fades to 40% alpha, skull ☠ overlay, badges hidden, moonstones auto-zeroed.
+- Rapid taps accumulate into a single toast chip (e.g. "−3 HP") that auto-dismisses 2 s after the last tap.
 
-`FrontSide` accepts `trackingMode: GameTrackingMode = FULL_TRACKING`. When `LOW_DETAIL`, the energy section is hidden. Health always uses `HealthPipsChunked`.
+**Two tracking modes** (`GameTrackingMode`, persisted in SharedPreferences):
+- `LOW_DETAIL` — grid shows portraits + stats only; energy/moonstones/abilities tracked physically.
+- `FULL_TRACKING` — HP/Energy/Moonstone badges on portrait, ability-used markers in card modal, collapsible resource pool bar in the bottom bar.
 
-Settings for both are in `SettingsScreen.kt` under "Game View" and "Game Layout" sections.
+**Card modal (`GameCharacterCardModal`):**
+- Tap any portrait (grid or roster strip) → full-screen overlay with 3D `graphicsLayer` flip animation.
+- Front face uses `CharacterFront(showHealthTracker = false, abilityUsedStates = ..., onAbilityUsedChange = ...)` — compendium-style layout, no health pips, with ability tracking in FULL_TRACKING mode.
+- FULL_TRACKING adds a compact energy counter row (−/value/+) between the name header and the card content.
+- Back face uses `CharacterBack`. The signature-move link inside `CharacterFront` triggers the flip.
+- No expand/collapse — all abilities always visible.
+
+**`CharacterFront` (CommonComponents.kt):** now accepts optional parameters for game-mode use:
+- `showHealthTracker: Boolean = true` — pass `false` in game modal to hide health pips.
+- `abilityUsedStates: Map<String, Boolean>? = null` — when non-null, shows used/unused state on abilities.
+- `onAbilityUsedChange: ((String, Boolean) -> Unit)? = null` — callback for toggling ability state.
+
+**`FrontSide`** (ActiveGameScreen.kt) is retained for internal use but is no longer shown in any layout. It may be removed in a future cleanup.
+
+**Settings:** Game View tracking mode toggle remains in `SettingsScreen.kt`. The "Game Layout" section has been removed.

--- a/app/schemas/io.github.garemat.lunachron.UserDatabase/3.json
+++ b/app/schemas/io.github.garemat.lunachron.UserDatabase/3.json
@@ -1,0 +1,221 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "d99a959e74346767659abcef2de4fca0",
+    "entities": [
+      {
+        "tableName": "Troupe",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `troupeName` TEXT NOT NULL, `faction` TEXT NOT NULL, `characterIds` TEXT NOT NULL, `shareCode` TEXT NOT NULL, `isTournamentList` INTEGER NOT NULL, `isCampaignTroupe` INTEGER NOT NULL, `victoryPoints` INTEGER NOT NULL, `equippedUpgrades` TEXT NOT NULL, `campaignCards` TEXT NOT NULL, `isFavourite` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "troupeName",
+            "columnName": "troupeName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "faction",
+            "columnName": "faction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "characterIds",
+            "columnName": "characterIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shareCode",
+            "columnName": "shareCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isTournamentList",
+            "columnName": "isTournamentList",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCampaignTroupe",
+            "columnName": "isCampaignTroupe",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "victoryPoints",
+            "columnName": "victoryPoints",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "equippedUpgrades",
+            "columnName": "equippedUpgrades",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "campaignCards",
+            "columnName": "campaignCards",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavourite",
+            "columnName": "isFavourite",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "Campaign",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `players` TEXT NOT NULL, `currentRound` INTEGER NOT NULL, `totalRounds` INTEGER NOT NULL, `gameSize` INTEGER NOT NULL, `startingCharacters` INTEGER NOT NULL, `characterGrowthEvery` INTEGER NOT NULL, `upgradeGrowthEvery` INTEGER NOT NULL, `rounds` TEXT NOT NULL, `attacksEnabled` INTEGER NOT NULL, `machinationPhaseActive` INTEGER NOT NULL, `machinationDraft` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "players",
+            "columnName": "players",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentRound",
+            "columnName": "currentRound",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalRounds",
+            "columnName": "totalRounds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gameSize",
+            "columnName": "gameSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startingCharacters",
+            "columnName": "startingCharacters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "characterGrowthEvery",
+            "columnName": "characterGrowthEvery",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "upgradeGrowthEvery",
+            "columnName": "upgradeGrowthEvery",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rounds",
+            "columnName": "rounds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attacksEnabled",
+            "columnName": "attacksEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "machinationPhaseActive",
+            "columnName": "machinationPhaseActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "machinationDraft",
+            "columnName": "machinationDraft",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "GameResult",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestamp` INTEGER NOT NULL, `playerStats` TEXT NOT NULL, `winnerIndex` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playerStats",
+            "columnName": "playerStats",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "winnerIndex",
+            "columnName": "winnerIndex",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd99a959e74346767659abcef2de4fca0')"
+    ]
+  }
+}

--- a/app/src/main/java/io/github/garemat/lunachron/Character.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/Character.kt
@@ -206,7 +206,8 @@ data class Troupe(
     val isCampaignTroupe: Boolean = false,
     val victoryPoints: Int = 0,
     val equippedUpgrades: Map<Int, List<Int>> = emptyMap(),
-    val campaignCards: List<TroupeCampaignCard> = emptyList()
+    val campaignCards: List<TroupeCampaignCard> = emptyList(),
+    val isFavourite: Boolean = false
 )
 
 @Entity

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
@@ -13,6 +13,7 @@ sealed interface CharacterEvent {
     
     data class DeleteTroupe(val troupe: Troupe) : CharacterEvent
     data class EditTroupe(val troupe: Troupe) : CharacterEvent
+    data class ToggleTroupeFavourite(val troupeId: Int) : CharacterEvent
 
     data class SortCharacters(val sortType: SortType) : CharacterEvent
     
@@ -56,7 +57,6 @@ sealed interface CharacterEvent {
 
     // Game View / Tracking
     data class ChangeGameTrackingMode(val mode: GameTrackingMode) : CharacterEvent
-    data class ChangeGameLayoutMode(val mode: GameLayoutMode) : CharacterEvent
     data class AddSummonedCharacter(val playerIndex: Int, val characterId: Int, val summonedByCharacterId: Int?) : CharacterEvent
     data class RemoveSummonedCharacter(val playerIndex: Int, val characterId: Int) : CharacterEvent
     data class UpdatePoolResource(val playerIndex: Int, val resourceName: String, val count: Int) : CharacterEvent

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
@@ -14,8 +14,6 @@ enum class LayoutDensity {
 @Serializable
 enum class GameTrackingMode { LOW_DETAIL, FULL_TRACKING }
 
-@Serializable
-enum class GameLayoutMode { COMPACT_GRID, DETAILED_LIST }
 
 @Serializable
 enum class ImageDownloadPreference { PROMPT, ENABLED, DISABLED }
@@ -146,7 +144,6 @@ data class CharacterState(
     val tournamentHistory: List<TournamentRound> = emptyList(),
 
     val gameTrackingMode: GameTrackingMode = GameTrackingMode.LOW_DETAIL,
-    val gameLayoutMode: GameLayoutMode = GameLayoutMode.COMPACT_GRID,
 
     // Active Game Play State
     val currentTurn: Int = 1,

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -91,7 +91,6 @@ class CharacterViewModel(
         useSinglePlayerMode = prefs.getBoolean("use_single_player_mode", false),
         hasSeenGlobalTutorial = prefs.getBoolean("has_seen_global_tutorial", false),
         gameTrackingMode = GameTrackingMode.valueOf(prefs.getString("game_tracking_mode", GameTrackingMode.LOW_DETAIL.name) ?: GameTrackingMode.LOW_DETAIL.name),
-        gameLayoutMode = GameLayoutMode.valueOf(prefs.getString("game_layout_mode", GameLayoutMode.COMPACT_GRID.name) ?: GameLayoutMode.COMPACT_GRID.name),
         newsItems = loadCachedNews(),
         autoFetchNews = prefs.getBoolean("auto_fetch_news", false),
         autoCheckDataUpdates = dataUpdateRepository.loadAutoCheck(),
@@ -277,6 +276,10 @@ class CharacterViewModel(
     fun onEvent(event: CharacterEvent) {
         when (event) {
             is CharacterEvent.DeleteTroupe -> viewModelScope.launch { repository.deleteTroupe(event.troupe) }
+            is CharacterEvent.ToggleTroupeFavourite -> viewModelScope.launch {
+                val troupe = state.value.troupes.find { it.id == event.troupeId } ?: return@launch
+                repository.upsertTroupe(troupe.copy(isFavourite = !troupe.isFavourite))
+            }
             is CharacterEvent.EditTroupe -> {
                 editingTroupeId = event.troupe.id; newTroupeName = event.troupe.troupeName
                 selectedTroupeFaction = event.troupe.faction; selectedCharacterIds = event.troupe.characterIds.toSet()
@@ -295,18 +298,9 @@ class CharacterViewModel(
             is CharacterEvent.SetActiveTheme -> {
                 _state.update { it.copy(activeThemeId = event.themeId) }
                 prefs.edit { putString("app_theme", event.themeId) }
-                // Clear override flags so theme preferences apply fresh on this switch.
-                prefs.edit {
-                    putBoolean("layout_mode_overridden", false)
-                    putBoolean("tracking_mode_overridden", false)
-                }
+                // Clear override flag so theme preferences apply fresh on this switch.
+                prefs.edit { putBoolean("tracking_mode_overridden", false) }
                 val gp = runCatching { themeRepository.resolve(event.themeId).gameplayPreferences }.getOrNull()
-                gp?.defaultLayoutMode?.let { name ->
-                    runCatching { GameLayoutMode.valueOf(name) }.getOrNull()?.let { mode ->
-                        _state.update { it.copy(gameLayoutMode = mode) }
-                        prefs.edit { putString("game_layout_mode", mode.name) }
-                    }
-                }
                 gp?.defaultTrackingMode?.let { name ->
                     runCatching { GameTrackingMode.valueOf(name) }.getOrNull()?.let { mode ->
                         _state.update { it.copy(gameTrackingMode = mode) }
@@ -357,13 +351,6 @@ class CharacterViewModel(
                 prefs.edit {
                     putString("game_tracking_mode", event.mode.name)
                     putBoolean("tracking_mode_overridden", true)
-                }
-            }
-            is CharacterEvent.ChangeGameLayoutMode -> {
-                _state.update { it.copy(gameLayoutMode = event.mode) }
-                prefs.edit {
-                    putString("game_layout_mode", event.mode.name)
-                    putBoolean("layout_mode_overridden", true)
                 }
             }
             is CharacterEvent.AddSummonedCharacter -> {

--- a/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
@@ -370,6 +370,10 @@ class MainActivity : ComponentActivity() {
                                     HomeScreen(
                                         state = state,
                                         onEvent = viewModel::onEvent,
+                                        onQuickStartTroupe = { troupe ->
+                                            viewModel.startNewGame(listOf(troupe))
+                                            navController.navigate(Screen.ActiveGame.route)
+                                        },
                                         onTargetPositioned = { name, coords -> tutorialCoords[name] = coords }
                                     )
                                 }

--- a/app/src/main/java/io/github/garemat/lunachron/UserDatabase.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/UserDatabase.kt
@@ -10,7 +10,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [Troupe::class, Campaign::class, GameResult::class],
-    version = 2,
+    version = 3,
     exportSchema = true  // required for MigrationTestHelper in future migration tests
 )
 @TypeConverters(Converters::class)
@@ -32,6 +32,12 @@ abstract class UserDatabase : RoomDatabase() {
             }
         }
 
+        internal val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE Troupe ADD COLUMN isFavourite INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
         fun getDatabase(context: Context): UserDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -39,7 +45,7 @@ abstract class UserDatabase : RoomDatabase() {
                     UserDatabase::class.java,
                     "moonstone_user_db"
                 )
-                    .addMigrations(MIGRATION_1_2)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
                     .build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
@@ -4,22 +4,20 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.itemsIndexed as gridItemsIndexed
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
@@ -29,37 +27,93 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import io.github.garemat.lunachron.*
-import io.github.garemat.lunachron.R
 import io.github.garemat.lunachron.ui.theme.LocalAppThemeProperties
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import kotlin.math.max
 import kotlin.math.roundToInt
 
+
+// ─── Supporting types ────────────────────────────────────────────────────────
 
 data class SummonerPickerState(
     val playerIndex: Int,
     val character: Character,
     val possibleSummoners: List<Character>
 )
+
+sealed class StoneSource {
+    data object Pot : StoneSource()
+    data class Character(val playerIndex: Int, val charIndex: Int) : StoneSource()
+}
+
+private sealed class GameGridItem {
+    data class Header(val playerIndex: Int, val troupe: Troupe) : GameGridItem()
+    data class CharItem(
+        val playerIndex: Int,
+        val charIndex: Int,
+        val character: Character,
+        val isSummoned: Boolean,
+        val summoner: Character?
+    ) : GameGridItem()
+}
+
+// ─── Adaptive grid helpers ───────────────────────────────────────────────────
+
+private fun adaptiveCols(totalChars: Int) = if (totalChars <= 8) 2 else 3
+
+private fun adaptivePortraitSize(totalChars: Int) = if (totalChars <= 8) 120.dp else 80.dp
+
+/** Formats a stat value: positive values get a "+" prefix for quick visual scanning. */
+private fun statSign(value: Int): String = if (value > 0) "+$value" else "$value"
+
+/**
+ * Fades the four edges of a portrait to transparent, mimicking the organic irregular edges
+ * that naturally-trimmed character PNGs already have. Uses an offscreen compositing layer
+ * so the four directional DstIn gradient passes combine correctly.
+ */
+private fun Modifier.portraitCrimpedEdge(fadePercent: Float = 0.15f): Modifier =
+    this
+        .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
+        .drawWithContent {
+            drawContent()
+            val fw = size.width * fadePercent
+            val fh = size.height * fadePercent
+            // Each pass fades one edge; the gradient clamps to full-opacity beyond its range
+            // so it acts as a pure pass-through for the other edges.
+            drawRect(brush = Brush.verticalGradient(listOf(Color.Transparent, Color.Black), 0f, fh), blendMode = BlendMode.DstIn)
+            drawRect(brush = Brush.verticalGradient(listOf(Color.Black, Color.Transparent), size.height - fh, size.height), blendMode = BlendMode.DstIn)
+            drawRect(brush = Brush.horizontalGradient(listOf(Color.Transparent, Color.Black), 0f, fw), blendMode = BlendMode.DstIn)
+            drawRect(brush = Brush.horizontalGradient(listOf(Color.Black, Color.Transparent), size.width - fw, size.width), blendMode = BlendMode.DstIn)
+        }
+
+// ─── Main screen ─────────────────────────────────────────────────────────────
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -72,10 +126,11 @@ fun ActiveGameScreen(
     currentTutorialStep: TutorialStep? = null,
     onTargetPositioned: (String, LayoutCoordinates) -> Unit = { _, _ -> }
 ) {
-    val pagerState = rememberPagerState(pageCount = { if (isTutorialActive) 1 else players.size })
     val scope = rememberCoroutineScope()
     val theme = LocalAppThemeProperties.current
+    val gridState = rememberLazyGridState()
 
+    // Tutorial restricts to a single demo player
     val activePlayers = remember(isTutorialActive, state.characters, players) {
         if (isTutorialActive && state.characters.isNotEmpty()) {
             val grub = state.characters.find { it.name.equals("Grub", ignoreCase = true) } ?: state.characters[0]
@@ -88,6 +143,39 @@ fun ActiveGameScreen(
         } else players
     }
 
+    // Index of the local player (for pool bar and summon panel)
+    val localPlayerIndex = remember(state.gameSession, state.deviceId) {
+        if (state.gameSession == null) 0
+        else state.gameSession.players.indexOfFirst { it.deviceId == state.deviceId }.coerceAtLeast(0)
+    }
+
+    // Build flat list of grid items (headers + characters including summons)
+    val allGridItems: List<GameGridItem> = remember(activePlayers, state.activeSummons, state.characters) {
+        buildList {
+            activePlayers.forEachIndexed { pi, (troupe, chars) ->
+                if (activePlayers.size > 1) add(GameGridItem.Header(pi, troupe))
+                val troupeCharIds = troupe.characterIds.toSet()
+                val baseChars = chars.filter { it.id in troupeCharIds }
+                val summonEntries = state.activeSummons[pi] ?: emptyList()
+                val summonedChars = summonEntries.mapNotNull { e -> state.characters.find { it.id == e.characterId } }
+                (baseChars + summonedChars).forEachIndexed { ci, char ->
+                    val isSummoned = ci >= baseChars.size
+                    val summonEntry = if (isSummoned) summonEntries.getOrNull(ci - baseChars.size) else null
+                    val summoner = summonEntry?.summonedByCharacterId?.let { id -> baseChars.find { it.id == id } }
+                    add(GameGridItem.CharItem(pi, ci, char, isSummoned, summoner))
+                }
+            }
+        }
+    }
+
+    val totalChars = allGridItems.filterIsInstance<GameGridItem.CharItem>().size
+    val cols = adaptiveCols(totalChars)
+    val portraitSize = adaptivePortraitSize(totalChars)
+
+    val trackingMode = state.gameTrackingMode
+    val isFullTracking = trackingMode == GameTrackingMode.FULL_TRACKING
+
+    // Moonstone drag state
     var draggingStoneSource by remember { mutableStateOf<StoneSource?>(null) }
     var draggingStoneIndex by remember { mutableIntStateOf(-1) }
     var dragPosition by remember { mutableStateOf(Offset.Zero) }
@@ -96,23 +184,30 @@ fun ActiveGameScreen(
     var rootLayoutCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
     val stateRef = rememberUpdatedState(state)
 
+    // Summon panel state
     var isSummonPanelOpen by rememberSaveable { mutableStateOf(false) }
-    var showEndGameConfirm by remember { mutableStateOf(false) }
-    var selectedChar by remember { mutableStateOf<Pair<Character, CharacterPlayState>?>(null) }
     var summonerPickerState by remember { mutableStateOf<SummonerPickerState?>(null) }
 
-    val trackingMode = state.gameTrackingMode
-    val layoutMode = state.gameLayoutMode
+    // Card modal state
+    var selectedCharInfo by remember { mutableStateOf<Triple<Int, Int, Character>?>(null) }
+    var showEndGameConfirm by remember { mutableStateOf(false) }
 
-    // Compute current page display chars for the bottom bar pool
-    val currentPageIndex = pagerState.currentPage
-    val currentPageAllDisplayChars = remember(currentPageIndex, activePlayers, state.activeSummons, state.characters) {
-        val currentPair = activePlayers.getOrNull(currentPageIndex) ?: return@remember emptyList<Character>()
-        val troupeCharIds = currentPair.first.characterIds.toSet()
-        val baseChars = currentPair.second.filter { it.id in troupeCharIds }
-        val summonEntries = state.activeSummons[currentPageIndex] ?: emptyList()
-        val summonedChars = summonEntries.mapNotNull { e -> state.characters.find { it.id == e.characterId } }
-        baseChars + summonedChars
+    // Accumulating toast state
+    val accMap = remember { mutableStateMapOf<String, Pair<Int, String>>() }
+    val accJobs = remember { mutableMapOf<String, Job>() }
+    var visibleToastKey by remember { mutableStateOf<String?>(null) }
+
+    fun recordDelta(key: String, delta: Int, label: String) {
+        val prev = accMap[key]?.first ?: 0
+        accMap[key] = Pair(prev + delta, label)
+        visibleToastKey = key
+        accJobs[key]?.cancel()
+        accJobs[key] = scope.launch {
+            delay(2000)
+            accMap.remove(key)
+            if (visibleToastKey == key) visibleToastKey = null
+            accJobs.remove(key)
+        }
     }
 
     LaunchedEffect(currentTutorialStep) {
@@ -120,234 +215,244 @@ fun ActiveGameScreen(
         else if (isTutorialActive && currentTutorialStep?.targetName != "CharacterDrawerButton") isSummonPanelOpen = false
     }
 
+    // Local player display chars (for pool bar)
+    val localDisplayChars = remember(localPlayerIndex, activePlayers, state.activeSummons, state.characters) {
+        val pair = activePlayers.getOrNull(localPlayerIndex) ?: return@remember emptyList<Character>()
+        val troupeCharIds = pair.first.characterIds.toSet()
+        val baseChars = pair.second.filter { it.id in troupeCharIds }
+        val summonEntries = state.activeSummons[localPlayerIndex] ?: emptyList()
+        val summonedChars = summonEntries.mapNotNull { e -> state.characters.find { it.id == e.characterId } }
+        baseChars + summonedChars
+    }
+    val localBaseChars = remember(localPlayerIndex, activePlayers) {
+        val pair = activePlayers.getOrNull(localPlayerIndex) ?: return@remember emptyList<Character>()
+        val troupeCharIds = pair.first.characterIds.toSet()
+        pair.second.filter { it.id in troupeCharIds }
+    }
+    val localSummonEntries = state.activeSummons[localPlayerIndex] ?: emptyList()
+
     Scaffold(
         topBar = {
-            ActiveGameTopBar(
-                state, viewModel, isTutorialActive, isSummonPanelOpen,
-                onDrawerToggle = { isSummonPanelOpen = !isSummonPanelOpen },
-                onEndGameClick = { showEndGameConfirm = true },
-                onQuitGame = onQuitGame,
-                onTargetPositioned = onTargetPositioned,
-                pagerState = pagerState,
-                activePlayers = activePlayers
-            )
+            Column {
+                ActiveGameTopBar(
+                    state = state,
+                    viewModel = viewModel,
+                    isTutorialActive = isTutorialActive,
+                    isSummonPanelOpen = isSummonPanelOpen,
+                    onDrawerToggle = { isSummonPanelOpen = !isSummonPanelOpen },
+                    onEndGameClick = { showEndGameConfirm = true },
+                    onQuitGame = onQuitGame,
+                    onTargetPositioned = onTargetPositioned
+                )
+            }
         },
         bottomBar = {
-            Column {
-                if (trackingMode == GameTrackingMode.FULL_TRACKING) {
-                    CollapsiblePoolBar(
-                        state = state,
-                        pageIndex = currentPageIndex,
-                        allDisplayChars = currentPageAllDisplayChars,
-                        isTutorialActive = isTutorialActive,
-                        potBounds = potBounds,
-                        onTargetPositioned = onTargetPositioned,
-                        onDragStart = { offset ->
-                            draggingStoneSource = StoneSource.Pot
-                            dragPosition = (potBounds.value?.topLeft ?: Offset.Zero) + offset
-                        },
-                        onDrag = { dragPosition += it },
-                        onDragEnd = {
-                            if (!isTutorialActive) {
-                                characterBounds.entries.find { it.value.contains(dragPosition) }?.let { target ->
-                                    val (tP, tC) = target.key.split("_").map { it.toInt() }
-                                    val currentStones = stateRef.value.characterPlayStates[target.key]?.moonstones ?: 0
-                                    if (currentStones < 7) viewModel.onEvent(CharacterEvent.UpdateCharacterMoonstones(tP, tC, currentStones + 1))
-                                }
+            if (isFullTracking) {
+                CollapsiblePoolBar(
+                    state = state,
+                    pageIndex = localPlayerIndex,
+                    allDisplayChars = localDisplayChars,
+                    isTutorialActive = isTutorialActive,
+                    potBounds = potBounds,
+                    onTargetPositioned = onTargetPositioned,
+                    onDragStart = { offset ->
+                        draggingStoneSource = StoneSource.Pot
+                        dragPosition = (potBounds.value?.topLeft ?: Offset.Zero) + offset
+                    },
+                    onDrag = { dragPosition += it },
+                    onDragEnd = {
+                        if (!isTutorialActive) {
+                            characterBounds.entries.find { it.value.contains(dragPosition) }?.let { target ->
+                                val (tP, tC) = target.key.split("_").map { it.toInt() }
+                                val currentStones = stateRef.value.characterPlayStates[target.key]?.moonstones ?: 0
+                                if (currentStones < 7) viewModel.onEvent(CharacterEvent.UpdateCharacterMoonstones(tP, tC, currentStones + 1))
                             }
-                            draggingStoneSource = null
-                        },
-                        viewModel = viewModel
-                    )
-                }
+                        }
+                        draggingStoneSource = null
+                    },
+                    viewModel = viewModel
+                )
             }
         }
     ) { padding ->
-        Box(modifier = Modifier.fillMaxSize().onGloballyPositioned { rootLayoutCoordinates = it }) {
-            HorizontalPager(state = pagerState, modifier = Modifier.fillMaxSize().padding(padding)) { pageIndex ->
-                val currentPair = activePlayers.getOrNull(pageIndex)
-                if (currentPair != null) {
-                    val troupeCharIds = currentPair.first.characterIds.toSet()
-                    val baseChars = currentPair.second.filter { it.id in troupeCharIds }
-                    val summonEntries = state.activeSummons[pageIndex] ?: emptyList()
-                    val summonedChars = summonEntries.mapNotNull { e -> state.characters.find { it.id == e.characterId } }
-                    val allDisplayChars = baseChars + summonedChars
-
-                    Box(modifier = Modifier.fillMaxSize()) {
-                        when (layoutMode) {
-                            GameLayoutMode.COMPACT_GRID -> {
-                                LazyVerticalGrid(
-                                    columns = GridCells.Fixed(2),
-                                    contentPadding = PaddingValues(
-                                        start = theme.screenPadding,
-                                        end = theme.screenPadding,
-                                        top = theme.screenPadding,
-                                        bottom = theme.screenPadding
-                                    ),
-                                    verticalArrangement = Arrangement.spacedBy(theme.verticalSpacing),
-                                    horizontalArrangement = Arrangement.spacedBy(theme.verticalSpacing),
-                                    modifier = Modifier.fillMaxSize()
-                                ) {
-                                    gridItemsIndexed(allDisplayChars, key = { _, char -> char.id }) { charIndex, character ->
-                                        val stateKey = "${pageIndex}_${charIndex}"
-                                        val playState = if (isTutorialActive) {
-                                            CharacterPlayState(currentHealth = character.health, moonstones = if (charIndex == 0) 2 else 0)
-                                        } else {
-                                            state.characterPlayStates[stateKey] ?: CharacterPlayState(currentHealth = character.health)
-                                        }
-                                        val isSummoned = charIndex >= baseChars.size
-                                        val summonEntry = if (isSummoned) summonEntries.getOrNull(charIndex - baseChars.size) else null
-                                        val summoner = summonEntry?.summonedByCharacterId?.let { id -> baseChars.find { it.id == id } }
-
-                                        DisposableEffect(stateKey) { onDispose { characterBounds.remove(stateKey) } }
-                                        Box(modifier = Modifier.onGloballyPositioned { characterBounds[stateKey] = it.boundsInWindow() }) {
-                                            GameCharacterGridCard(
-                                                character = character,
-                                                playState = playState,
-                                                trackingMode = trackingMode,
-                                                summoner = summoner,
-                                                isEditable = !isTutorialActive,
-                                                draggingStoneInfo = if (draggingStoneSource is StoneSource.Character &&
-                                                    (draggingStoneSource as StoneSource.Character).playerIndex == pageIndex &&
-                                                    (draggingStoneSource as StoneSource.Character).charIndex == charIndex
-                                                ) draggingStoneIndex else -1,
-                                                onHealthChange = { viewModel.onEvent(CharacterEvent.UpdateCharacterHealth(pageIndex, charIndex, it)) },
-                                                onEnergyChange = { viewModel.onEvent(CharacterEvent.UpdateCharacterEnergy(pageIndex, charIndex, it)) },
-                                                onAbilityToggle = { name, used -> viewModel.onEvent(CharacterEvent.ToggleAbilityUsed(pageIndex, charIndex, name, used)) },
-                                                onFlippedChange = { viewModel.onEvent(CharacterEvent.ToggleCharacterFlipped(pageIndex, charIndex, it)) },
-                                                onTap = { selectedChar = character to playState },
-                                                onTransform = if (character.transformsInto != null) { targetId -> viewModel.onEvent(CharacterEvent.TransformCharacter(pageIndex, charIndex, targetId)) } else null,
-                                                onStoneDragStart = { index, pos ->
-                                                    draggingStoneIndex = index
-                                                    draggingStoneSource = StoneSource.Character(pageIndex, charIndex)
-                                                    dragPosition = pos
-                                                },
-                                                onStoneDrag = { dragPosition += it },
-                                                onStoneDragEnd = {
-                                                    val source = draggingStoneSource as? StoneSource.Character
-                                                    if (source != null && !isTutorialActive) {
-                                                        if (potBounds.value?.contains(dragPosition) == true) {
-                                                            val s = stateRef.value.characterPlayStates["${source.playerIndex}_${source.charIndex}"]?.moonstones ?: 0
-                                                            if (s > 0) viewModel.onEvent(CharacterEvent.UpdateCharacterMoonstones(source.playerIndex, source.charIndex, s - 1))
-                                                        } else {
-                                                            characterBounds.entries.find { it.value.contains(dragPosition) }?.let { target ->
-                                                                val (tP, tC) = target.key.split("_").map { it.toInt() }
-                                                                if (tP != source.playerIndex || tC != source.charIndex) {
-                                                                    val sStones = stateRef.value.characterPlayStates["${source.playerIndex}_${source.charIndex}"]?.moonstones ?: 0
-                                                                    val tStones = stateRef.value.characterPlayStates[target.key]?.moonstones ?: 0
-                                                                    if (tStones < 7) {
-                                                                        viewModel.onEvent(CharacterEvent.UpdateCharacterMoonstones(source.playerIndex, source.charIndex, sStones - 1))
-                                                                        viewModel.onEvent(CharacterEvent.UpdateCharacterMoonstones(tP, tC, tStones + 1))
-                                                                    }
-                                                                }
+        Box(modifier = Modifier.fillMaxSize().padding(padding).onGloballyPositioned { rootLayoutCoordinates = it }) {
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(cols),
+                state = gridState,
+                contentPadding = PaddingValues(theme.screenPadding),
+                verticalArrangement = Arrangement.spacedBy(theme.verticalSpacing),
+                horizontalArrangement = Arrangement.spacedBy(theme.verticalSpacing),
+                modifier = Modifier.fillMaxSize()
+            ) {
+                for (gridItem in allGridItems) {
+                    when (gridItem) {
+                        is GameGridItem.Header -> item(span = { GridItemSpan(maxLineSpan) }) {
+                            GamePlayerSectionHeader(troupe = gridItem.troupe)
+                        }
+                        is GameGridItem.CharItem -> {
+                            val pi = gridItem.playerIndex
+                            val ci = gridItem.charIndex
+                            val char = gridItem.character
+                            val stateKey = "${pi}_${ci}"
+                            item(key = stateKey) {
+                                val ps = if (isTutorialActive) {
+                                    CharacterPlayState(currentHealth = char.health, moonstones = if (ci == 0) 2 else 0)
+                                } else {
+                                    state.characterPlayStates[stateKey] ?: CharacterPlayState(currentHealth = char.health)
+                                }
+                                DisposableEffect(stateKey) { onDispose { characterBounds.remove(stateKey) } }
+                                Box(modifier = Modifier.onGloballyPositioned { characterBounds[stateKey] = it.boundsInWindow() }) {
+                                    CharacterPortraitCell(
+                                        character = char,
+                                        playState = ps,
+                                        trackingMode = trackingMode,
+                                        summoner = gridItem.summoner,
+                                        isEditable = !isTutorialActive,
+                                        onTap = { selectedCharInfo = Triple(pi, ci, char) },
+                                        onHpBadgeTap = {
+                                            if (!isTutorialActive) {
+                                                val newHp = max(0, ps.currentHealth - 1)
+                                                viewModel.onEvent(CharacterEvent.UpdateCharacterHealth(pi, ci, newHp))
+                                                if (newHp == 0 && ps.moonstones > 0) {
+                                                    viewModel.onEvent(CharacterEvent.UpdateCharacterMoonstones(pi, ci, 0))
+                                                }
+                                                recordDelta("${pi}_${ci}_hp", -1, "HP")
+                                            }
+                                        },
+                                        onEnergyBadgeTap = {
+                                            if (!isTutorialActive) {
+                                                viewModel.onEvent(CharacterEvent.UpdateCharacterEnergy(pi, ci, max(0, ps.currentEnergy - 1)))
+                                                recordDelta("${pi}_${ci}_en", -1, "Energy")
+                                            }
+                                        },
+                                        onMoonstoneBadgeTap = {
+                                            if (!isTutorialActive && ps.currentHealth > 0) {
+                                                viewModel.onEvent(CharacterEvent.UpdateCharacterMoonstones(pi, ci, ps.moonstones + 1))
+                                                recordDelta("${pi}_${ci}_ms", +1, "Stones")
+                                            }
+                                        },
+                                        onStoneDragStart = { index, pos ->
+                                            draggingStoneIndex = index
+                                            draggingStoneSource = StoneSource.Character(pi, ci)
+                                            dragPosition = pos
+                                        },
+                                        onStoneDrag = { dragPosition += it },
+                                        onStoneDragEnd = {
+                                            val source = draggingStoneSource as? StoneSource.Character
+                                            if (source != null && !isTutorialActive) {
+                                                if (potBounds.value?.contains(dragPosition) == true) {
+                                                    val s = stateRef.value.characterPlayStates["${source.playerIndex}_${source.charIndex}"]?.moonstones ?: 0
+                                                    if (s > 0) viewModel.onEvent(CharacterEvent.UpdateCharacterMoonstones(source.playerIndex, source.charIndex, s - 1))
+                                                } else {
+                                                    characterBounds.entries.find { it.value.contains(dragPosition) }?.let { target ->
+                                                        val (tP, tC) = target.key.split("_").map { it.toInt() }
+                                                        if (tP != source.playerIndex || tC != source.charIndex) {
+                                                            val sStones = stateRef.value.characterPlayStates["${source.playerIndex}_${source.charIndex}"]?.moonstones ?: 0
+                                                            val tStones = stateRef.value.characterPlayStates[target.key]?.moonstones ?: 0
+                                                            if (tStones < 7) {
+                                                                viewModel.onEvent(CharacterEvent.UpdateCharacterMoonstones(source.playerIndex, source.charIndex, sStones - 1))
+                                                                viewModel.onEvent(CharacterEvent.UpdateCharacterMoonstones(tP, tC, tStones + 1))
                                                             }
                                                         }
                                                     }
-                                                    draggingStoneSource = null
-                                                    draggingStoneIndex = -1
                                                 }
-                                            )
-                                        }
-                                    }
-                                }
-                            }
-
-                            GameLayoutMode.DETAILED_LIST -> {
-                                LazyColumn(
-                                    contentPadding = PaddingValues(
-                                        start = theme.screenPadding,
-                                        end = theme.screenPadding,
-                                        top = theme.screenPadding,
-                                        bottom = theme.screenPadding
-                                    ),
-                                    verticalArrangement = Arrangement.spacedBy(theme.verticalSpacing),
-                                    modifier = Modifier.fillMaxSize()
-                                ) {
-                                    itemsIndexed(allDisplayChars, key = { _, char -> char.id }) { charIndex, character ->
-                                        val stateKey = "${pageIndex}_${charIndex}"
-                                        val playState = if (isTutorialActive) {
-                                            CharacterPlayState(currentHealth = character.health, moonstones = if (charIndex == 0) 2 else 0)
-                                        } else {
-                                            state.characterPlayStates[stateKey] ?: CharacterPlayState(currentHealth = character.health)
-                                        }
-                                        val isEditable = !isTutorialActive
-                                        val isSummoned = charIndex >= baseChars.size
-                                        val summonEntry = if (isSummoned) summonEntries.getOrNull(charIndex - baseChars.size) else null
-                                        val summoner = summonEntry?.summonedByCharacterId?.let { id -> baseChars.find { it.id == id } }
-
-                                        ThemedCard(modifier = Modifier.fillMaxWidth()) {
-                                            Column(modifier = Modifier.padding(theme.cardContentPadding)) {
-                                                if (playState.isFlipped) {
-                                                    CharacterBack(
-                                                        character = character,
-                                                        searchQuery = "",
-                                                        onFlip = { viewModel.onEvent(CharacterEvent.ToggleCharacterFlipped(pageIndex, charIndex, false)) }
-                                                    )
-                                                } else {
-                                                    FrontSide(
-                                                        character = character,
-                                                        playState = playState,
-                                                        isEditable = isEditable,
-                                                        trackingMode = trackingMode,
-                                                        onHealthChange = { viewModel.onEvent(CharacterEvent.UpdateCharacterHealth(pageIndex, charIndex, it)) },
-                                                        onEnergyChange = { viewModel.onEvent(CharacterEvent.UpdateCharacterEnergy(pageIndex, charIndex, it)) },
-                                                        onExpandToggle = { viewModel.onEvent(CharacterEvent.ToggleCharacterExpanded(pageIndex, charIndex, !playState.isExpanded)) },
-                                                        onAbilityToggle = { name, used -> viewModel.onEvent(CharacterEvent.ToggleAbilityUsed(pageIndex, charIndex, name, used)) },
-                                                        onFlip = { viewModel.onEvent(CharacterEvent.ToggleCharacterFlipped(pageIndex, charIndex, true)) },
-                                                        onTransform = if (character.transformsInto != null) { targetId -> viewModel.onEvent(CharacterEvent.TransformCharacter(pageIndex, charIndex, targetId)) } else null
-                                                    )
-                                                }
-                                                if (playState.moonstones > 0) {
-                                                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(top = 4.dp)) {
-                                                        MoonstoneIcon(size = 12.dp)
-                                                        Spacer(Modifier.width(4.dp))
-                                                        Text("×${playState.moonstones}", style = MaterialTheme.typography.labelSmall)
-                                                    }
-                                                }
-                                                SummonerIndicator(summoner)
                                             }
+                                            draggingStoneSource = null
+                                            draggingStoneIndex = -1
                                         }
-                                    }
+                                    )
                                 }
                             }
-                        }
-
-                        AnimatedVisibility(
-                            visible = isSummonPanelOpen,
-                            enter = expandHorizontally(),
-                            exit = shrinkHorizontally(),
-                            modifier = Modifier.fillMaxHeight()
-                        ) {
-                            SummonPanel(
-                                allChars = state.characters,
-                                baseChars = baseChars,
-                                summonEntries = summonEntries,
-                                trackingMode = trackingMode,
-                                onAdd = { char ->
-                                    handleSummonAdd(pageIndex, char, baseChars, trackingMode, viewModel) {
-                                        summonerPickerState = it
-                                    }
-                                },
-                                onRemove = { char ->
-                                    viewModel.onEvent(CharacterEvent.RemoveSummonedCharacter(pageIndex, char.id))
-                                }
-                            )
                         }
                     }
                 }
             }
 
+            // Summon panel slides in from the start edge
+            AnimatedVisibility(
+                visible = isSummonPanelOpen,
+                enter = expandHorizontally(),
+                exit = shrinkHorizontally(),
+                modifier = Modifier.fillMaxHeight()
+            ) {
+                SummonPanel(
+                    allChars = state.characters,
+                    baseChars = localBaseChars,
+                    summonEntries = localSummonEntries,
+                    trackingMode = trackingMode,
+                    onAdd = { char ->
+                        handleSummonAdd(localPlayerIndex, char, localBaseChars, trackingMode, viewModel) {
+                            summonerPickerState = it
+                        }
+                    },
+                    onRemove = { char ->
+                        viewModel.onEvent(CharacterEvent.RemoveSummonedCharacter(localPlayerIndex, char.id))
+                    }
+                )
+            }
+
+            // Dragging stone overlay
             if (draggingStoneSource != null) {
                 val localPos = rootLayoutCoordinates?.windowToLocal(dragPosition) ?: dragPosition
-                Box(modifier = Modifier.offset { IntOffset(localPos.x.roundToInt() - 20.dp.toPx().toInt(), localPos.y.roundToInt() - 20.dp.toPx().toInt()) }.zIndex(1000f)) {
+                Box(
+                    modifier = Modifier
+                        .offset { IntOffset(localPos.x.roundToInt() - 20.dp.toPx().toInt(), localPos.y.roundToInt() - 20.dp.toPx().toInt()) }
+                        .zIndex(1000f)
+                ) {
                     MoonstoneIcon(size = 40.dp)
                 }
             }
 
-            selectedChar?.let { (char, ps) ->
-                FullScreenCharacterModal(character = char, playState = ps, scaffoldPadding = padding, onDismiss = { selectedChar = null })
+            // Accumulating toast chip
+            val toastData = visibleToastKey?.let { accMap[it] }
+            if (toastData != null) {
+                val (delta, label) = toastData
+                val sign = if (delta > 0) "+" else ""
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = 80.dp)
+                        .zIndex(50f)
+                ) {
+                    Surface(
+                        shape = MaterialTheme.shapes.extraLarge,
+                        color = MaterialTheme.colorScheme.inverseSurface,
+                        tonalElevation = 6.dp
+                    ) {
+                        Text(
+                            text = "$sign$delta $label",
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.inverseOnSurface,
+                            modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp)
+                        )
+                    }
+                }
             }
 
+            // Card modal
+            selectedCharInfo?.let { (pi, ci, char) ->
+                val ps = if (isTutorialActive) {
+                    CharacterPlayState(currentHealth = char.health)
+                } else {
+                    state.characterPlayStates["${pi}_${ci}"] ?: CharacterPlayState(currentHealth = char.health)
+                }
+                GameCharacterCardModal(
+                    character = char,
+                    playState = ps,
+                    trackingMode = trackingMode,
+                    isEditable = !isTutorialActive,
+                    onEnergyChange = { viewModel.onEvent(CharacterEvent.UpdateCharacterEnergy(pi, ci, it)) },
+                    onAbilityToggle = { name, used -> viewModel.onEvent(CharacterEvent.ToggleAbilityUsed(pi, ci, name, used)) },
+                    onFlip = { viewModel.onEvent(CharacterEvent.ToggleCharacterFlipped(pi, ci, !ps.isFlipped)) },
+                    onTransform = if (char.transformsInto != null) { targetId ->
+                        viewModel.onEvent(CharacterEvent.TransformCharacter(pi, ci, targetId))
+                        selectedCharInfo = null
+                    } else null,
+                    onDismiss = { selectedCharInfo = null }
+                )
+            }
+
+            // Summoner picker dialog
             summonerPickerState?.let { pickerState ->
                 SummonerPickerDialog(
                     character = pickerState.character,
@@ -362,13 +467,18 @@ fun ActiveGameScreen(
         }
     }
 
+    // End game confirm dialog
     if (showEndGameConfirm) {
         AlertDialog(
             onDismissRequest = { showEndGameConfirm = false },
             title = { Text("End Game?") },
-            text = { Text("Are you sure you want to end the game now and calculate the winner based on current Moonstones?") },
+            text = { Text("End the game now and calculate the winner based on current Moonstones?") },
             confirmButton = {
-                Button(onClick = { showEndGameConfirm = false; viewModel.onEvent(CharacterEvent.EndGame) }, colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error), shape = theme.cardShape) {
+                Button(
+                    onClick = { showEndGameConfirm = false; viewModel.onEvent(CharacterEvent.EndGame) },
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
+                    shape = theme.cardShape
+                ) {
                     Text("Confirm End", style = theme.buttonTextStyle)
                 }
             },
@@ -378,6 +488,8 @@ fun ActiveGameScreen(
     }
     GameEndDialogs(state, viewModel, isTutorialActive)
 }
+
+// ─── Summon helper ────────────────────────────────────────────────────────────
 
 private fun handleSummonAdd(
     pageIndex: Int,
@@ -399,6 +511,8 @@ private fun handleSummonAdd(
     }
 }
 
+// ─── Top bar ─────────────────────────────────────────────────────────────────
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ActiveGameTopBar(
@@ -409,20 +523,20 @@ private fun ActiveGameTopBar(
     onDrawerToggle: () -> Unit,
     onEndGameClick: () -> Unit,
     onQuitGame: () -> Unit,
-    onTargetPositioned: (String, LayoutCoordinates) -> Unit,
-    pagerState: androidx.compose.foundation.pager.PagerState,
-    activePlayers: List<Pair<Troupe, List<Character>>>
+    onTargetPositioned: (String, LayoutCoordinates) -> Unit
 ) {
     val theme = LocalAppThemeProperties.current
-    val scope = rememberCoroutineScope()
-    Column(modifier = Modifier.background(MaterialTheme.colorScheme.surfaceVariant)) {
+    Surface(color = MaterialTheme.colorScheme.surfaceVariant, tonalElevation = theme.surfaceElevation) {
         CenterAlignedTopAppBar(
             navigationIcon = {
                 IconButton(
                     onClick = { if (!isTutorialActive) onDrawerToggle() },
                     modifier = Modifier.onGloballyPositioned { onTargetPositioned("CharacterDrawerButton", it) }
                 ) {
-                    Icon(if (isSummonPanelOpen) Icons.Default.MenuOpen else Icons.Default.Menu, contentDescription = null)
+                    Icon(
+                        if (isSummonPanelOpen) Icons.Default.MenuOpen else Icons.Default.Menu,
+                        contentDescription = null
+                    )
                 }
             },
             title = {
@@ -430,45 +544,641 @@ private fun ActiveGameTopBar(
                     val rReady = state.readyForRewind.contains(state.deviceId)
                     val rCount = state.readyForRewind.size
                     val totalP = state.gameSession?.players?.size ?: 1
-                    val canR = state.currentTurn > 1 || isTutorialActive
-                    IconButton(onClick = { if (!isTutorialActive) viewModel.onEvent(CharacterEvent.RewindTurn) }, enabled = canR, modifier = Modifier.onGloballyPositioned { onTargetPositioned("RewindButton", it) }) {
+                    val canRewind = state.currentTurn > 1 || isTutorialActive
+                    IconButton(
+                        onClick = { if (!isTutorialActive) viewModel.onEvent(CharacterEvent.RewindTurn) },
+                        enabled = canRewind,
+                        modifier = Modifier.onGloballyPositioned { onTargetPositioned("RewindButton", it) }
+                    ) {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Icon(Icons.Default.History, contentDescription = null, tint = if (rReady) MaterialTheme.colorScheme.primary else if (canR) MaterialTheme.colorScheme.primary.copy(alpha = 0.6f) else MaterialTheme.colorScheme.outline)
+                            Icon(
+                                Icons.Default.History, contentDescription = null,
+                                tint = if (rReady) MaterialTheme.colorScheme.primary
+                                       else if (canRewind) MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+                                       else MaterialTheme.colorScheme.outline
+                            )
                             if (state.gameSession != null) Text("($rCount/$totalP)", style = MaterialTheme.typography.labelSmall, fontSize = 8.sp)
                         }
                     }
-                    Text(text = if (state.currentTurn > 4) "Sudden Death" else "Round: ${state.currentTurn}", style = theme.titleStyle, color = MaterialTheme.colorScheme.primary, modifier = Modifier.padding(horizontal = theme.screenPadding))
+                    Text(
+                        text = if (state.currentTurn > 4) "Sudden Death" else "Round: ${state.currentTurn}",
+                        style = theme.titleStyle,
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(horizontal = theme.screenPadding)
+                    )
                     val nReady = state.readyForNextTurn.contains(state.deviceId)
                     val nCount = state.readyForNextTurn.size
-                    IconButton(onClick = { if (!isTutorialActive) viewModel.onEvent(CharacterEvent.NextTurn) }, modifier = Modifier.onGloballyPositioned { onTargetPositioned("NextTurnButton", it) }) {
+                    IconButton(
+                        onClick = { if (!isTutorialActive) viewModel.onEvent(CharacterEvent.NextTurn) },
+                        modifier = Modifier.onGloballyPositioned { onTargetPositioned("NextTurnButton", it) }
+                    ) {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Icon(Icons.Default.SkipNext, contentDescription = null, tint = if (nReady) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.primary.copy(alpha = 0.6f))
+                            Icon(
+                                Icons.Default.SkipNext, contentDescription = null,
+                                tint = if (nReady) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+                            )
                             if (state.gameSession != null) Text("($nCount/$totalP)", style = MaterialTheme.typography.labelSmall, fontSize = 8.sp)
                         }
                     }
-                    IconButton(onClick = { if (!isTutorialActive) onEndGameClick() }, modifier = Modifier.onGloballyPositioned { onTargetPositioned("EndGameQuickButton", it) }) {
+                    IconButton(
+                        onClick = { if (!isTutorialActive) onEndGameClick() },
+                        modifier = Modifier.onGloballyPositioned { onTargetPositioned("EndGameQuickButton", it) }
+                    ) {
                         Icon(Icons.Default.Flag, contentDescription = null, tint = MaterialTheme.colorScheme.error.copy(alpha = 0.7f))
                     }
                 }
             },
             actions = {
-                IconButton(onClick = { if (!isTutorialActive) onQuitGame() }, modifier = Modifier.onGloballyPositioned { onTargetPositioned("CloseGameButton", it) }) {
+                IconButton(
+                    onClick = { if (!isTutorialActive) onQuitGame() },
+                    modifier = Modifier.onGloballyPositioned { onTargetPositioned("CloseGameButton", it) }
+                ) {
                     Icon(Icons.Default.Close, contentDescription = null)
                 }
             },
             colors = TopAppBarDefaults.centerAlignedTopAppBarColors(containerColor = Color.Transparent),
             windowInsets = WindowInsets(top = 0.dp)
         )
-        if (activePlayers.size > 1) {
-            ScrollableTabRow(selectedTabIndex = pagerState.currentPage, edgePadding = theme.screenPadding, containerColor = Color.Transparent, divider = {}) {
-                activePlayers.forEachIndexed { index, (troupe, _) ->
-                    Tab(selected = pagerState.currentPage == index, onClick = { scope.launch { pagerState.animateScrollToPage(index) } }, text = { Text(text = troupe.troupeName, style = theme.labelStyle) })
+    }
+}
+
+// ─── Roster strip ─────────────────────────────────────────────────────────────
+
+// ─── Grid cell ────────────────────────────────────────────────────────────────
+
+@Composable
+private fun CharacterPortraitCell(
+    character: Character,
+    playState: CharacterPlayState,
+    trackingMode: GameTrackingMode,
+    summoner: Character?,
+    isEditable: Boolean,
+    onTap: () -> Unit,
+    onHpBadgeTap: () -> Unit,
+    onEnergyBadgeTap: () -> Unit,
+    onMoonstoneBadgeTap: () -> Unit,
+    onStoneDragStart: (Int, Offset) -> Unit,
+    onStoneDrag: (Offset) -> Unit,
+    onStoneDragEnd: () -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    val isFullTracking = trackingMode == GameTrackingMode.FULL_TRACKING
+    val isDead = playState.currentHealth <= 0
+    val moonstoneColor = theme.moonstoneColor
+    val stoneCoords = remember { mutableStateMapOf<Int, LayoutCoordinates>() }
+
+    val hasCombatModifiers = remember(character) {
+        (character.slicingDamageBuff ?: 0) > 0 ||
+        (character.piercingDamageBuff ?: 0) > 0 ||
+        (character.impactDamageBuff ?: 0) > 0 ||
+        character.dealsMagicalDamage ||
+        character.allDamageMitigation > 0 ||
+        character.slicingDamageMitigation > 0 ||
+        character.piercingDamageMitigation > 0 ||
+        character.impactDamageMitigation > 0 ||
+        character.magicalDamageMitigation > 0
+    }
+
+    var showCombatProfile by remember { mutableStateOf(false) }
+    val overlayAlpha by animateFloatAsState(
+        targetValue = if (showCombatProfile) 1f else 0f,
+        animationSpec = tween(200),
+        label = "combatOverlay"
+    )
+    // Auto-dismiss after 3 s
+    LaunchedEffect(showCombatProfile) {
+        if (showCombatProfile) {
+            delay(3000)
+            showCombatProfile = false
+        }
+    }
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(theme.cardShape)
+    ) {
+        // ── Portrait area fills full cell width ──────────────────────────────
+        BoxWithConstraints(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onTap)
+        ) {
+            val size = maxWidth
+            val portraitHeight = size * 0.85f
+
+            Box(
+                modifier = Modifier
+                    .width(size)
+                    .height(portraitHeight)
+                    .portraitCrimpedEdge()
+                    .then(if (isDead) Modifier.alpha(0.4f) else Modifier)
+            ) {
+                CharacterPortrait(character, size, shape = RectangleShape)
+            }
+
+            if (isDead) {
+                Text(
+                    "☠",
+                    fontSize = (size.value * 0.38f).sp,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            } else if (isFullTracking) {
+                // HP badge — bottom start, tap to decrement
+                StatBadge(
+                    value = playState.currentHealth,
+                    color = Color(0xFF2E7D32),
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .offset(4.dp, (-4).dp)
+                        .then(if (isEditable) Modifier.clickable(onClick = onHpBadgeTap) else Modifier)
+                )
+                // Energy badge — bottom end, tap to decrement
+                StatBadge(
+                    value = playState.currentEnergy,
+                    color = Color(0xFF1565C0),
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .offset((-4).dp, (-4).dp)
+                        .then(if (isEditable) Modifier.clickable(onClick = onEnergyBadgeTap) else Modifier)
+                )
+                // Moonstone badge — top center, tap to increment
+                if (playState.moonstones > 0 || isEditable) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopCenter)
+                            .offset(0.dp, 4.dp)
+                    ) {
+                        StatBadge(
+                            value = playState.moonstones,
+                            color = moonstoneColor,
+                            textColor = Color.Black,
+                            modifier = if (isEditable) Modifier.clickable(onClick = onMoonstoneBadgeTap) else Modifier
+                        )
+                        // Support drag-off for moonstone transfer to pool
+                        if (isEditable && playState.moonstones > 0) {
+                            repeat(playState.moonstones) { i ->
+                                Box(
+                                    modifier = Modifier
+                                        .size(1.dp)
+                                        .onGloballyPositioned { stoneCoords[i] = it }
+                                        .pointerInput(i) {
+                                            detectDragGestures(
+                                                onDragStart = { offset ->
+                                                    onStoneDragStart(i, (stoneCoords[i]?.boundsInWindow()?.topLeft ?: Offset.Zero) + offset)
+                                                },
+                                                onDrag = { change, amount -> change.consume(); onStoneDrag(amount) },
+                                                onDragEnd = { onStoneDragEnd() },
+                                                onDragCancel = { onStoneDragEnd() }
+                                            )
+                                        }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Combat profile overlay — fades in over portrait on stat bundle tap
+            if (overlayAlpha > 0f) {
+                Box(
+                    modifier = Modifier
+                        .width(size)
+                        .height(portraitHeight)
+                        .graphicsLayer { alpha = overlayAlpha }
+                        .background(Color(0xE6080812))
+                        .padding(8.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CombatProfileContent(character)
+                }
+            }
+        }
+
+        // ── Nameplate ────────────────────────────────────────────────────────
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                .padding(horizontal = 6.dp, vertical = 4.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
+            // Stat bundle pill — tappable if character has combat modifiers
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(MaterialTheme.shapes.small)
+                    .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.7f))
+                    .then(
+                        if (!isDead && hasCombatModifiers)
+                            Modifier.clickable { showCombatProfile = !showCombatProfile }
+                        else Modifier
+                    )
+                    .padding(horizontal = 5.dp, vertical = 3.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "⚔ ${character.melee}  ${character.meleeRange}\"  ✦ ${character.arcane}  💨 ${statSign(character.evade)}",
+                    style = MaterialTheme.typography.labelSmall,
+                    fontSize = 10.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.Center,
+                    color = if (isDead) MaterialTheme.colorScheme.outline
+                            else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            // Character name
+            Text(
+                text = character.name,
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
+                color = if (isDead) MaterialTheme.colorScheme.outline else MaterialTheme.colorScheme.onSurface
+            )
+
+            SummonerIndicator(summoner)
+        }
+    }
+}
+
+// ─── Stat badge ───────────────────────────────────────────────────────────────
+
+@Composable
+private fun StatBadge(
+    value: Int,
+    color: Color,
+    modifier: Modifier = Modifier,
+    textColor: Color = Color.White
+) {
+    Box(
+        modifier = modifier
+            .size(22.dp)
+            .clip(CircleShape)
+            .background(color),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = value.toString(),
+            color = textColor,
+            style = MaterialTheme.typography.labelSmall,
+            fontSize = 9.sp,
+            fontWeight = FontWeight.ExtraBold
+        )
+    }
+}
+
+// ─── Combat profile overlay content ─────────────────────────────────────────
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun CombatProfileContent(character: Character) {
+    data class Chip(val label: String, val fg: Color, val bg: Color)
+
+    val slicingBuff  = character.slicingDamageBuff ?: 0
+    val piercingBuff = character.piercingDamageBuff ?: 0
+    val impactBuff   = character.impactDamageBuff ?: 0
+
+    val atkChips = buildList<Chip> {
+        if (slicingBuff > 0)              add(Chip("⚔ +$slicingBuff Slicing",    Color(0xFFFF6B6B), Color(0x20E53935)))
+        if (piercingBuff > 0)             add(Chip("▲ +$piercingBuff Piercing",  Color(0xFFFFB74D), Color(0x20F57C00)))
+        if (impactBuff > 0)               add(Chip("⬤ +$impactBuff Impact",      Color(0xFFBCAAA4), Color(0x20795548)))
+        if (character.dealsMagicalDamage) add(Chip("✦ Magical",                  Color(0xFFCE93D8), Color(0x209C27B0)))
+    }
+    val defChips = buildList<Chip> {
+        val all = character.allDamageMitigation
+        if (all > 0)                                   add(Chip("⬡ −$all All",                                        Color(0xFFB0BEC5), Color(0x2090A4AE)))
+        if (character.slicingDamageMitigation > 0)     add(Chip("⚔ −${character.slicingDamageMitigation} Slicing",   Color(0xFFEF9A9A), Color(0x20E53935)))
+        if (character.piercingDamageMitigation > 0)    add(Chip("▲ −${character.piercingDamageMitigation} Piercing", Color(0xFFFFE082), Color(0x20F57C00)))
+        if (character.impactDamageMitigation > 0)      add(Chip("⬤ −${character.impactDamageMitigation} Impact",     Color(0xFFD7CCC8), Color(0x20795548)))
+        if (character.magicalDamageMitigation > 0)     add(Chip("✦ −${character.magicalDamageMitigation} Magical",   Color(0xFFE1BEE7), Color(0x209C27B0)))
+    }
+
+    if (atkChips.isEmpty() && defChips.isEmpty()) {
+        Text(
+            "No modifiers",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontStyle = FontStyle.Italic
+        )
+        return
+    }
+
+    @Composable
+    fun ChipSection(label: String, chips: List<Chip>) {
+        if (chips.isEmpty()) return
+        Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+            Text(
+                label,
+                style = MaterialTheme.typography.labelSmall,
+                fontSize = 8.sp,
+                letterSpacing = 1.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.65f)
+            )
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                chips.forEach { chip ->
+                    Box(
+                        modifier = Modifier
+                            .clip(CircleShape)
+                            .background(chip.bg)
+                            .border(1.dp, chip.fg.copy(alpha = 0.5f), CircleShape)
+                            .padding(horizontal = 6.dp, vertical = 2.dp)
+                    ) {
+                        Text(
+                            chip.label,
+                            style = MaterialTheme.typography.labelSmall,
+                            fontSize = 9.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = chip.fg
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        ChipSection("OFFENSIVE", atkChips)
+        ChipSection("DEFENSIVE", defChips)
+    }
+}
+
+// ─── Section header ───────────────────────────────────────────────────────────
+
+@Composable
+private fun GamePlayerSectionHeader(troupe: Troupe) {
+    val theme = LocalAppThemeProperties.current
+    val factionColor = getFactionColor(troupe.faction)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(factionColor.copy(alpha = 0.15f))
+            .border(
+                width = 1.dp,
+                color = factionColor.copy(alpha = 0.4f),
+                shape = theme.cardShape
+            )
+            .padding(horizontal = theme.screenPadding, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Icon(getFactionIcon(troupe.faction), contentDescription = null, tint = factionColor, modifier = Modifier.size(16.dp))
+        Text(
+            text = troupe.troupeName,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            color = factionColor
+        )
+    }
+}
+
+// ─── Card modal ───────────────────────────────────────────────────────────────
+
+@Composable
+private fun GameCharacterCardModal(
+    character: Character,
+    playState: CharacterPlayState,
+    trackingMode: GameTrackingMode,
+    isEditable: Boolean,
+    onEnergyChange: (Int) -> Unit,
+    onAbilityToggle: (String, Boolean) -> Unit,
+    onFlip: () -> Unit,
+    onTransform: ((Int) -> Unit)? = null,
+    onDismiss: () -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    val isFullTracking = trackingMode == GameTrackingMode.FULL_TRACKING
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .zIndex(100f)
+    ) {
+        // Scrim — tap to dismiss
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.72f))
+                .clickable { onDismiss() }
+        )
+
+        ThemedCard(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .fillMaxWidth(0.94f)
+                .fillMaxHeight(0.88f)
+                .clickable {} // Absorb touches so scrim doesn't dismiss
+        ) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    // Energy controls row (FULL_TRACKING only)
+                    if (isFullTracking) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = theme.screenPadding, vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Text(
+                                "ENERGY",
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = FontWeight.Bold,
+                                modifier = Modifier.weight(1f)
+                            )
+                            IconButton(
+                                onClick = { if (playState.currentEnergy > 0) onEnergyChange(playState.currentEnergy - 1) },
+                                modifier = Modifier.size(32.dp),
+                                enabled = isEditable
+                            ) { Icon(Icons.Default.Remove, contentDescription = null, modifier = Modifier.size(18.dp)) }
+                            Text(
+                                text = playState.currentEnergy.toString(),
+                                style = MaterialTheme.typography.titleLarge,
+                                fontWeight = FontWeight.ExtraBold,
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.widthIn(min = 28.dp),
+                                textAlign = TextAlign.Center
+                            )
+                            IconButton(
+                                onClick = { onEnergyChange(playState.currentEnergy + 1) },
+                                modifier = Modifier.size(32.dp),
+                                enabled = isEditable
+                            ) { Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(18.dp)) }
+                        }
+                        HorizontalDivider()
+                    }
+
+                    // Flip-animated card content (fills remaining space, pinned footer)
+                    CharacterCardContent(
+                        character = character,
+                        searchQuery = "",
+                        isFlipped = playState.isFlipped,
+                        onFlip = onFlip,
+                        modifier = Modifier.weight(1f).fillMaxWidth(),
+                        animateFlip = true,
+                        showBackgroundImage = theme.showBackgroundImageOverlay,
+                        showHealthTracker = true,
+                        abilityUsedStates = if (isFullTracking && isEditable) playState.usedAbilities else null,
+                        onAbilityUsedChange = if (isFullTracking && isEditable) onAbilityToggle else null,
+                        pinnedFooter = true
+                    )
+
+                    // Transform button
+                    if (onTransform != null && character.transformsInto != null) {
+                        HorizontalDivider()
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(MaterialTheme.shapes.small)
+                                .clickable(enabled = isEditable) { onTransform(character.transformsInto) }
+                                .padding(vertical = 8.dp, horizontal = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(Icons.Default.AutoAwesome, contentDescription = null, modifier = Modifier.size(16.dp), tint = MaterialTheme.colorScheme.primary)
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text("Transform", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
+                        }
+                    }
+                }
+
+                // Floating close button — overlays top-right corner
+                Box(modifier = Modifier.align(Alignment.TopEnd).zIndex(10f)) {
+                    IconButton(onClick = onDismiss) {
+                        Icon(Icons.Default.Close, contentDescription = "Close")
+                    }
                 }
             }
         }
     }
 }
 
+// ─── Reusable composables ─────────────────────────────────────────────────────
+
+@Composable
+private fun SummonerIndicator(summoner: Character?) {
+    summoner ?: return
+    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(top = 2.dp)) {
+        CharacterPortrait(summoner, 14.dp)
+        Spacer(Modifier.width(3.dp))
+        Text(
+            "↳ ${summoner.name}",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            fontSize = 9.sp
+        )
+    }
+}
+
+@Composable
+private fun SummonPanel(
+    allChars: List<Character>,
+    baseChars: List<Character>,
+    summonEntries: List<SummonEntry>,
+    trackingMode: GameTrackingMode,
+    onAdd: (Character) -> Unit,
+    onRemove: (Character) -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    val troupeCharIds = baseChars.map { it.id }.toSet()
+    val summonableIds = baseChars.flatMap { it.summonsCharacterIds }.toSet()
+    val summonableChars = allChars.filter { it.id in summonableIds && it.id !in troupeCharIds }
+    val summonedIds = summonEntries.map { it.characterId }.toSet()
+
+    Column(
+        modifier = Modifier
+            .width(100.dp)
+            .fillMaxHeight()
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.95f))
+            .padding(vertical = theme.verticalSpacing / 2),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(theme.verticalSpacing / 2)
+    ) {
+        if (summonableChars.isEmpty()) {
+            Text(
+                "No summons",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.outline,
+                modifier = Modifier.padding(theme.screenPadding),
+                textAlign = TextAlign.Center
+            )
+        } else {
+            summonableChars.forEach { char ->
+                val isAlreadySummoned = char.id in summonedIds
+                Box(modifier = Modifier.clickable { if (isAlreadySummoned) onRemove(char) else onAdd(char) }) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier
+                            .alpha(if (isAlreadySummoned) 1f else 0.45f)
+                            .padding(horizontal = 4.dp)
+                    ) {
+                        CharacterPortrait(char, 44.dp)
+                        Text(char.name, style = MaterialTheme.typography.labelSmall, maxLines = 1, overflow = TextOverflow.Ellipsis, textAlign = TextAlign.Center)
+                    }
+                    if (isAlreadySummoned) {
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.TopEnd)
+                                .size(16.dp)
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.error),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(Icons.Default.Close, contentDescription = "Remove", modifier = Modifier.size(10.dp), tint = MaterialTheme.colorScheme.onError)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SummonerPickerDialog(
+    character: Character,
+    possibleSummoners: List<Character>,
+    onSelect: (Int) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Who summons ${character.name}?") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                possibleSummoners.forEach { summoner ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onSelect(summoner.id) }
+                            .padding(vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        CharacterPortrait(summoner, 32.dp)
+                        Spacer(Modifier.width(8.dp))
+                        Text(summoner.name, style = MaterialTheme.typography.bodyMedium)
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        shape = theme.cardShape
+    )
+}
 
 @Composable
 private fun CollapsiblePoolBar(
@@ -492,7 +1202,10 @@ private fun CollapsiblePoolBar(
     Surface(color = MaterialTheme.colorScheme.surfaceVariant, tonalElevation = theme.surfaceElevation) {
         Column {
             Row(
-                modifier = Modifier.fillMaxWidth().clickable { poolExpanded = !poolExpanded }.padding(horizontal = theme.screenPadding, vertical = theme.verticalSpacing / 4),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { poolExpanded = !poolExpanded }
+                    .padding(horizontal = theme.screenPadding, vertical = theme.verticalSpacing / 4),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Icon(if (poolExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore, contentDescription = null, modifier = Modifier.size(16.dp))
@@ -503,7 +1216,8 @@ private fun CollapsiblePoolBar(
                 Column(modifier = Modifier.padding(horizontal = theme.screenPadding).padding(bottom = theme.verticalSpacing / 2)) {
                     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center, verticalAlignment = Alignment.CenterVertically) {
                         Box(
-                            modifier = Modifier.size(60.dp)
+                            modifier = Modifier
+                                .size(60.dp)
                                 .onGloballyPositioned { potBounds.value = it.boundsInWindow(); onTargetPositioned("MoonstonePool", it) }
                                 .pointerInput(isLocal) {
                                     if (isLocal) detectDragGestures(
@@ -540,7 +1254,9 @@ private fun CollapsiblePoolBar(
 private fun PoolResourceRow(definition: PoolResourceDefinition, currentCount: Int, onCountChange: (Int) -> Unit) {
     val theme = LocalAppThemeProperties.current
     Row(
-        modifier = Modifier.fillMaxWidth().padding(vertical = theme.verticalSpacing / 4),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = theme.verticalSpacing / 4),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
@@ -558,321 +1274,30 @@ private fun PoolResourceRow(definition: PoolResourceDefinition, currentCount: In
 }
 
 @Composable
-private fun GameCharacterGridCard(
-    character: Character,
-    playState: CharacterPlayState,
-    trackingMode: GameTrackingMode,
-    summoner: Character?,
-    isEditable: Boolean,
-    draggingStoneInfo: Int,
-    onHealthChange: (Int) -> Unit,
-    onEnergyChange: (Int) -> Unit,
-    onAbilityToggle: (String, Boolean) -> Unit,
-    onFlippedChange: (Boolean) -> Unit,
-    onTap: () -> Unit,
-    onTransform: ((Int) -> Unit)? = null,
-    onStoneDragStart: (Int, Offset) -> Unit,
-    onStoneDrag: (Offset) -> Unit,
-    onStoneDragEnd: () -> Unit
-) {
-    val theme = LocalAppThemeProperties.current
-    val isFullTracking = trackingMode == GameTrackingMode.FULL_TRACKING
-    val isDead = playState.currentHealth <= 0
-    val stoneCoords = remember { mutableStateMapOf<Int, LayoutCoordinates>() }
-
-    val sigName = remember(character) {
-        character.signatureMove?.let { if (it.upgradeFor.isNotEmpty()) it.upgradeFor else it.name } ?: ""
-    }
-    val trackableAbilities = remember(character) {
-        character.abilities.filter { it.abilityType in listOf("Active", "Arcane") && (it.oncePerTurn || it.oncePerGame) }.map { it.name }
-    }
-
-    ThemedCard(
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onTap),
-        containerColor = if (isDead) Color.DarkGray else null
-    ) {
-        Column(modifier = Modifier.padding(theme.cardContentPadding)) {
-            // Name + signature move
-            Text(
-                text = buildAnnotatedString {
-                    append(character.name)
-                    if (sigName.isNotEmpty()) {
-                        append(" - ")
-                        withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append(sigName) }
-                    }
-                },
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                style = MaterialTheme.typography.labelMedium
-            )
-            // Portrait + stats/damage row
-            Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.Top) {
-                CharacterPortrait(character, 52.dp)
-                Spacer(modifier = Modifier.width(6.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text("⚔ ${character.melee} | ${character.meleeRange}\"", style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Bold)
-                    Text("Evade ${character.evade.toString()}", style = MaterialTheme.typography.bodySmall)
-                    ModifierDisplay(character, isOffense = true)
-                    ModifierDisplay(character, isOffense = false)
-                }
-            }
-            // Trackable resources row: energy + once-per-turn/game ability toggles
-            if (isFullTracking) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.padding(top = 4.dp)
-                ) {
-                    IconButton(onClick = { if (playState.currentEnergy > 0) onEnergyChange(playState.currentEnergy - 1) }, modifier = Modifier.size(24.dp), enabled = isEditable) {
-                        Icon(Icons.Default.Remove, contentDescription = null, modifier = Modifier.size(14.dp))
-                    }
-                    Text("E:${playState.currentEnergy}", style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Bold)
-                    IconButton(onClick = { onEnergyChange(playState.currentEnergy + 1) }, modifier = Modifier.size(24.dp), enabled = isEditable) {
-                        Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(14.dp))
-                    }
-                    trackableAbilities.forEach { abilityName ->
-                        val isUsed = playState.usedAbilities[abilityName] ?: false
-                        Spacer(Modifier.width(6.dp))
-                        Text(
-                            abilityName,
-                            style = MaterialTheme.typography.labelSmall,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.weight(1f, fill = false).widthIn(max = 64.dp)
-                        )
-                        Spacer(Modifier.width(2.dp))
-                        Box(
-                            modifier = Modifier
-                                .size(12.dp)
-                                .clip(CircleShape)
-                                .background(if (isUsed) MaterialTheme.colorScheme.onSurfaceVariant else Color.Transparent)
-                                .border(1.dp, if (isEditable) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline, CircleShape)
-                                .then(if (isEditable) Modifier.clickable { onAbilityToggle(abilityName, !isUsed) } else Modifier),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            if (isUsed) Icon(Icons.Default.Close, contentDescription = null, modifier = Modifier.size(8.dp), tint = Color.White)
-                        }
-                    }
-                }
-            }
-
-            // Moonstones
-            if (playState.moonstones > 0 || isFullTracking) {
-                Row(
-                    modifier = Modifier.padding(top = 4.dp),
-                    horizontalArrangement = Arrangement.spacedBy(2.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    if (isFullTracking) {
-                        repeat(playState.moonstones) { i ->
-                            Box(
-                                modifier = Modifier
-                                    .onGloballyPositioned { stoneCoords[i] = it }
-                                    .alpha(if (draggingStoneInfo == i) 0f else 1f)
-                                    .pointerInput(i, isEditable) {
-                                        if (isEditable) detectDragGestures(
-                                            onDragStart = { offset -> onStoneDragStart(i, (stoneCoords[i]?.boundsInWindow()?.topLeft ?: Offset.Zero) + offset) },
-                                            onDrag = { change, amount -> change.consume(); onStoneDrag(amount) },
-                                            onDragEnd = { onStoneDragEnd() },
-                                            onDragCancel = { onStoneDragEnd() }
-                                        )
-                                    }
-                            ) { MoonstoneIcon(size = 12.dp) }
-                        }
-                    } else if (playState.moonstones > 0) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            MoonstoneIcon(size = 10.dp)
-                            Spacer(Modifier.width(2.dp))
-                            Text("×${playState.moonstones}", style = MaterialTheme.typography.labelSmall)
-                        }
-                    }
-                }
-            }
-
-            HealthPipsChunked(
-                total = character.health,
-                current = playState.currentHealth,
-                energyTrack = character.energyTrack,
-                compact = trackingMode == GameTrackingMode.LOW_DETAIL,
-                isEditable = isFullTracking && isEditable,
-                onHealthChange = onHealthChange
-            )
-
-            SummonerIndicator(summoner)
-
-            if (onTransform != null && character.transformsInto != null) {
-                Spacer(modifier = Modifier.height(4.dp))
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(MaterialTheme.shapes.small)
-                        .clickable(enabled = isEditable) { onTransform(character.transformsInto) }
-                        .padding(vertical = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.Center
-                ) {
-                    Icon(Icons.Default.AutoAwesome, contentDescription = null, modifier = Modifier.size(12.dp), tint = MaterialTheme.colorScheme.primary)
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text("Transform", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
-                }
-            }
-        }
-    }
-}
-
-
-
-
-// CharacterPortrait is defined in CommonComponents.kt
-
-@Composable
-private fun SummonerIndicator(summoner: Character?) {
-    summoner ?: return
-    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(top = 4.dp)) {
-        CharacterPortrait(summoner, 18.dp)
-        Spacer(Modifier.width(4.dp))
-        Text(
-            "by ${summoner.name}",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
-    }
-}
-
-@Composable
-private fun SummonPanel(
-    allChars: List<Character>,
-    baseChars: List<Character>,
-    summonEntries: List<SummonEntry>,
-    trackingMode: GameTrackingMode,
-    onAdd: (Character) -> Unit,
-    onRemove: (Character) -> Unit
-) {
-    val theme = LocalAppThemeProperties.current
-    val troupeCharIds = baseChars.map { it.id }.toSet()
-    val summonableIds = baseChars.flatMap { it.summonsCharacterIds }.toSet()
-    val summonableChars = allChars.filter { it.id in summonableIds && it.id !in troupeCharIds }
-    val summonedIds = summonEntries.map { it.characterId }.toSet()
-
-    Column(
-        modifier = Modifier
-            .width(100.dp)
-            .fillMaxHeight()
-            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.95f))
-            .padding(vertical = theme.verticalSpacing / 2),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(theme.verticalSpacing / 2)
-    ) {
-        if (summonableChars.isEmpty()) {
-            Text("No summons", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.outline, modifier = Modifier.padding(theme.screenPadding), textAlign = TextAlign.Center)
-        } else {
-            summonableChars.forEach { char ->
-                val isAlreadySummoned = char.id in summonedIds
-                Box(
-                    modifier = Modifier.clickable { if (isAlreadySummoned) onRemove(char) else onAdd(char) }
-                ) {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        modifier = Modifier.alpha(if (isAlreadySummoned) 1f else 0.45f).padding(horizontal = 4.dp)
-                    ) {
-                        CharacterPortrait(char, 44.dp)
-                        Text(char.name, style = MaterialTheme.typography.labelSmall, maxLines = 1, overflow = TextOverflow.Ellipsis, textAlign = TextAlign.Center)
-                    }
-                    if (isAlreadySummoned) {
-                        Box(
-                            modifier = Modifier.align(Alignment.TopEnd).size(16.dp).clip(CircleShape).background(MaterialTheme.colorScheme.error),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(Icons.Default.Close, contentDescription = "Remove", modifier = Modifier.size(10.dp), tint = MaterialTheme.colorScheme.onError)
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun SummonerPickerDialog(
-    character: Character,
-    possibleSummoners: List<Character>,
-    onSelect: (Int) -> Unit,
-    onDismiss: () -> Unit
-) {
-    val theme = LocalAppThemeProperties.current
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text("Who summons ${character.name}?") },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                possibleSummoners.forEach { summoner ->
-                    Row(
-                        modifier = Modifier.fillMaxWidth().clickable { onSelect(summoner.id) }.padding(vertical = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        CharacterPortrait(summoner, 32.dp)
-                        Spacer(Modifier.width(8.dp))
-                        Text(summoner.name, style = MaterialTheme.typography.bodyMedium)
-                    }
-                }
-            }
-        },
-        confirmButton = {},
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
-        shape = theme.cardShape
-    )
-}
-
-@Composable
-private fun FullScreenCharacterModal(
-    character: Character,
-    playState: CharacterPlayState,
-    scaffoldPadding: PaddingValues,
-    onDismiss: () -> Unit
-) {
-    val theme = LocalAppThemeProperties.current
-    val isFlipped = remember { mutableStateOf(false) }
-    val scrollState = rememberScrollState()
-    Box(modifier = Modifier.fillMaxSize().zIndex(100f)) {
-        Box(modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.72f)).clickable { onDismiss() })
-        ThemedCard(
-            modifier = Modifier
-                .align(Alignment.Center)
-                .fillMaxWidth(0.92f)
-                .padding(
-                    top = scaffoldPadding.calculateTopPadding() + 8.dp,
-                    bottom = scaffoldPadding.calculateBottomPadding() + 8.dp
-                )
-                .fillMaxHeight()
-                .clickable {}
-        ) {
-            Column(
-                modifier = Modifier
-                    .verticalScroll(scrollState)
-                    .padding(theme.cardContentPadding)
-            ) {
-                if (!isFlipped.value) {
-                    CharacterFront(character = character, searchQuery = "", onFlip = { isFlipped.value = true })
-                } else {
-                    CharacterBack(character = character, searchQuery = "", onFlip = { isFlipped.value = false })
-                }
-            }
-        }
-    }
-}
-
-@Composable
 private fun GameEndDialogs(state: CharacterState, viewModel: CharacterViewModel, isTutorialActive: Boolean) {
     val isMoonstone = LocalAppThemeProperties.current.showExpandedStatsHeader
     val theme = LocalAppThemeProperties.current
     if (state.winnerName != null && !isTutorialActive) {
-        AlertDialog(onDismissRequest = { viewModel.onEvent(CharacterEvent.ResetGamePlayState) }, title = { Text("Victory!", style = if (isMoonstone) MaterialTheme.typography.displayLarge else MaterialTheme.typography.headlineMedium) }, text = { Text(text = "${state.winnerName} has collected the most Moonstones and wins the game!", textAlign = TextAlign.Center, modifier = Modifier.fillMaxWidth()) }, confirmButton = { Button(onClick = { viewModel.onEvent(CharacterEvent.ResetGamePlayState) }, shape = theme.cardShape) { Text("New Game", style = theme.buttonTextStyle) } }, shape = theme.cardShape)
+        AlertDialog(
+            onDismissRequest = { viewModel.onEvent(CharacterEvent.ResetGamePlayState) },
+            title = { Text("Victory!", style = if (isMoonstone) MaterialTheme.typography.displayLarge else MaterialTheme.typography.headlineMedium) },
+            text = { Text(text = "${state.winnerName} has collected the most Moonstones and wins the game!", textAlign = TextAlign.Center, modifier = Modifier.fillMaxWidth()) },
+            confirmButton = { Button(onClick = { viewModel.onEvent(CharacterEvent.ResetGamePlayState) }, shape = theme.cardShape) { Text("New Game", style = theme.buttonTextStyle) } },
+            shape = theme.cardShape
+        )
     }
     if (state.isTie && !isTutorialActive) {
-        AlertDialog(onDismissRequest = { viewModel.onEvent(CharacterEvent.ResetGamePlayState) }, title = { Text("It's a Tie!", style = if (isMoonstone) MaterialTheme.typography.displayLarge else MaterialTheme.typography.headlineMedium) }, text = { Text(text = "No single player collected more Moonstones than the others. The game ends in a draw!", textAlign = TextAlign.Center, modifier = Modifier.fillMaxWidth()) }, confirmButton = { Button(onClick = { viewModel.onEvent(CharacterEvent.ResetGamePlayState) }, shape = theme.cardShape) { Text("New Game", style = theme.buttonTextStyle) } }, shape = theme.cardShape)
+        AlertDialog(
+            onDismissRequest = { viewModel.onEvent(CharacterEvent.ResetGamePlayState) },
+            title = { Text("It's a Tie!", style = if (isMoonstone) MaterialTheme.typography.displayLarge else MaterialTheme.typography.headlineMedium) },
+            text = { Text(text = "No single player collected more Moonstones than the others. The game ends in a draw!", textAlign = TextAlign.Center, modifier = Modifier.fillMaxWidth()) },
+            confirmButton = { Button(onClick = { viewModel.onEvent(CharacterEvent.ResetGamePlayState) }, shape = theme.cardShape) { Text("New Game", style = theme.buttonTextStyle) } },
+            shape = theme.cardShape
+        )
     }
 }
+
+// ─── Public utility composables ──────────────────────────────────────────────
 
 @Composable
 fun CharacterPortraitJump(character: Character, onClick: () -> Unit) {
@@ -888,16 +1313,16 @@ fun CharacterPortraitJump(character: Character, onClick: () -> Unit) {
     }
 }
 
-sealed class StoneSource {
-    data object Pot : StoneSource()
-    data class Character(val playerIndex: Int, val charIndex: Int) : StoneSource()
-}
-
 @Composable
 fun MoonstoneIcon(size: Dp, modifier: Modifier = Modifier) {
     val moonstoneColor = LocalAppThemeProperties.current.moonstoneColor
     Canvas(modifier = modifier.size(size)) {
-        val path = Path().apply { moveTo(size.toPx() / 2f, 0f); lineTo(size.toPx(), size.toPx()); lineTo(0f, size.toPx()); close() }
+        val path = Path().apply {
+            moveTo(size.toPx() / 2f, 0f)
+            lineTo(size.toPx(), size.toPx())
+            lineTo(0f, size.toPx())
+            close()
+        }
         drawPath(path, color = moonstoneColor)
     }
 }
@@ -947,9 +1372,13 @@ fun FrontSide(
                 Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.CenterHorizontally) {
                     Text("ENERGY", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold)
                     Row(verticalAlignment = Alignment.CenterVertically) {
-                        IconButton(onClick = { if (playState.currentEnergy > 0) onEnergyChange(playState.currentEnergy - 1) }, modifier = Modifier.size(32.dp), enabled = isEditable) { Icon(Icons.Default.Remove, contentDescription = null, modifier = Modifier.size(20.dp)) }
+                        IconButton(onClick = { if (playState.currentEnergy > 0) onEnergyChange(playState.currentEnergy - 1) }, modifier = Modifier.size(32.dp), enabled = isEditable) {
+                            Icon(Icons.Default.Remove, contentDescription = null, modifier = Modifier.size(20.dp))
+                        }
                         Text(text = playState.currentEnergy.toString(), fontSize = 22.sp, fontWeight = FontWeight.ExtraBold, color = if (isEditable) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline, modifier = Modifier.padding(horizontal = 4.dp))
-                        IconButton(onClick = { onEnergyChange(playState.currentEnergy + 1) }, modifier = Modifier.size(32.dp), enabled = isEditable) { Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(20.dp)) }
+                        IconButton(onClick = { onEnergyChange(playState.currentEnergy + 1) }, modifier = Modifier.size(32.dp), enabled = isEditable) {
+                            Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(20.dp))
+                        }
                     }
                 }
             }
@@ -965,10 +1394,14 @@ fun FrontSide(
                     onHealthChange = onHealthChange
                 )
             }
-            IconButton(onClick = onExpandToggle, modifier = Modifier.size(32.dp)) { Icon(Icons.Default.KeyboardArrowDown, contentDescription = null) }
+            IconButton(onClick = onExpandToggle, modifier = Modifier.size(32.dp)) {
+                Icon(Icons.Default.KeyboardArrowDown, contentDescription = null)
+            }
         }
         if (playState.isExpanded) {
-            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2)); HorizontalDivider(); Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
             val passiveAbilities = character.abilities.filter { it.abilityType == "Passive" }
             val activeAbilities = character.abilities.filter { it.abilityType == "Active" }
             val arcaneAbilities = character.abilities.filter { it.abilityType == "Arcane" }
@@ -979,12 +1412,30 @@ fun FrontSide(
             }
             if (activeAbilities.isNotEmpty()) {
                 Text("ACTIVE ABILITIES", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
-                activeAbilities.forEach { ability -> CommonAbilityItem(name = "${ability.name} (${ability.energyCost ?: 0})${if ((ability.range ?: "").isNotEmpty()) " " + ability.range else ""}", description = ability.description, oncePerTurn = ability.oncePerTurn, oncePerGame = ability.oncePerGame, isUsed = playState.usedAbilities[ability.name] ?: false, onUsedChange = { u -> onAbilityToggle(ability.name, u) }, isEditable = isEditable) }
+                activeAbilities.forEach { ability ->
+                    CommonAbilityItem(
+                        name = "${ability.name} (${ability.energyCost ?: 0})${if ((ability.range ?: "").isNotEmpty()) " " + ability.range else ""}",
+                        description = ability.description,
+                        oncePerTurn = ability.oncePerTurn, oncePerGame = ability.oncePerGame,
+                        isUsed = playState.usedAbilities[ability.name] ?: false,
+                        onUsedChange = { u -> onAbilityToggle(ability.name, u) },
+                        isEditable = isEditable
+                    )
+                }
                 Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
             }
             if (arcaneAbilities.isNotEmpty()) {
                 Text("ARCANE ABILITIES", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
-                arcaneAbilities.forEach { ability -> CommonAbilityItem(name = "${ability.name} (${ability.energyCost ?: 0})${if ((ability.range ?: "").isNotEmpty()) " " + ability.range else ""}", description = buildArcaneDescription(ability), oncePerTurn = ability.oncePerTurn, oncePerGame = ability.oncePerGame, isUsed = playState.usedAbilities[ability.name] ?: false, onUsedChange = { u -> onAbilityToggle(ability.name, u) }, isEditable = isEditable) }
+                arcaneAbilities.forEach { ability ->
+                    CommonAbilityItem(
+                        name = "${ability.name} (${ability.energyCost ?: 0})${if ((ability.range ?: "").isNotEmpty()) " " + ability.range else ""}",
+                        description = buildArcaneDescription(ability),
+                        oncePerTurn = ability.oncePerTurn, oncePerGame = ability.oncePerGame,
+                        isUsed = playState.usedAbilities[ability.name] ?: false,
+                        onUsedChange = { u -> onAbilityToggle(ability.name, u) },
+                        isEditable = isEditable
+                    )
+                }
             }
             if (onTransform != null && character.transformsInto != null) {
                 Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -1,6 +1,8 @@
 package io.github.garemat.lunachron.ui
 
 import androidx.compose.animation.*
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -26,6 +28,8 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.LayoutCoordinates
@@ -57,11 +61,15 @@ import java.io.File
 // --- Base Utilities ---
 
 /**
- * Circular character portrait. Prefers {imageName}-head.png (zoomed head crop) for the
- * circular display, then falls back to the full portrait variants, then shows first initial.
+ * Character portrait. Prefers {imageName}-head.png (zoomed head crop), then falls back to
+ * full portrait variants, then shows the first initial.
+ *
+ * @param shape Clip shape applied to the portrait. Defaults to [CircleShape] for list/roster
+ *              contexts; pass [RectangleShape] (or any other shape) for the game grid cells
+ *              where the natural PNG shape is preferred.
  */
 @Composable
-fun CharacterPortrait(character: Character, size: Dp, modifier: Modifier = Modifier) {
+fun CharacterPortrait(character: Character, size: Dp, modifier: Modifier = Modifier, shape: Shape = CircleShape) {
     val context = LocalContext.current
     val imageFile = remember(character.imageName) {
         character.imageName?.let { name ->
@@ -71,7 +79,7 @@ fun CharacterPortrait(character: Character, size: Dp, modifier: Modifier = Modif
         }
     }
     Box(
-        modifier = modifier.size(size).clip(CircleShape),
+        modifier = modifier.size(size).clip(shape),
         contentAlignment = Alignment.Center
     ) {
         if (imageFile != null) {
@@ -415,7 +423,16 @@ fun CommonAbilityItem(name: String, description: String, searchQuery: String = "
 }
 
 @Composable
-fun CharacterFront(character: Character, searchQuery: String, onFlip: () -> Unit, onFlipPositioned: (LayoutCoordinates) -> Unit = {}) {
+fun CharacterFront(
+    character: Character,
+    searchQuery: String,
+    onFlip: () -> Unit,
+    onFlipPositioned: (LayoutCoordinates) -> Unit = {},
+    showHealthTracker: Boolean = true,
+    showSignatureLink: Boolean = true,
+    abilityUsedStates: Map<String, Boolean>? = null,
+    onAbilityUsedChange: ((String, Boolean) -> Unit)? = null
+) {
     val theme = LocalAppThemeProperties.current
     Column {
         if (theme.showExpandedStatsHeader) MoonstoneHeader(character, searchQuery)
@@ -430,21 +447,57 @@ fun CharacterFront(character: Character, searchQuery: String, onFlip: () -> Unit
         val passiveAbilities = character.abilities.filter { it.abilityType == "Passive" }
         val activeAbilities = character.abilities.filter { it.abilityType == "Active" }
         val arcaneAbilities = character.abilities.filter { it.abilityType == "Arcane" }
-        passiveAbilities.forEach { CommonAbilityItem(it.name, it.description, searchQuery, it.oncePerTurn, it.oncePerGame, passive = true) }
-        if (activeAbilities.isNotEmpty()) { AbilityTypeSeparator(); activeAbilities.forEach { CommonAbilityItem("${it.name} (${it.energyCost ?: 0}) ${it.range ?: ""}", it.description, searchQuery, it.oncePerTurn, it.oncePerGame, showColon = false) } }
-        if (arcaneAbilities.isNotEmpty()) { AbilityTypeSeparator(); arcaneAbilities.forEach { CommonAbilityItem("${it.name} (${it.energyCost ?: 0}) ${it.range ?: ""}", buildArcaneDescription(it), searchQuery, it.oncePerTurn, it.oncePerGame, showColon = false) } }
-        character.signatureMove?.let { sigMove ->
-            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
-            Row(
-                modifier = Modifier.fillMaxWidth().clickable { onFlip() }.onGloballyPositioned { onFlipPositioned(it) },
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(text = buildAnnotatedString { append(if (theme.showExpandedStatsHeader) "Signature Move on a " else "Signature Move: "); withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { appendWithHighlight(if (theme.showExpandedStatsHeader) sigMove.upgradeFor else sigMove.name, searchQuery) }; append(".") }, style = MaterialTheme.typography.bodyMedium, fontStyle = FontStyle.Italic, modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.secondary)
-                Icon(imageVector = Icons.Default.KeyboardArrowRight, contentDescription = "View signature move", modifier = Modifier.size(16.dp), tint = MaterialTheme.colorScheme.secondary)
-            }
-            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+        passiveAbilities.forEach { ability ->
+            CommonAbilityItem(
+                ability.name, ability.description, searchQuery, ability.oncePerTurn, ability.oncePerGame,
+                passive = true,
+                isUsed = abilityUsedStates?.get(ability.name) ?: false,
+                onUsedChange = if (abilityUsedStates != null) { used -> onAbilityUsedChange?.invoke(ability.name, used) } else null,
+                isEditable = abilityUsedStates != null
+            )
         }
-        HealthTracker(character.health, character.health, character.energyTrack, {}, isEditable = false)
+        if (activeAbilities.isNotEmpty()) {
+            AbilityTypeSeparator()
+            activeAbilities.forEach { ability ->
+                CommonAbilityItem(
+                    "${ability.name} (${ability.energyCost ?: 0}) ${ability.range ?: ""}",
+                    ability.description, searchQuery, ability.oncePerTurn, ability.oncePerGame,
+                    showColon = false,
+                    isUsed = abilityUsedStates?.get(ability.name) ?: false,
+                    onUsedChange = if (abilityUsedStates != null) { used -> onAbilityUsedChange?.invoke(ability.name, used) } else null,
+                    isEditable = abilityUsedStates != null
+                )
+            }
+        }
+        if (arcaneAbilities.isNotEmpty()) {
+            AbilityTypeSeparator()
+            arcaneAbilities.forEach { ability ->
+                CommonAbilityItem(
+                    "${ability.name} (${ability.energyCost ?: 0}) ${ability.range ?: ""}",
+                    buildArcaneDescription(ability), searchQuery, ability.oncePerTurn, ability.oncePerGame,
+                    showColon = false,
+                    isUsed = abilityUsedStates?.get(ability.name) ?: false,
+                    onUsedChange = if (abilityUsedStates != null) { used -> onAbilityUsedChange?.invoke(ability.name, used) } else null,
+                    isEditable = abilityUsedStates != null
+                )
+            }
+        }
+        if (showSignatureLink) {
+            character.signatureMove?.let { sigMove ->
+                Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+                Row(
+                    modifier = Modifier.fillMaxWidth().clickable { onFlip() }.onGloballyPositioned { onFlipPositioned(it) },
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(text = buildAnnotatedString { append(if (theme.showExpandedStatsHeader) "Signature Move on a " else "Signature Move: "); withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { appendWithHighlight(if (theme.showExpandedStatsHeader) sigMove.upgradeFor else sigMove.name, searchQuery) }; append(".") }, style = MaterialTheme.typography.bodyMedium, fontStyle = FontStyle.Italic, modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.secondary)
+                    Icon(imageVector = Icons.Default.KeyboardArrowRight, contentDescription = "View signature move", modifier = Modifier.size(16.dp), tint = MaterialTheme.colorScheme.secondary)
+                }
+                Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+            }
+        }
+        if (showHealthTracker) {
+            HealthTracker(character.health, character.health, character.energyTrack, {}, isEditable = false)
+        }
         Text(text = "Base: ${character.baseSize}", style = MaterialTheme.typography.labelSmall, modifier = Modifier.fillMaxWidth(), textAlign = TextAlign.End)
     }
 }
@@ -495,7 +548,7 @@ private fun MoonstoneStats(character: Character) {
 }
 
 @Composable
-fun CharacterBack(character: Character, searchQuery: String, onFlip: () -> Unit, onFlipPositioned: (LayoutCoordinates) -> Unit = {}) {
+fun CharacterBack(character: Character, searchQuery: String, onFlip: () -> Unit, onFlipPositioned: (LayoutCoordinates) -> Unit = {}, showBackLink: Boolean = true) {
     val theme = LocalAppThemeProperties.current
     Column {
         val sigMove = character.signatureMove
@@ -520,14 +573,16 @@ fun CharacterBack(character: Character, searchQuery: String, onFlip: () -> Unit,
                 if (sigMove.extraText.isNotEmpty()) Text(text = parseAbilityDescription(sigMove.extraText, searchQuery), style = MaterialTheme.typography.bodyMedium, inlineContent = getMoonstoneInlineContent())
                 if (sigMove.endStepEffect.isNotEmpty()) Text(text = buildAnnotatedString { withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("End Step Effect: ") }; append(parseAbilityDescription(sigMove.endStepEffect, searchQuery)) }, style = MaterialTheme.typography.bodyMedium, inlineContent = getMoonstoneInlineContent())
             }
-            Spacer(modifier = Modifier.height(theme.verticalSpacing))
-            Row(
-                modifier = Modifier.fillMaxWidth().clickable { onFlip() },
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Center
-            ) {
-                Icon(imageVector = Icons.Default.KeyboardArrowLeft, contentDescription = "Back to character stats", modifier = Modifier.size(16.dp), tint = MaterialTheme.colorScheme.secondary)
-                Text(text = "Character stats", style = MaterialTheme.typography.labelMedium, fontStyle = FontStyle.Italic, color = MaterialTheme.colorScheme.secondary)
+            if (showBackLink) {
+                Spacer(modifier = Modifier.height(theme.verticalSpacing))
+                Row(
+                    modifier = Modifier.fillMaxWidth().clickable { onFlip() },
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    Icon(imageVector = Icons.Default.KeyboardArrowLeft, contentDescription = "Back to character stats", modifier = Modifier.size(16.dp), tint = MaterialTheme.colorScheme.secondary)
+                    Text(text = "Character stats", style = MaterialTheme.typography.labelMedium, fontStyle = FontStyle.Italic, color = MaterialTheme.colorScheme.secondary)
+                }
             }
         }
     }
@@ -536,18 +591,7 @@ fun CharacterBack(character: Character, searchQuery: String, onFlip: () -> Unit,
 @Composable
 fun CommonCharacterCard(character: Character, searchQuery: String, isExpanded: Boolean, onExpandClick: () -> Unit, modifier: Modifier = Modifier, cardTargetName: String = "CharacterCard", onPositioned: (String, LayoutCoordinates) -> Unit = { _, _ -> }, forceFlipped: Boolean? = null, selectionControl: @Composable (RowScope.() -> Unit)? = null, bottomContent: (@Composable () -> Unit)? = null) {
     var isFlippedState by remember { mutableStateOf(false) }; val isFlipped = forceFlipped ?: isFlippedState
-    val context = LocalContext.current
     val theme = LocalAppThemeProperties.current
-    val density = LocalDensity.current
-    var frontHeightPx by remember { mutableStateOf(0) }
-    val bgImageFile = remember(character.imageName) {
-        character.imageName?.let { name ->
-            val dir = File(context.filesDir, "images")
-            listOf("", ".jpg", ".png", ".webp").firstNotNullOfOrNull { ext ->
-                File(dir, "$name$ext").takeIf { it.exists() }
-            }
-        }
-    }
     ThemedCard(modifier = modifier.fillMaxWidth().animateContentSize().onGloballyPositioned { onPositioned(cardTargetName, it) }) {
         Column {
             Row(modifier = Modifier.fillMaxWidth().clickable { onExpandClick() }.padding(theme.cardContentPadding), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
@@ -564,30 +608,205 @@ fun CommonCharacterCard(character: Character, searchQuery: String, isExpanded: B
             }
             if (isExpanded) {
                 if (theme.showCardDivider) HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
-                Box(modifier = Modifier.fillMaxWidth()) {
-                    if (theme.showBackgroundImageOverlay && bgImageFile != null) {
-                        AsyncImage(model = bgImageFile, contentDescription = null, modifier = Modifier.matchParentSize().alpha(0.25f), contentScale = ContentScale.Crop)
-                    }
-                    // Faction symbol(s) peeking from top-right corner, half-clipped by card edge
-                    if (character.factions.isNotEmpty()) {
-                        MultiFactionIcon(
-                            factions = character.factions,
-                            size = 64.dp,
-                            modifier = Modifier.align(Alignment.TopEnd).offset(x = 32.dp)
+                CharacterCardContent(
+                    character = character,
+                    searchQuery = searchQuery,
+                    isFlipped = isFlipped,
+                    onFlip = { isFlippedState = !isFlippedState },
+                    modifier = Modifier.fillMaxWidth(),
+                    animateFlip = true,
+                    showBackgroundImage = theme.showBackgroundImageOverlay,
+                    showHealthTracker = true,
+                    onFlipPositioned = { onPositioned("FlipButton", it) }
+                )
+            }
+            bottomContent?.invoke()
+        }
+    }
+}
+
+/**
+ * Shared card content composable used by both the compendium list and the in-game character modal.
+ *
+ * @param isFlipped    Whether the back face should be showing (controlled externally).
+ * @param onFlip       Called when the user taps the flip link.
+ * @param animateFlip  If true, animates the 3-D flip; if false, switches instantly.
+ * @param showBackgroundImage  If true and the character has a portrait image, renders it as a
+ *                     translucent background behind the card content.
+ * @param showHealthTracker  Passed through to [CharacterFront] — shows health pips on the card.
+ * @param pinnedFooter Controls whether the card content area is scrollable. Both `true` and `false`
+ *                     render the Signature-Move / ← Character stats link as a pinned footer row
+ *                     separated by a [HorizontalDivider]. When `true`, the content area gets a
+ *                     `verticalScroll` wrapper and fills the available height — use this for
+ *                     fixed-height containers (game modal). When `false` (default), the card
+ *                     auto-sizes to its content — use this inside a [LazyColumn] (compendium).
+ */
+@Composable
+fun CharacterCardContent(
+    character: Character,
+    searchQuery: String,
+    isFlipped: Boolean,
+    onFlip: () -> Unit,
+    modifier: Modifier = Modifier,
+    animateFlip: Boolean = true,
+    showBackgroundImage: Boolean = false,
+    showHealthTracker: Boolean = true,
+    abilityUsedStates: Map<String, Boolean>? = null,
+    onAbilityUsedChange: ((String, Boolean) -> Unit)? = null,
+    pinnedFooter: Boolean = false,
+    onFlipPositioned: (LayoutCoordinates) -> Unit = {}
+) {
+    val theme = LocalAppThemeProperties.current
+    val context = LocalContext.current
+    val localDensity = LocalDensity.current
+
+    val bgImageFile = remember(character.imageName) {
+        character.imageName?.let { name ->
+            val dir = File(context.filesDir, "images")
+            listOf("", ".jpg", ".png", ".webp").firstNotNullOfOrNull { ext ->
+                File(dir, "$name$ext").takeIf { it.exists() }
+            }
+        }
+    }
+
+    val rotation by animateFloatAsState(
+        targetValue = if (isFlipped) 180f else 0f,
+        animationSpec = if (animateFlip) tween(durationMillis = 600) else tween(durationMillis = 0),
+        label = "cardFlip"
+    )
+    val showBack = rotation > 90f
+
+    var frontHeightPx by remember { mutableStateOf(0) }
+
+    Box(modifier = modifier) {
+        // Full-bleed background art
+        if (showBackgroundImage && bgImageFile != null) {
+            AsyncImage(
+                model = bgImageFile,
+                contentDescription = null,
+                modifier = Modifier.matchParentSize().alpha(0.25f),
+                contentScale = ContentScale.Crop
+            )
+        }
+        // Faction symbol(s) peeking from top-right corner, half-clipped by card edge
+        if (character.factions.isNotEmpty()) {
+            MultiFactionIcon(
+                factions = character.factions,
+                size = 64.dp,
+                modifier = Modifier.align(Alignment.TopEnd).offset(x = 32.dp)
+            )
+        }
+
+        // Flip-animated card content.
+        // density inside graphicsLayer {} refers to GraphicsLayerScope.density (a Float).
+        val flipModifier = Modifier
+            .padding(theme.cardContentPadding)
+            .then(if (pinnedFooter) Modifier.fillMaxSize() else Modifier)
+            .graphicsLayer { rotationY = rotation; cameraDistance = 12f * density }
+
+        Box(modifier = flipModifier) {
+            if (!showBack) {
+                // Front face.
+                // pinnedFooter = true  → content scrolls, footer anchored to bottom (modal)
+                // pinnedFooter = false → card auto-sizes; track height so back face never shrinks
+                Column(
+                    modifier = Modifier.fillMaxWidth()
+                        .then(if (pinnedFooter) Modifier.fillMaxSize() else Modifier.onSizeChanged { sz -> frontHeightPx = sz.height })
+                ) {
+                    Column(
+                        modifier = if (pinnedFooter)
+                            Modifier.weight(1f).verticalScroll(rememberScrollState())
+                        else
+                            Modifier.fillMaxWidth()
+                    ) {
+                        CharacterFront(
+                            character = character,
+                            searchQuery = searchQuery,
+                            onFlip = onFlip,
+                            onFlipPositioned = onFlipPositioned,
+                            showHealthTracker = showHealthTracker,
+                            showSignatureLink = false,
+                            abilityUsedStates = abilityUsedStates,
+                            onAbilityUsedChange = onAbilityUsedChange
                         )
                     }
-                    Box(
-                        modifier = Modifier
-                            .padding(theme.cardContentPadding)
-                            .then(if (!isFlipped) Modifier.onSizeChanged { frontHeightPx = it.height }
-                                  else Modifier.heightIn(min = with(density) { frontHeightPx.toDp() }))
+                    // Signature-move link — pinned at the visual bottom in both modes
+                    character.signatureMove?.let { sigMove ->
+                        HorizontalDivider()
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onFlip() }
+                                .padding(vertical = 8.dp, horizontal = 16.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = buildAnnotatedString {
+                                    append(if (theme.showExpandedStatsHeader) "Signature Move on a " else "Signature Move: ")
+                                    withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+                                        appendWithHighlight(if (theme.showExpandedStatsHeader) sigMove.upgradeFor else sigMove.name, searchQuery)
+                                    }
+                                    append(".")
+                                },
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontStyle = FontStyle.Italic,
+                                modifier = Modifier.weight(1f),
+                                color = MaterialTheme.colorScheme.secondary
+                            )
+                            Icon(imageVector = Icons.Default.KeyboardArrowRight, contentDescription = "View signature move", modifier = Modifier.size(16.dp), tint = MaterialTheme.colorScheme.secondary)
+                        }
+                    }
+                }
+            } else {
+                // Back face — counter-rotate so text reads correctly after the Y flip.
+                Box(
+                    modifier = Modifier
+                        .graphicsLayer { rotationY = 180f }
+                        .then(if (pinnedFooter) Modifier.fillMaxSize() else Modifier.fillMaxWidth())
+                ) {
+                    // For compendium (pinnedFooter=false): Column is at least as tall as the front
+                    // face was (heightIn) and uses SpaceBetween to push the footer to the visual
+                    // bottom even when the back content is shorter than the front.
+                    Column(
+                        modifier = if (pinnedFooter)
+                            Modifier.fillMaxSize()
+                        else
+                            Modifier.fillMaxWidth().heightIn(min = with(localDensity) { frontHeightPx.toDp() }),
+                        verticalArrangement = if (pinnedFooter) Arrangement.Top else Arrangement.SpaceBetween
                     ) {
-                        if (!isFlipped) CharacterFront(character = character, searchQuery = searchQuery, onFlip = { isFlippedState = true }, onFlipPositioned = { onPositioned("FlipButton", it) })
-                        else CharacterBack(character = character, searchQuery = searchQuery, onFlip = { isFlippedState = false }, onFlipPositioned = { onPositioned("FlipButton", it) })
+                        Column(
+                            modifier = if (pinnedFooter)
+                                Modifier.weight(1f).verticalScroll(rememberScrollState())
+                            else
+                                Modifier.fillMaxWidth()
+                        ) {
+                            CharacterBack(
+                                character = character,
+                                searchQuery = searchQuery,
+                                onFlip = onFlip,
+                                onFlipPositioned = onFlipPositioned,
+                                showBackLink = false
+                            )
+                        }
+                        // Back-to-stats link — wrapped in Column so SpaceBetween treats it as
+                        // one unit and places it at the visual bottom of the card
+                        Column(modifier = Modifier.fillMaxWidth()) {
+                            HorizontalDivider()
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable { onFlip() }
+                                    .padding(vertical = 8.dp, horizontal = 16.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.Center
+                            ) {
+                                Icon(imageVector = Icons.Default.KeyboardArrowLeft, contentDescription = "Back to character stats", modifier = Modifier.size(16.dp), tint = MaterialTheme.colorScheme.secondary)
+                                Text(text = "Character stats", style = MaterialTheme.typography.labelMedium, fontStyle = FontStyle.Italic, color = MaterialTheme.colorScheme.secondary)
+                            }
+                        }
                     }
                 }
             }
-            bottomContent?.invoke()
         }
     }
 }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/GameSetupScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/GameSetupScreen.kt
@@ -9,6 +9,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -135,7 +136,8 @@ fun GameSetupScreen(
         Scaffold(
             topBar = {
                 // TopBar title and navigation is handled by MainActivity
-            }
+            },
+            contentWindowInsets = WindowInsets(0)
         ) { padding ->
             Column(modifier = Modifier.fillMaxSize().padding(padding).padding(16.dp)) {
                 if (state.tournamentSettings != null) {
@@ -186,7 +188,7 @@ fun GameSetupScreen(
                             )
                         }
                         else -> {
-                            SetupModeSelection(
+                            GameModeHeroUI(
                                 onLocalSelected = { setupMode.value = SetupMode.LOCAL },
                                 onHostSelected = { showHostModeDialog = true },
                                 onJoinSelected = {

--- a/app/src/main/java/io/github/garemat/lunachron/ui/HomeScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/HomeScreen.kt
@@ -3,10 +3,19 @@ package io.github.garemat.lunachron.ui
 import android.app.Activity
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -22,6 +31,7 @@ import coil.compose.AsyncImage
 import io.github.garemat.lunachron.CharacterEvent
 import io.github.garemat.lunachron.CharacterState
 import io.github.garemat.lunachron.NewsItem
+import io.github.garemat.lunachron.Troupe
 import io.github.garemat.lunachron.ui.theme.LocalAppThemeProperties
 import androidx.compose.ui.layout.ContentScale
 
@@ -29,6 +39,7 @@ import androidx.compose.ui.layout.ContentScale
 fun HomeScreen(
     state: CharacterState,
     onEvent: (CharacterEvent) -> Unit,
+    onQuickStartTroupe: (Troupe) -> Unit = {},
     onTargetPositioned: (String, LayoutCoordinates) -> Unit = { _, _ -> }
 ) {
     val context = LocalContext.current
@@ -46,8 +57,36 @@ fun HomeScreen(
         }
     }
 
+    val favouriteTroupes = remember(state.troupes) { state.troupes.filter { it.isFavourite } }
+    val newsListState = rememberLazyListState()
+    val showQuickStart by remember {
+        derivedStateOf {
+            newsListState.firstVisibleItemIndex == 0 && newsListState.firstVisibleItemScrollOffset < 80
+        }
+    }
+
     Box(modifier = Modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize().padding(horizontal = theme.screenPadding)) {
+            AnimatedVisibility(
+                visible = favouriteTroupes.isNotEmpty() && showQuickStart,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut()
+            ) {
+                Column {
+                    Spacer(modifier = Modifier.height(theme.verticalSpacing))
+                    Text(
+                        text = "Quick Start",
+                        style = theme.titleStyle.copy(fontSize = 20.sp),
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                    Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+                    favouriteTroupes.forEach { troupe ->
+                        QuickStartCard(troupe = troupe, onClick = { onQuickStartTroupe(troupe) })
+                        Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+                    }
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                }
+            }
             Text(
                 text = "Latest News",
                 style = theme.titleStyle.copy(fontSize = 28.sp),
@@ -80,6 +119,7 @@ fun HomeScreen(
                 }
                 else -> {
                     LazyColumn(
+                        state = newsListState,
                         modifier = Modifier.fillMaxSize(),
                         contentPadding = PaddingValues(bottom = theme.verticalSpacing),
                         verticalArrangement = Arrangement.spacedBy(theme.verticalSpacing)
@@ -89,6 +129,52 @@ fun HomeScreen(
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+fun QuickStartCard(troupe: Troupe, onClick: () -> Unit) {
+    val theme = LocalAppThemeProperties.current
+    val factionColor = getFactionColor(troupe.faction)
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable { onClick() },
+        shape = theme.cardShape,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Row(
+            modifier = Modifier.padding(theme.cardContentPadding),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.Star,
+                contentDescription = null,
+                tint = factionColor,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(modifier = Modifier.width(10.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = troupe.troupeName,
+                    style = theme.headerStyle.copy(fontSize = 16.sp),
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = "${troupe.faction.name.lowercase().replaceFirstChar { it.uppercase() }} · ${troupe.characterIds.size} characters",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            FilledTonalButton(
+                onClick = onClick,
+                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 0.dp),
+                modifier = Modifier.height(36.dp)
+            ) {
+                Icon(Icons.Default.PlayArrow, contentDescription = null, modifier = Modifier.size(16.dp))
+                Spacer(modifier = Modifier.width(4.dp))
+                Text("Play", style = theme.buttonTextStyle)
             }
         }
     }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/OfflineSetupUI.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/OfflineSetupUI.kt
@@ -1,24 +1,67 @@
 package io.github.garemat.lunachron.ui
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.garemat.lunachron.*
 import io.github.garemat.lunachron.ui.theme.LocalAppThemeProperties
 
-@OptIn(ExperimentalMaterial3Api::class)
+// ── Slot state ────────────────────────────────────────────────────────────────
+
+private data class SlotData(
+    val troupe: Troupe? = null,
+    val selectedCharIds: List<Int> = emptyList(),
+    val pickerOpen: Boolean = false
+)
+
+private enum class LocalSetupStep { PLAYER_COUNT, TROUPE_SELECTION, READY }
+
+private fun maxCharsForCount(playerCount: Int) = when (playerCount) {
+    3 -> 4; 4 -> 3; else -> 6
+}
+
+private fun slotStatus(slot: SlotData, max: Int): String = when {
+    slot.troupe == null -> "empty"
+    slot.troupe.characterIds.size <= max -> "confirmed"
+    slot.selectedCharIds.size >= max -> "confirmed"
+    else -> "trimming"
+}
+
+private fun finalCharIds(slot: SlotData, max: Int): List<Int> {
+    val t = slot.troupe ?: return emptyList()
+    return if (t.characterIds.size <= max) t.characterIds else slot.selectedCharIds
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
 @Composable
 fun OfflineSetupUI(
     state: CharacterState,
@@ -29,17 +72,21 @@ fun OfflineSetupUI(
     onPositioned: (String, LayoutCoordinates) -> Unit = { _, _ -> },
     onBack: () -> Unit = {}
 ) {
-    var playerCount by remember { mutableIntStateOf(2) }
-    val selectedTroupes = remember { mutableStateListOf<Troupe?>(null, null, null, null) }
-    var troupeToPrune by remember { mutableStateOf<Pair<Int, Troupe>?>(null) }
-    var troupeToSaveWithName by remember { mutableStateOf<Troupe?>(null) }
-    var customTroupeName by remember { mutableStateOf("") }
-    val theme = LocalAppThemeProperties.current
-    
+    var step by rememberSaveable { mutableStateOf(LocalSetupStep.PLAYER_COUNT) }
+    var playerCount by rememberSaveable { mutableIntStateOf(2) }
+    val slots = remember { mutableStateListOf(SlotData(), SlotData(), SlotData(), SlotData()) }
+    var troupeToSave by remember { mutableStateOf<Pair<Int, Troupe>?>(null) }
+    var saveNameDraft by remember { mutableStateOf("") }
+    var showQrForTroupe by remember { mutableStateOf<Troupe?>(null) }
+
     LaunchedEffect(Unit) {
         viewModel.scannedTroupeEvent.collect { (index, troupe) ->
-            if (index < selectedTroupes.size) {
-                selectedTroupes[index] = troupe
+            if (index < slots.size) {
+                val max = maxCharsForCount(playerCount)
+                slots[index] = if (troupe.characterIds.size <= max)
+                    SlotData(troupe = troupe)
+                else
+                    SlotData(troupe = troupe, pickerOpen = true)
             }
         }
     }
@@ -47,201 +94,1094 @@ fun OfflineSetupUI(
     LaunchedEffect(playerCount) {
         viewModel.uiEvent.collect { event ->
             if (event is CharacterViewModel.UiEvent.TroupeCreated) {
-                val index = event.playerIndex
-                if (index != null && index >= 0 && index < 4) {
-                    val maxAllowed = when(playerCount) {
-                        3 -> 4
-                        4 -> 3
-                        else -> 6
-                    }
-                    if (!event.troupe.isTournamentList && event.troupe.characterIds.size <= maxAllowed) {
-                        selectedTroupes[index] = event.troupe
-                    } else {
-                        troupeToPrune = index to event.troupe
-                    }
+                val index = event.playerIndex ?: return@collect
+                if (index < 0 || index >= 4) return@collect
+                val t = event.troupe
+                if (!t.isTournamentList) {
+                    val max = maxCharsForCount(playerCount)
+                    slots[index] = if (t.characterIds.size <= max)
+                        SlotData(troupe = t)
+                    else
+                        SlotData(troupe = t, pickerOpen = true)
                 }
             }
         }
     }
 
-    var showQrForTroupe by remember { mutableStateOf<Troupe?>(null) }
-
-    Column {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 8.dp)
-                .onGloballyPositioned { onPositioned("PlayerCount", it) }
-        ) {
-            IconButton(onClick = onBack) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-            }
-            Spacer(modifier = Modifier.weight(1f))
-            Text(text = "Players:", style = theme.titleStyle.copy(fontSize = 20.sp), color = MaterialTheme.colorScheme.primary)
-            Spacer(modifier = Modifier.width(8.dp))
-            Row {
-                listOf(2, 3, 4).forEach { count ->
-                    FilterChip(
-                        selected = playerCount == count,
-                        onClick = { 
-                            playerCount = count
-                            for (i in count until 4) selectedTroupes[i] = null
-                        },
-                        label = { Text(count.toString()) },
-                        modifier = Modifier.padding(horizontal = 4.dp),
-                        shape = theme.cardShape
-                    )
-                }
-            }
-            Spacer(modifier = Modifier.weight(1f))
-        }
-        
-        Spacer(modifier = Modifier.height(16.dp))
-
-        LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.weight(1f)) {
-            items(playerCount) { index ->
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
-                    shape = theme.cardShape,
-                    elevation = CardDefaults.cardElevation(defaultElevation = theme.surfaceElevation)
-                ) {
-                    Column(modifier = Modifier.padding(theme.cardContentPadding)) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Icon(Icons.Default.Person, contentDescription = null)
-                            Spacer(modifier = Modifier.width(8.dp))
-                            val name = if (index == 0) state.name.ifEmpty { "Player 1" } else "Player ${index + 1}"
-                            Text(name, fontWeight = FontWeight.Bold)
-                            Spacer(modifier = Modifier.weight(1f))
-                            
-                            val troupe = selectedTroupes[index]
-                            val showSave = troupe != null && state.troupes.none { it.shareCode == troupe.shareCode && troupe.shareCode.isNotEmpty() }
-                            
-                            if (showSave) {
-                                IconButton(
-                                    onClick = { 
-                                        troupe?.let {
-                                            troupeToSaveWithName = it
-                                            customTroupeName = it.troupeName
-                                        }
-                                    },
-                                    modifier = Modifier.onGloballyPositioned { if (index == 0) onPositioned("SaveTroupeSetup", it) }
-                                ) { Icon(Icons.Default.Save, contentDescription = "Save Troupe") }
-                            }
-                            
-                            if (troupe != null) {
-                                IconButton(
-                                    onClick = { showQrForTroupe = troupe },
-                                    modifier = Modifier.onGloballyPositioned { if (index == 0) onPositioned("QrCodeDisplayButton", it) }
-                                ) { Icon(Icons.Default.QrCode, contentDescription = "Show QR") }
-                            }
-
-                            IconButton(
-                                onClick = { onScanRequest(index) },
-                                modifier = Modifier.onGloballyPositioned { if (index == 0) onPositioned("ScanQR", it) }
-                            ) { Icon(Icons.Default.QrCodeScanner, contentDescription = "Scan QR") }
-                        }
-
-                        TroupeSelector(
-                            troupes = state.troupes,
-                            selectedTroupe = selectedTroupes[index],
-                            allCharacters = state.characters,
-                            onTroupeSelected = { t ->
-                                val maxAllowed = when(playerCount) { 3 -> 4; 4 -> 3; else -> 6 }
-                                if (t.isTournamentList || t.characterIds.size > maxAllowed) troupeToPrune = index to t
-                                else selectedTroupes[index] = t
-                            },
-                            onCreateNewTroupe = {
-                                viewModel.editingTroupeId = null
-                                viewModel.pendingTroupePlayerIndex = index
-                                onNavigateToAddEditTroupe()
-                            },
-                            onEditTroupe = { t ->
-                                viewModel.onEvent(CharacterEvent.EditTroupe(t))
-                                viewModel.pendingTroupePlayerIndex = index
-                                onNavigateToAddEditTroupe()
-                            },
-                            modifier = Modifier.onGloballyPositioned { if (index == 0) onPositioned("TroupeSelector", it) },
-                            onPositioned = onPositioned
-                        )
-                    }
-                }
-            }
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        Button(
-            onClick = {
-                val nonNullTroupes = selectedTroupes.take(playerCount).filterNotNull()
-                if (nonNullTroupes.size == playerCount) {
-                    viewModel.startNewGame(nonNullTroupes)
-                    onStartGame()
-                }
+    when (step) {
+        LocalSetupStep.PLAYER_COUNT -> PlayerCountStep(
+            playerCount = playerCount,
+            onCountSelected = { count ->
+                playerCount = count
+                for (i in count until 4) slots[i] = SlotData()
             },
-            enabled = selectedTroupes.take(playerCount).all { it != null },
-            modifier = Modifier.fillMaxWidth().height(56.dp).onGloballyPositioned { onPositioned("StartBattleButton", it) },
-            shape = theme.cardShape
-        ) {
-            Text(
-                "BATTLE!", 
-                style = theme.buttonTextStyle
-            )
-        }
-    }
-    
-    if (showQrForTroupe != null) {
-        val shareCode = viewModel.generateFullShareCode(showQrForTroupe!!, state.characters, state.upgradeCards)
-        QrCodeDialog(troupeName = showQrForTroupe!!.troupeName, shareCode = shareCode, onDismiss = { showQrForTroupe = null })
-    }
-
-    if (troupeToPrune != null) {
-        val (index, troupe) = troupeToPrune!!
-        val maxAllowed = when(playerCount) { 3 -> 4; 4 -> 3; else -> 6 }
-        TroupeSelectionDialog(
-            troupe = troupe,
-            maxSelection = maxAllowed,
-            allCharacters = state.characters,
-            onConfirmed = { selectedChars ->
-                selectedTroupes[index] = troupe.copy(characterIds = selectedChars.map { it.id })
-                troupeToPrune = null
+            onBack = onBack,
+            onContinue = { step = LocalSetupStep.TROUPE_SELECTION },
+            onPositioned = onPositioned
+        )
+        LocalSetupStep.TROUPE_SELECTION -> TroupeSelectionStep(
+            state = state,
+            viewModel = viewModel,
+            playerCount = playerCount,
+            slots = slots,
+            onScanRequest = onScanRequest,
+            onNavigateToAddEditTroupe = onNavigateToAddEditTroupe,
+            onBack = { step = LocalSetupStep.PLAYER_COUNT },
+            onContinue = { step = LocalSetupStep.READY },
+            onPositioned = onPositioned,
+            onRequestSave = { index, troupe ->
+                troupeToSave = index to troupe
+                saveNameDraft = troupe.troupeName
             },
-            onDismiss = { troupeToPrune = null }
+            onShowQr = { troupe -> showQrForTroupe = troupe }
+        )
+        LocalSetupStep.READY -> ReadyStep(
+            state = state,
+            playerCount = playerCount,
+            slots = slots,
+            onBack = { step = LocalSetupStep.TROUPE_SELECTION },
+            onStartGame = {
+                val max = maxCharsForCount(playerCount)
+                val troupes = (0 until playerCount).map { i ->
+                    val slot = slots[i]
+                    slot.troupe!!.copy(characterIds = finalCharIds(slot, max))
+                }
+                viewModel.startNewGame(troupes)
+                onStartGame()
+            },
+            onPositioned = onPositioned
         )
     }
 
-    if (troupeToSaveWithName != null) {
+    if (showQrForTroupe != null) {
+        val shareCode = viewModel.generateFullShareCode(showQrForTroupe!!, state.characters, state.upgradeCards)
+        QrCodeDialog(
+            troupeName = showQrForTroupe!!.troupeName,
+            shareCode = shareCode,
+            onDismiss = { showQrForTroupe = null }
+        )
+    }
+
+    if (troupeToSave != null) {
         AlertDialog(
-            onDismissRequest = { troupeToSaveWithName = null },
+            onDismissRequest = { troupeToSave = null },
             title = { Text("Save Troupe") },
             text = {
                 Column {
                     Text("Enter a name for this troupe:")
                     Spacer(modifier = Modifier.height(8.dp))
                     OutlinedTextField(
-                        value = customTroupeName,
-                        onValueChange = { customTroupeName = it },
+                        value = saveNameDraft,
+                        onValueChange = { saveNameDraft = it },
                         modifier = Modifier.fillMaxWidth(),
                         placeholder = { Text("Troupe Name") },
                         singleLine = true,
-                        shape = theme.cardShape
+                        shape = LocalAppThemeProperties.current.cardShape
                     )
                 }
             },
             confirmButton = {
+                val theme = LocalAppThemeProperties.current
                 Button(
                     onClick = {
-                        troupeToSaveWithName?.let { troupe: Troupe ->
-                            viewModel.saveTroupe(troupe.copy(troupeName = customTroupeName))
+                        troupeToSave?.let { (_, troupe) ->
+                            viewModel.saveTroupe(troupe.copy(troupeName = saveNameDraft))
                         }
-                        troupeToSaveWithName = null
+                        troupeToSave = null
                     },
-                    enabled = customTroupeName.isNotBlank(),
-                    shape = theme.cardShape
+                    enabled = saveNameDraft.isNotBlank(),
+                    shape = LocalAppThemeProperties.current.cardShape
                 ) { Text("Save") }
             },
-            dismissButton = { TextButton(onClick = { troupeToSaveWithName = null }) { Text("Cancel") } }
+            dismissButton = { TextButton(onClick = { troupeToSave = null }) { Text("Cancel") } }
         )
+    }
+}
+
+// ── Step pips ─────────────────────────────────────────────────────────────────
+
+@Composable
+private fun StepPips(activeIndex: Int) {
+    Row(horizontalArrangement = Arrangement.spacedBy(5.dp), verticalAlignment = Alignment.CenterVertically) {
+        repeat(3) { i ->
+            Box(
+                modifier = Modifier
+                    .height(5.dp)
+                    .width(if (i == activeIndex) 14.dp else 5.dp)
+                    .clip(RoundedCornerShape(3.dp))
+                    .background(
+                        if (i == activeIndex) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.outlineVariant
+                    )
+            )
+        }
+    }
+}
+
+// ── Step 1: Player Count ──────────────────────────────────────────────────────
+
+@Composable
+private fun PlayerCountStep(
+    playerCount: Int,
+    onCountSelected: (Int) -> Unit,
+    onBack: () -> Unit,
+    onContinue: () -> Unit,
+    onPositioned: (String, LayoutCoordinates) -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            StepPips(0)
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = theme.screenPadding)
+        ) {
+            Text("How many players?", style = theme.titleStyle.copy(fontSize = 22.sp))
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                "Sets the character limit per troupe",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .onGloballyPositioned { onPositioned("PlayerCount", it) },
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                    PlayerCountCard(
+                        count = 1, label = "Solo", limit = "up to 6 chars",
+                        selected = playerCount == 1, onClick = { onCountSelected(1) },
+                        modifier = Modifier.weight(1f)
+                    )
+                    PlayerCountCard(
+                        count = 2, label = "Duel", limit = "up to 6 chars",
+                        selected = playerCount == 2, onClick = { onCountSelected(2) },
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+                Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                    PlayerCountCard(
+                        count = 3, label = "Three-way", limit = "up to 4 chars",
+                        selected = playerCount == 3, onClick = { onCountSelected(3) },
+                        modifier = Modifier.weight(1f)
+                    )
+                    PlayerCountCard(
+                        count = 4, label = "Full Table", limit = "up to 3 chars",
+                        selected = playerCount == 4, onClick = { onCountSelected(4) },
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+            Button(
+                onClick = onContinue,
+                modifier = Modifier.fillMaxWidth().height(52.dp),
+                shape = theme.cardShape
+            ) {
+                Text("Continue", style = theme.buttonTextStyle)
+                Spacer(modifier = Modifier.width(8.dp))
+                Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = null, modifier = Modifier.size(18.dp))
+            }
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+        }
+    }
+}
+
+@Composable
+private fun PlayerCountCard(
+    count: Int,
+    label: String,
+    limit: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val theme = LocalAppThemeProperties.current
+    val borderColor = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant
+    Card(
+        onClick = onClick,
+        modifier = modifier.border(if (selected) 2.dp else 1.dp, borderColor, theme.cardShape),
+        shape = theme.cardShape,
+        colors = CardDefaults.cardColors(
+            containerColor = if (selected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.15f)
+                            else MaterialTheme.colorScheme.surfaceVariant
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = count.toString(),
+                style = theme.titleStyle.copy(fontSize = 32.sp),
+                color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+            )
+            PlayerCountShape(count = count, selected = selected)
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Surface(
+                shape = RoundedCornerShape(20.dp),
+                color = if (selected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.6f)
+                        else MaterialTheme.colorScheme.surfaceVariant
+            ) {
+                Text(
+                    text = limit,
+                    modifier = Modifier.padding(horizontal = 9.dp, vertical = 3.dp),
+                    style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+                    color = if (selected) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlayerCountShape(count: Int, selected: Boolean) {
+    val barColor = if (selected) MaterialTheme.colorScheme.primary.copy(alpha = 0.5f)
+                   else MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+    Box(modifier = Modifier.fillMaxWidth().height(36.dp), contentAlignment = Alignment.BottomCenter) {
+        when (count) {
+            4 -> Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(3.dp)
+            ) {
+                Row(
+                    modifier = Modifier.weight(1f).fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(3.dp)
+                ) {
+                    repeat(2) {
+                        Box(modifier = Modifier.weight(1f).fillMaxHeight().clip(RoundedCornerShape(3.dp)).background(barColor))
+                    }
+                }
+                Row(
+                    modifier = Modifier.weight(1f).fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(3.dp)
+                ) {
+                    repeat(2) {
+                        Box(modifier = Modifier.weight(1f).fillMaxHeight().clip(RoundedCornerShape(3.dp)).background(barColor))
+                    }
+                }
+            }
+            else -> {
+                val heights = when (count) {
+                    1 -> listOf(36f)
+                    2 -> listOf(36f, 36f)
+                    3 -> listOf(28f, 36f, 28f)
+                    else -> listOf(36f)
+                }
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.Bottom,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    heights.forEach { h ->
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(h.dp)
+                                .clip(RoundedCornerShape(topStart = 3.dp, topEnd = 3.dp))
+                                .background(barColor)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Step 2: Troupe Selection ──────────────────────────────────────────────────
+
+@Composable
+private fun TroupeSelectionStep(
+    state: CharacterState,
+    viewModel: CharacterViewModel,
+    playerCount: Int,
+    slots: SnapshotStateList<SlotData>,
+    onScanRequest: (Int) -> Unit,
+    onNavigateToAddEditTroupe: () -> Unit,
+    onBack: () -> Unit,
+    onContinue: () -> Unit,
+    onPositioned: (String, LayoutCoordinates) -> Unit,
+    onRequestSave: (Int, Troupe) -> Unit,
+    onShowQr: (Troupe) -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    val max = maxCharsForCount(playerCount)
+    val allConfirmed = (0 until playerCount).all { slotStatus(slots[it], max) == "confirmed" }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            StepPips(1)
+        }
+
+        LazyColumn(
+            modifier = Modifier.weight(1f).padding(horizontal = theme.screenPadding),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+            contentPadding = PaddingValues(bottom = theme.verticalSpacing)
+        ) {
+            item {
+                Text(
+                    text = "Each player needs a troupe  ·  $max char${if (max > 1) "s" else ""} max this game",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+            itemsIndexed(List(playerCount) { slots[it] }) { index, slot ->
+                val playerName = if (index == 0) state.name.ifEmpty { "Player 1" } else "Player ${index + 1}"
+                val showSave = slot.troupe != null &&
+                    state.troupes.none { it.shareCode == slot.troupe.shareCode && slot.troupe.shareCode.isNotEmpty() }
+                TroupeSlotCard(
+                    index = index,
+                    slot = slot,
+                    maxAllowed = max,
+                    characters = state.characters,
+                    troupes = state.troupes,
+                    playerName = playerName,
+                    showSave = showSave,
+                    onTroupeSelected = { t ->
+                        slots[index] = if (t.characterIds.size <= max)
+                            SlotData(troupe = t)
+                        else
+                            SlotData(troupe = t, pickerOpen = true)
+                    },
+                    onToggleChar = { charId ->
+                        val s = slots[index]
+                        val current = s.selectedCharIds.toMutableList()
+                        if (charId in current) {
+                            current.remove(charId)
+                            slots[index] = s.copy(selectedCharIds = current)
+                        } else if (current.size < max) {
+                            current.add(charId)
+                            val doneNow = current.size >= max
+                            slots[index] = s.copy(selectedCharIds = current, pickerOpen = !doneNow)
+                        }
+                    },
+                    onTogglePicker = { slots[index] = slots[index].copy(pickerOpen = !slots[index].pickerOpen) },
+                    onScanRequest = { onScanRequest(index) },
+                    onCreateNew = {
+                        viewModel.editingTroupeId = null
+                        viewModel.pendingTroupePlayerIndex = index
+                        onNavigateToAddEditTroupe()
+                    },
+                    onEditTroupe = { t ->
+                        viewModel.onEvent(CharacterEvent.EditTroupe(t))
+                        viewModel.pendingTroupePlayerIndex = index
+                        onNavigateToAddEditTroupe()
+                    },
+                    onShowQr = { t -> onShowQr(t) },
+                    onRequestSave = { t -> onRequestSave(index, t) },
+                    onPositioned = if (index == 0) onPositioned else { _, _ -> }
+                )
+            }
+        }
+
+        Column(modifier = Modifier.padding(horizontal = theme.screenPadding).padding(bottom = theme.verticalSpacing)) {
+            Button(
+                onClick = onContinue,
+                enabled = allConfirmed,
+                modifier = Modifier.fillMaxWidth().height(52.dp)
+                    .onGloballyPositioned { onPositioned("StartBattleButton", it) },
+                shape = theme.cardShape
+            ) {
+                Text("Review & Start", style = theme.buttonTextStyle)
+                Spacer(modifier = Modifier.width(8.dp))
+                Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = null, modifier = Modifier.size(18.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun TroupeSlotCard(
+    index: Int,
+    slot: SlotData,
+    maxAllowed: Int,
+    characters: List<Character>,
+    troupes: List<Troupe>,
+    playerName: String,
+    showSave: Boolean,
+    onTroupeSelected: (Troupe) -> Unit,
+    onToggleChar: (Int) -> Unit,
+    onTogglePicker: () -> Unit,
+    onScanRequest: () -> Unit,
+    onCreateNew: () -> Unit,
+    onEditTroupe: (Troupe) -> Unit,
+    onShowQr: (Troupe) -> Unit,
+    onRequestSave: (Troupe) -> Unit,
+    onPositioned: (String, LayoutCoordinates) -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    val status = slotStatus(slot, maxAllowed)
+    val factionColor = slot.troupe?.let { getFactionColor(it.faction) }
+    var showBrowseSheet by remember { mutableStateOf(false) }
+
+    // Pulsing amber border for trimming
+    val infiniteTransition = rememberInfiniteTransition(label = "slotBorder$index")
+    val amberAlpha by infiniteTransition.animateFloat(
+        initialValue = 0.55f, targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(1400, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "amberAlpha$index"
+    )
+
+    val borderColor = when (status) {
+        "confirmed" -> MaterialTheme.colorScheme.primary.copy(alpha = 0.55f)
+        "trimming" -> Color(0xFFF57C00).copy(alpha = amberAlpha)
+        else -> MaterialTheme.colorScheme.outlineVariant
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth().border(
+            width = if (status == "empty") 1.dp else 1.5.dp,
+            color = borderColor,
+            shape = theme.cardShape
+        ),
+        shape = theme.cardShape,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Column {
+            // ── Slot header ───────────────────────────────────────────────────
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp)
+            ) {
+                Text(
+                    text = "PLAYER ${index + 1}",
+                    style = MaterialTheme.typography.labelSmall.copy(
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = 1.5.sp
+                    ),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                if (factionColor != null && slot.troupe != null) {
+                    Box(
+                        modifier = Modifier.size(8.dp).clip(CircleShape).background(factionColor)
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(
+                        text = slot.troupe.troupeName,
+                        style = theme.headerStyle.copy(fontSize = 14.sp),
+                        modifier = Modifier.weight(1f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                } else {
+                    Text(
+                        text = "No troupe selected",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f),
+                        fontStyle = FontStyle.Italic,
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                // Save / QR actions on confirmed slots
+                if (slot.troupe != null) {
+                    if (showSave) {
+                        IconButton(
+                            onClick = { onRequestSave(slot.troupe) },
+                            modifier = Modifier.size(30.dp)
+                        ) {
+                            Icon(Icons.Default.Save, contentDescription = "Save", modifier = Modifier.size(16.dp))
+                        }
+                    }
+                    IconButton(
+                        onClick = { onShowQr(slot.troupe) },
+                        modifier = Modifier.size(30.dp)
+                    ) {
+                        Icon(Icons.Default.QrCode, contentDescription = "QR", modifier = Modifier.size(16.dp))
+                    }
+                }
+                // Status icon
+                when (status) {
+                    "confirmed" -> Icon(
+                        Icons.Default.CheckCircle, contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                    "trimming" -> Text("⚠", style = MaterialTheme.typography.bodyMedium.copy(fontSize = 16.sp))
+                    else -> Icon(
+                        Icons.Default.RadioButtonUnchecked, contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.35f)
+                    )
+                }
+            }
+
+            // ── Slot body ─────────────────────────────────────────────────────
+            when (status) {
+                "empty" -> SlotEmptyBody(
+                    onBrowse = { showBrowseSheet = true },
+                    onScanRequest = onScanRequest,
+                    onPositioned = onPositioned
+                )
+                "trimming" -> SlotTrimmingBody(
+                    slot = slot,
+                    maxAllowed = maxAllowed,
+                    characters = characters,
+                    onTogglePicker = onTogglePicker,
+                    onToggleChar = onToggleChar
+                )
+                "confirmed" -> SlotConfirmedBody(
+                    slot = slot,
+                    maxAllowed = maxAllowed,
+                    characters = characters,
+                    onTogglePicker = onTogglePicker,
+                    onToggleChar = onToggleChar
+                )
+            }
+        }
+    }
+
+    if (showBrowseSheet) {
+        TroupeBrowseSheet(
+            troupes = troupes,
+            characters = characters,
+            onTroupeSelected = { t ->
+                onTroupeSelected(t)
+                showBrowseSheet = false
+            },
+            onCreateNew = {
+                onCreateNew()
+                showBrowseSheet = false
+            },
+            onDismiss = { showBrowseSheet = false }
+        )
+    }
+}
+
+@Composable
+private fun SlotEmptyBody(
+    onBrowse: () -> Unit,
+    onScanRequest: () -> Unit,
+    onPositioned: (String, LayoutCoordinates) -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    Row(
+        modifier = Modifier
+            .padding(start = 14.dp, end = 14.dp, bottom = 12.dp)
+            .onGloballyPositioned { onPositioned("TroupeSelector", it) },
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Button(
+            onClick = onBrowse,
+            modifier = Modifier.weight(1f),
+            shape = theme.cardShape,
+            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 10.dp)
+        ) {
+            Icon(Icons.Default.ListAlt, contentDescription = null, modifier = Modifier.size(16.dp))
+            Spacer(modifier = Modifier.width(6.dp))
+            Text("Browse", style = theme.buttonTextStyle.copy(fontSize = 13.sp))
+        }
+        OutlinedButton(
+            onClick = onScanRequest,
+            modifier = Modifier.weight(1f),
+            shape = theme.cardShape,
+            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 10.dp)
+        ) {
+            Icon(Icons.Default.QrCodeScanner, contentDescription = null, modifier = Modifier.size(16.dp))
+            Spacer(modifier = Modifier.width(6.dp))
+            Text("Scan QR", style = theme.buttonTextStyle.copy(fontSize = 13.sp))
+        }
+    }
+}
+
+@Composable
+private fun SlotTrimmingBody(
+    slot: SlotData,
+    maxAllowed: Int,
+    characters: List<Character>,
+    onTogglePicker: () -> Unit,
+    onToggleChar: (Int) -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    val totalChars = slot.troupe?.characterIds?.size ?: 0
+    val amber = Color(0xFFF57C00)
+
+    Column(modifier = Modifier.padding(horizontal = 14.dp).padding(bottom = 12.dp)) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(theme.cardShape)
+                .background(amber.copy(alpha = 0.1f))
+                .border(1.dp, amber.copy(alpha = 0.35f), theme.cardShape)
+                .clickable { onTogglePicker() }
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text("⚠", style = MaterialTheme.typography.bodySmall)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "Select $maxAllowed of $totalChars characters",
+                style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.SemiBold),
+                color = Color(0xFFFFA040),
+                modifier = Modifier.weight(1f)
+            )
+            Icon(
+                imageVector = if (slot.pickerOpen) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+                tint = Color(0xFFFFA040)
+            )
+        }
+
+        AnimatedVisibility(visible = slot.pickerOpen) {
+            CharacterPickerRow(
+                troupe = slot.troupe!!,
+                selectedCharIds = slot.selectedCharIds,
+                maxAllowed = maxAllowed,
+                characters = characters,
+                onToggleChar = onToggleChar
+            )
+        }
+    }
+}
+
+@Composable
+private fun SlotConfirmedBody(
+    slot: SlotData,
+    maxAllowed: Int,
+    characters: List<Character>,
+    onTogglePicker: () -> Unit,
+    onToggleChar: (Int) -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    val wasTrimmed = (slot.troupe?.characterIds?.size ?: 0) > maxAllowed
+    val charIds = finalCharIds(slot, maxAllowed)
+    val charNames = charIds.mapNotNull { id -> characters.find { it.id == id }?.name }
+
+    Column(modifier = Modifier.padding(horizontal = 14.dp).padding(bottom = 12.dp)) {
+        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = charNames.joinToString(" · "),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.weight(1f),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Surface(
+                shape = RoundedCornerShape(20.dp),
+                color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.6f)
+            ) {
+                Text(
+                    text = "✓ ${charIds.size}/$maxAllowed",
+                    modifier = Modifier.padding(horizontal = 9.dp, vertical = 3.dp),
+                    style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+            if (wasTrimmed) {
+                Spacer(modifier = Modifier.width(6.dp))
+                Surface(
+                    shape = RoundedCornerShape(20.dp),
+                    color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f),
+                    modifier = Modifier.clickable { onTogglePicker() }
+                ) {
+                    Text(
+                        text = "✎ Edit",
+                        modifier = Modifier.padding(horizontal = 9.dp, vertical = 3.dp),
+                        style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+                        color = MaterialTheme.colorScheme.onSecondaryContainer
+                    )
+                }
+            }
+        }
+
+        // Re-opened character picker (edit mode for already-trimmed slots)
+        if (wasTrimmed && slot.pickerOpen) {
+            CharacterPickerRow(
+                troupe = slot.troupe!!,
+                selectedCharIds = slot.selectedCharIds,
+                maxAllowed = maxAllowed,
+                characters = characters,
+                onToggleChar = onToggleChar
+            )
+        }
+    }
+}
+
+// ── Character picker row ──────────────────────────────────────────────────────
+
+@Composable
+private fun CharacterPickerRow(
+    troupe: Troupe,
+    selectedCharIds: List<Int>,
+    maxAllowed: Int,
+    characters: List<Character>,
+    onToggleChar: (Int) -> Unit
+) {
+    val troupeChars = remember(troupe, characters) {
+        troupe.characterIds.mapNotNull { id -> characters.find { it.id == id } }
+    }
+    val done = selectedCharIds.size >= maxAllowed
+
+    Column(modifier = Modifier.padding(top = 10.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                "Tap to select",
+                style = MaterialTheme.typography.labelSmall.copy(
+                    letterSpacing = 1.2.sp, fontWeight = FontWeight.Bold
+                ),
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                "${selectedCharIds.size}/$maxAllowed",
+                style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+                color = if (done) MaterialTheme.colorScheme.primary else Color(0xFFF57C00)
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            contentPadding = PaddingValues(end = 4.dp)
+        ) {
+            items(troupeChars) { char ->
+                val isOn = char.id in selectedCharIds
+                val isOff = !isOn && selectedCharIds.size >= maxAllowed
+                CharacterBubble(
+                    character = char,
+                    isOn = isOn,
+                    isOff = isOff,
+                    onClick = { if (!isOff) onToggleChar(char.id) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CharacterBubble(
+    character: Character,
+    isOn: Boolean,
+    isOff: Boolean,
+    onClick: () -> Unit
+) {
+    val initials = remember(character.name) {
+        character.name.split(" ").mapNotNull { it.firstOrNull()?.uppercaseChar() }.take(2).joinToString("")
+    }
+    Column(
+        modifier = Modifier.clickable(enabled = !isOff, onClick = onClick),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(44.dp)
+                .clip(CircleShape)
+                .background(
+                    when {
+                        isOn -> MaterialTheme.colorScheme.primaryContainer
+                        isOff -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+                        else -> MaterialTheme.colorScheme.surfaceVariant
+                    }
+                )
+                .border(
+                    width = 2.dp,
+                    color = when {
+                        isOn -> MaterialTheme.colorScheme.primary
+                        isOff -> MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+                        else -> MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                    },
+                    shape = CircleShape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            CharacterPortrait(
+                character = character,
+                size = 44.dp,
+                shape = CircleShape
+            )
+        }
+        Text(
+            text = character.name.split(" ").first(),
+            style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+            color = if (isOff) MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            modifier = Modifier.widthIn(max = 44.dp),
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+// ── Step 3: Ready ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun ReadyStep(
+    state: CharacterState,
+    playerCount: Int,
+    slots: SnapshotStateList<SlotData>,
+    onBack: () -> Unit,
+    onStartGame: () -> Unit,
+    onPositioned: (String, LayoutCoordinates) -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    val max = maxCharsForCount(playerCount)
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            StepPips(2)
+        }
+
+        LazyColumn(
+            modifier = Modifier.weight(1f).padding(horizontal = theme.screenPadding),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(bottom = theme.verticalSpacing)
+        ) {
+            item {
+                Text(
+                    "All Set!",
+                    style = theme.titleStyle.copy(fontSize = 22.sp),
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    "Review your lineup before kickoff",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+            itemsIndexed(List(playerCount) { slots[it] }) { index, slot ->
+                if (slot.troupe != null) {
+                    val playerName = if (index == 0) state.name.ifEmpty { "Player 1" } else "Player ${index + 1}"
+                    val charIds = finalCharIds(slot, max)
+                    val charNames = charIds.mapNotNull { id -> state.characters.find { it.id == id }?.name }
+                    val factionColor = getFactionColor(slot.troupe.faction)
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = theme.cardShape,
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant
+                        )
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .border(
+                                    width = 3.dp,
+                                    color = factionColor.copy(alpha = 0.6f),
+                                    shape = theme.cardShape
+                                )
+                                .padding(14.dp, 12.dp)
+                        ) {
+                            Text(
+                                text = playerName.uppercase(),
+                                style = MaterialTheme.typography.labelSmall.copy(
+                                    fontWeight = FontWeight.Bold,
+                                    letterSpacing = 1.8.sp
+                                ),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                            )
+                            Spacer(modifier = Modifier.height(3.dp))
+                            Text(
+                                text = slot.troupe.troupeName,
+                                style = theme.titleStyle.copy(fontSize = 16.sp),
+                                color = factionColor
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = charNames.joinToString("  ·  "),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                lineHeight = 18.sp
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        Column(modifier = Modifier.padding(horizontal = theme.screenPadding).padding(bottom = theme.verticalSpacing)) {
+            Button(
+                onClick = onStartGame,
+                modifier = Modifier.fillMaxWidth().height(56.dp)
+                    .onGloballyPositioned { onPositioned("StartBattleButton", it) },
+                shape = theme.cardShape,
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+            ) {
+                Text("⚔  Start Game", style = theme.buttonTextStyle.copy(fontSize = 15.sp))
+            }
+        }
+    }
+}
+
+// ── Troupe browse bottom sheet ────────────────────────────────────────────────
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TroupeBrowseSheet(
+    troupes: List<Troupe>,
+    characters: List<Character>,
+    onTroupeSelected: (Troupe) -> Unit,
+    onCreateNew: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface
+    ) {
+        val theme = LocalAppThemeProperties.current
+        Text(
+            "Choose a Troupe",
+            style = theme.titleStyle.copy(fontSize = 18.sp),
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Create new option
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { onCreateNew() }
+                .padding(horizontal = 20.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(36.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primaryContainer),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(20.dp), tint = MaterialTheme.colorScheme.onPrimaryContainer)
+            }
+            Spacer(modifier = Modifier.width(14.dp))
+            Text(
+                "Create New Troupe",
+                style = theme.headerStyle.copy(fontSize = 14.sp),
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+
+        if (troupes.isNotEmpty()) {
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+            LazyColumn(contentPadding = PaddingValues(bottom = 32.dp)) {
+                items(troupes) { troupe ->
+                    TroupeSheetRow(troupe = troupe, characters = characters, onClick = { onTroupeSelected(troupe) })
+                }
+            }
+        } else {
+            Box(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 32.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    "No saved troupes yet",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TroupeSheetRow(
+    troupe: Troupe,
+    characters: List<Character>,
+    onClick: () -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    val factionColor = getFactionColor(troupe.faction)
+    val troupeChars = remember(troupe.characterIds, characters) {
+        troupe.characterIds.mapNotNull { id -> characters.find { it.id == id } }
+    }
+    val factionLabel = troupe.faction.name.lowercase().replaceFirstChar { it.uppercase() }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Faction colour bar
+        Box(
+            modifier = Modifier
+                .width(4.dp)
+                .height(if (troupeChars.isEmpty()) 36.dp else 56.dp)
+                .clip(RoundedCornerShape(2.dp))
+                .background(factionColor)
+        )
+        Spacer(modifier = Modifier.width(14.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = troupe.troupeName,
+                style = theme.headerStyle.copy(fontSize = 15.sp),
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = "$factionLabel · ${troupe.characterIds.size} characters",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            if (troupeChars.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(6.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy((-6).dp)) {
+                    troupeChars.forEach { char ->
+                        Box(
+                            modifier = Modifier
+                                .size(28.dp)
+                                .clip(CircleShape)
+                                .border(1.5.dp, MaterialTheme.colorScheme.surface, CircleShape)
+                        ) {
+                            CharacterPortrait(character = char, size = 28.dp, shape = CircleShape)
+                        }
+                    }
+                }
+            }
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        Text("›", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
     }
 }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/SettingsScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/SettingsScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.platform.LocalContext
 import io.github.garemat.lunachron.CharacterEvent
 import io.github.garemat.lunachron.ui.theme.ThemeRepository
 import io.github.garemat.lunachron.CharacterState
-import io.github.garemat.lunachron.GameLayoutMode
 import io.github.garemat.lunachron.GameTrackingMode
 import io.github.garemat.lunachron.ImageDownloadPreference
 import io.github.garemat.lunachron.InstallerSource
@@ -122,47 +121,6 @@ fun SettingsScreen(
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
             Spacer(modifier = Modifier.height(theme.verticalSpacing))
 
-            Text("Gameplay", style = theme.titleStyle.copy(fontSize = 20.sp), color = MaterialTheme.colorScheme.primary)
-            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onEvent(CharacterEvent.SetLocalModeDefault(!state.useLocalModeByDefault)) }
-                    .padding(vertical = theme.verticalSpacing / 4),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text("Skip Game Mode Selection", style = theme.headerStyle.copy(fontSize = 18.sp))
-                    Text("Always jump straight to Local Game setup.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                }
-                Switch(checked = state.useLocalModeByDefault, onCheckedChange = { onEvent(CharacterEvent.SetLocalModeDefault(it)) })
-            }
-
-            if (state.useLocalModeByDefault) {
-                Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable { onEvent(CharacterEvent.SetSinglePlayerMode(!state.useSinglePlayerMode)) }
-                        .padding(vertical = theme.verticalSpacing / 4)
-                        .padding(start = 16.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text("Only track 1 player", style = theme.headerStyle.copy(fontSize = 18.sp))
-                        Text("Skip setup and pick a troupe directly for a solo session.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                    }
-                    Switch(checked = state.useSinglePlayerMode, onCheckedChange = { onEvent(CharacterEvent.SetSinglePlayerMode(it)) })
-                }
-            }
-
-            Spacer(modifier = Modifier.height(theme.verticalSpacing))
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-            Spacer(modifier = Modifier.height(theme.verticalSpacing))
-
             Text("Game View", style = theme.titleStyle.copy(fontSize = 20.sp), color = MaterialTheme.colorScheme.primary)
             Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
 
@@ -187,30 +145,6 @@ fun SettingsScreen(
                     onCheckedChange = { enabled ->
                         onEvent(CharacterEvent.ChangeGameTrackingMode(if (enabled) GameTrackingMode.FULL_TRACKING else GameTrackingMode.LOW_DETAIL))
                     }
-                )
-            }
-
-            Spacer(modifier = Modifier.height(theme.verticalSpacing))
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-            Spacer(modifier = Modifier.height(theme.verticalSpacing))
-
-            Text("Game Layout", style = theme.titleStyle.copy(fontSize = 20.sp), color = MaterialTheme.colorScheme.primary)
-            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
-
-            Column {
-                SelectionOption(
-                    title = "Low Detail",
-                    selected = state.gameLayoutMode == GameLayoutMode.COMPACT_GRID,
-                    onSelect = { onEvent(CharacterEvent.ChangeGameLayoutMode(GameLayoutMode.COMPACT_GRID)) },
-                    theme = theme,
-                    subtitle = "2-column grid, quick overview of all characters"
-                )
-                SelectionOption(
-                    title = "Detailed",
-                    selected = state.gameLayoutMode == GameLayoutMode.DETAILED_LIST,
-                    onSelect = { onEvent(CharacterEvent.ChangeGameLayoutMode(GameLayoutMode.DETAILED_LIST)) },
-                    theme = theme,
-                    subtitle = "Single column, expandable cards with full stats"
                 )
             }
 

--- a/app/src/main/java/io/github/garemat/lunachron/ui/SetupCommonUI.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/SetupCommonUI.kt
@@ -1,156 +1,193 @@
 package io.github.garemat.lunachron.ui
 
-import androidx.compose.animation.*
-import androidx.compose.foundation.Image
+import android.widget.Toast
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.garemat.lunachron.HostMode
-import io.github.garemat.lunachron.R
 import io.github.garemat.lunachron.ui.theme.LocalAppThemeProperties
 
 @Composable
-fun SetupModeSelection(
+fun GameModeHeroUI(
     onLocalSelected: () -> Unit,
     onHostSelected: () -> Unit,
     onJoinSelected: () -> Unit,
     onJoinTournamentSelected: () -> Unit,
     onTargetPositioned: (String, LayoutCoordinates) -> Unit = { _, _ -> }
 ) {
-    val isMoonstone = LocalAppThemeProperties.current.showExpandedStatsHeader
-    
-    Column(
-        modifier = Modifier.fillMaxSize().padding(16.dp),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(
-            text = "Choose Game Mode",
-            style = if (isMoonstone) MaterialTheme.typography.displayLarge.copy(fontSize = 32.sp) else MaterialTheme.typography.headlineMedium,
-            fontWeight = FontWeight.Bold,
-            color = if (isMoonstone) MaterialTheme.colorScheme.primary else Color.Unspecified
-        )
-        
-        Spacer(modifier = Modifier.height(24.dp))
-        
-        SetupOptionCard(
-            title = "Local Game",
-            description = "Play on a single device with 2-4 players.",
-            icon = Icons.Default.Smartphone,
-            backgroundType = "commonwealth",
-            onClick = onLocalSelected,
-            modifier = Modifier.onGloballyPositioned { onTargetPositioned("LocalGameOption", it) }
-        )
-        
-        Spacer(modifier = Modifier.height(12.dp))
-        
-        SetupOptionCard(
-            title = "Host Game",
-            description = "Start a multiplayer session for others to join.",
-            icon = Icons.Default.WifiTethering,
-            backgroundType = "dominion",
-            onClick = onHostSelected
-        )
-        
-        Spacer(modifier = Modifier.height(12.dp))
-        
-        SetupOptionCard(
-            title = "Join Game",
-            description = "Connect to an existing multiplayer session nearby.",
-            icon = Icons.Default.Wifi,
-            backgroundType = "leshavult",
-            onClick = onJoinSelected
-        )
+    val theme = LocalAppThemeProperties.current
+    val context = LocalContext.current
 
-        Spacer(modifier = Modifier.height(12.dp))
-        
-        SetupOptionCard(
-            title = "Join Local Tournament",
-            description = "Connect to a tournament session nearby.",
-            icon = Icons.Default.EmojiEvents,
-            backgroundType = "shades",
-            onClick = onJoinTournamentSelected
+    // Cycling faction colour tint for hero card background
+    val infiniteTransition = rememberInfiniteTransition(label = "heroFaction")
+    val phase by infiniteTransition.animateFloat(
+        initialValue = 0f, targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(14000, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "heroPhase"
+    )
+    val factionTints = remember {
+        listOf(
+            Color(0xFFC0392B), // Dominion
+            Color(0xFF4A90D9), // Commonwealth
+            Color(0xFF27AE60), // Leshavult
+            Color(0xFF8E44AD), // Shades
         )
+    }
+    val tintIndex = ((phase * 4f).toInt()).coerceIn(0, 3)
+    val nextTintIndex = (tintIndex + 1) % 4
+    val tintFraction = (phase * 4f) - tintIndex.toFloat()
+    val heroTint = lerp(factionTints[tintIndex], factionTints[nextTintIndex], tintFraction)
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Text(
+            "Choose Mode",
+            style = MaterialTheme.typography.labelSmall.copy(
+                letterSpacing = 3.sp, fontWeight = FontWeight.Bold
+            ),
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f),
+            modifier = Modifier.padding(horizontal = 2.dp, vertical = 4.dp)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // ── Hero card — Local Game ───────────────────────────────────────────
+        Card(
+            onClick = onLocalSelected,
+            modifier = Modifier.fillMaxWidth()
+                .onGloballyPositioned { onTargetPositioned("LocalGameOption", it) },
+            shape = theme.cardShape,
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        ) {
+            Box(
+                modifier = Modifier.fillMaxWidth().background(
+                    Brush.linearGradient(
+                        colors = listOf(
+                            heroTint.copy(alpha = 0.10f),
+                            heroTint.copy(alpha = 0.20f)
+                        ),
+                        start = Offset(0f, 0f),
+                        end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
+                    )
+                )
+            ) {
+                Column(modifier = Modifier.padding(start = 22.dp, top = 24.dp, end = 22.dp, bottom = 20.dp)) {
+                    Text("⚔️", style = MaterialTheme.typography.headlineLarge)
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Text("Local Game", style = theme.titleStyle.copy(fontSize = 26.sp))
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        "Play at the table with friends",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(18.dp))
+                    Surface(
+                        shape = RoundedCornerShape(20.dp),
+                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.20f),
+                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.45f))
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 7.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            Text(
+                                "Begin Setup",
+                                style = MaterialTheme.typography.labelSmall.copy(
+                                    fontWeight = FontWeight.Bold,
+                                    letterSpacing = 1.sp
+                                ),
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                            Icon(
+                                Icons.AutoMirrored.Filled.ArrowForward,
+                                contentDescription = null,
+                                modifier = Modifier.size(12.dp),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            "Other Modes",
+            style = MaterialTheme.typography.labelSmall.copy(
+                letterSpacing = 2.5.sp, fontWeight = FontWeight.Bold
+            ),
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f),
+            modifier = Modifier.padding(horizontal = 2.dp, vertical = 4.dp)
+        )
+        Spacer(modifier = Modifier.height(6.dp))
+
+        // ── Secondary modes ─────────────────────────────────────────────────
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = theme.cardShape,
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+        ) {
+            Column {
+                SecondaryModeRow("📡", "Host Game", "Invite players over Wi-Fi") {
+                    Toast.makeText(context, "These features are getting improved in an upcoming update", Toast.LENGTH_SHORT).show()
+                }
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                SecondaryModeRow("🔗", "Join Game", "Connect to a hosted session") {
+                    Toast.makeText(context, "These features are getting improved in an upcoming update", Toast.LENGTH_SHORT).show()
+                }
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                SecondaryModeRow("🏆", "Local Tournament", "Round-robin bracket play") {
+                    Toast.makeText(context, "These features are getting improved in an upcoming update", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
     }
 }
 
 @Composable
-fun SetupOptionCard(
-    title: String,
-    description: String,
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
-    backgroundType: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val isMoonstone = LocalAppThemeProperties.current.showExpandedStatsHeader
-    val backgroundRes = when (backgroundType) {
-        "commonwealth" -> R.drawable.commonwealth
-        "dominion" -> R.drawable.dominion
-        "leshavult" -> R.drawable.leshavult
-        "shades" -> R.drawable.shades
-        else -> 0
-    }
-    
-    Card(
-        onClick = onClick,
-        modifier = modifier.fillMaxWidth().height(80.dp),
-        shape = RoundedCornerShape(if (isMoonstone) 0.dp else 12.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = if (isMoonstone) MaterialTheme.colorScheme.surfaceVariant else MaterialTheme.colorScheme.surface
-        ),
-        elevation = CardDefaults.cardElevation(defaultElevation = if (isMoonstone) 2.dp else 4.dp)
+private fun SecondaryModeRow(icon: String, title: String, description: String, onClick: () -> Unit) {
+    val theme = LocalAppThemeProperties.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .alpha(0.5f)
+            .clickable { onClick() }
+            .padding(horizontal = 16.dp, vertical = 13.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Box(modifier = Modifier.fillMaxSize()) {
-            if (isMoonstone && backgroundRes != 0) {
-                Image(
-                    painter = painterResource(id = backgroundRes),
-                    contentDescription = null,
-                    modifier = Modifier.matchParentSize().alpha(0.1f),
-                    contentScale = ContentScale.Crop
-                )
-            }
-            Row(
-                modifier = Modifier.fillMaxSize().padding(12.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null,
-                    modifier = Modifier.size(32.dp),
-                    tint = MaterialTheme.colorScheme.primary
-                )
-                Spacer(modifier = Modifier.width(16.dp))
-                Column {
-                    Text(
-                        text = title, 
-                        style = if (isMoonstone) MaterialTheme.typography.displayLarge.copy(fontSize = 20.sp) else MaterialTheme.typography.titleLarge, 
-                        fontWeight = FontWeight.Bold,
-                        color = if (isMoonstone) MaterialTheme.colorScheme.primary else androidx.compose.ui.graphics.Color.Unspecified
-                    )
-                    Text(
-                        text = description, 
-                        style = MaterialTheme.typography.bodySmall, 
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
+        Text(icon, style = MaterialTheme.typography.bodyLarge, modifier = Modifier.width(26.dp))
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(title, style = theme.headerStyle.copy(fontSize = 13.sp))
+            Text(description, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
+        Text("›", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
     }
 }
 

--- a/app/src/main/java/io/github/garemat/lunachron/ui/TroupeListScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/TroupeListScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.outlined.StarOutline
+import androidx.compose.ui.graphics.Color
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -100,6 +102,9 @@ fun TroupeListScreen(
                                 shareTroupe(context, troupe.troupeName, code)
                             },
                             onEdit = { viewModel.onEvent(CharacterEvent.EditTroupe(troupe)); onEditTroupe() },
+                            onToggleFavourite = if (!selectionMode && troupe.id != -1) {
+                                { viewModel.onEvent(CharacterEvent.ToggleTroupeFavourite(troupe.id)) }
+                            } else null,
                             isDimmed = selectionMode && !isValid,
                             selectionMode = selectionMode,
                             characters = troupeCharacters,
@@ -133,6 +138,7 @@ fun TroupeListItem(
     onQr: () -> Unit = {},
     onShare: () -> Unit,
     onEdit: () -> Unit,
+    onToggleFavourite: (() -> Unit)? = null,
     isDimmed: Boolean = false,
     selectionMode: Boolean = false,
     showDelete: Boolean = true,
@@ -172,6 +178,16 @@ fun TroupeListItem(
                         style = MaterialTheme.typography.bodySmall.copy(lineHeight = 16.sp),
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
+                }
+                if (onToggleFavourite != null) {
+                    IconButton(onClick = onToggleFavourite, modifier = Modifier.size(36.dp)) {
+                        Icon(
+                            imageVector = if (troupe.isFavourite) Icons.Default.Star else Icons.Outlined.StarOutline,
+                            contentDescription = if (troupe.isFavourite) "Unfavourite" else "Favourite",
+                            modifier = Modifier.size(20.dp),
+                            tint = if (troupe.isFavourite) Color(0xFFFFC107) else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                        )
+                    }
                 }
                 if (selectionMode) {
                     IconButton(onClick = onEdit, modifier = Modifier.size(36.dp)) { Icon(Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(20.dp)) }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/theme/ThemeDefinition.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/theme/ThemeDefinition.kt
@@ -146,10 +146,9 @@ data class GameColorDefinition(
     val catastrophe: String? = null,
 )
 
-/** Preferred game layout and tracking modes applied when the user switches to this theme. */
+/** Preferred game tracking mode applied when the user switches to this theme. */
 @Serializable
 data class GameplayPreferencesDefinition(
-    val defaultLayoutMode: String? = null,   // "COMPACT_GRID" | "DETAILED_LIST"
     val defaultTrackingMode: String? = null, // "LOW_DETAIL" | "FULL_TRACKING"
 )
 

--- a/app/src/main/java/io/github/garemat/lunachron/ui/theme/ThemeRepository.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/theme/ThemeRepository.kt
@@ -323,7 +323,6 @@ private fun CharacterCardDefinition?.mergeOver(base: CharacterCardDefinition?) =
 
 private fun GameplayPreferencesDefinition?.mergeOver(base: GameplayPreferencesDefinition?) =
     GameplayPreferencesDefinition(
-        defaultLayoutMode   = this?.defaultLayoutMode   ?: base?.defaultLayoutMode,
         defaultTrackingMode = this?.defaultTrackingMode ?: base?.defaultTrackingMode,
     )
 


### PR DESCRIPTION
## Description
- New 3-step local game setup (Player Count → Troupe Selection → Ready): bottom-sheet troupe browser with character portrait circles, inline character trimming when a troupe is over the game-size limit
- Favourite troupes: star button on troupe cards; UserDatabase migrated to v3 with isFavourite column (MIGRATION_2_3)
- Quick Start bar on Home screen for favourite troupes; auto-hides on scroll and reappears at top
- GameModeHeroUI: "Local Game" hero card with animated faction-colour gradient; multiplayer/tournament modes show upcoming-update notice
- Removed "Skip Game Mode Selection" and "Only track 1 player" settings
- Fixed ToggleTroupeFavourite lookup to use state.value.troupes (not _state.value.troupes which is always empty)
- Fixed GameSetupScreen top padding via contentWindowInsets = WindowInsets(0)
- Updated CLAUDE.md and CHANGELOG.md


## Type of Change
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Chore (Non functional changes, documentation, etc.)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)
