### PR TITLE
feat: LunaChron online campaign API integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,7 +40,12 @@ android {
     }
 
     buildTypes {
+        debug {
+            // Emulator loopback — change to LAN IP for testing on a physical device.
+            buildConfigField("String", "LUNACHRON_API_URL", "\"http://10.0.2.2:3000\"")
+        }
         release {
+            buildConfigField("String", "LUNACHRON_API_URL", "\"https://api.garemat.co.uk\"")
             isMinifyEnabled = false
             isCrunchPngs = false
             // Only apply signingConfig if it exists and storeFile is set.
@@ -65,6 +70,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     kotlin {
         compilerOptions {

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Debug manifest overlay — merged on top of src/main/AndroidManifest.xml.
+    Applies the debug network security config that permits plain HTTP to 10.0.2.2.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:networkSecurityConfig="@xml/network_security_config"
+        tools:replace="android:networkSecurityConfig" />
+
+</manifest>

--- a/app/src/debug/res/xml/network_security_config.xml
+++ b/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Debug-only network security config.
+    Allows plain HTTP to the local dev server (emulator host alias 10.0.2.2).
+    This file is only included in debug builds — release builds use Android's
+    default policy (HTTPS only).
+-->
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <!-- Android emulator: host machine is reachable at 10.0.2.2 -->
+        <domain includeSubdomains="false">10.0.2.2</domain>
+        <!-- Physical device on the same LAN: add your PC's IP here if needed -->
+    </domain-config>
+</network-security-config>

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
@@ -87,4 +87,75 @@ sealed interface CharacterEvent {
     // Tournament Events
     data class CreateTournament(val tournamentName: String, val troupeSize: TroupeSizeSetting, val timer: Int, val hostParticipating: Boolean, val passcode: String, val hostMode: HostMode = HostMode.WIFI_NSD) : CharacterEvent
     data class JoinTournament(val sessionId: String) : CharacterEvent
+
+    // LunaChron API — device registration
+    data class RegisterDevice(val username: String) : CharacterEvent
+    data object DismissRegistrationError : CharacterEvent
+
+    // LunaChron API — online campaigns
+    data object LoadOnlineCampaigns : CharacterEvent
+    data class CreateOnlineCampaign(
+        val name: String,
+        val description: String?,
+        val settings: OnlineCampaignSettings
+    ) : CharacterEvent
+    data class RequestJoinCampaign(val joinCode: String) : CharacterEvent
+    data object DismissOnlineCampaignError : CharacterEvent
+    data object DismissCreatedCampaignResult : CharacterEvent
+
+    // LunaChron API — campaign detail & member management
+    data class LoadOnlineCampaign(val campaignId: String) : CharacterEvent
+    data class ApproveMember(val campaignId: String, val memberId: String) : CharacterEvent
+    data class RejectMember(val campaignId: String, val memberId: String) : CharacterEvent
+    data object ClearSelectedOnlineCampaign : CharacterEvent
+
+    // LunaChron API — campaign lock / schedule
+    data class LockOnlineCampaign(val campaignId: String) : CharacterEvent
+    data class UnlockOnlineCampaign(val campaignId: String) : CharacterEvent
+    data class SetOnlineScheduleRoundCount(val count: Int) : CharacterEvent
+    data class GenerateOnlineSchedule(val campaignId: String, val totalRounds: Int) : CharacterEvent
+    data class PublishOnlineSchedule(val campaignId: String) : CharacterEvent
+
+    // LunaChron API — troupe sharing + ready
+    data class UploadOnlineTroupe(val campaignId: String, val troupeData: String) : CharacterEvent
+    data class SetOnlineCampaignReady(val campaignId: String, val isReady: Boolean) : CharacterEvent
+
+    // LunaChron API — local player management (host only)
+    data class AddLocalCampaignMember(val campaignId: String, val name: String) : CharacterEvent
+    data class UploadLocalMemberTroupe(val campaignId: String, val targetDeviceId: String, val troupeData: String) : CharacterEvent
+    data class SetLocalMemberReady(val campaignId: String, val targetDeviceId: String, val isReady: Boolean) : CharacterEvent
+
+    // LunaChron API — rankings + round advancement
+    data class UpdateOnlineRankings(val campaignId: String) : CharacterEvent
+    data class AdvanceOnlineRound(val campaignId: String) : CharacterEvent
+
+    // LunaChron API — match result recording
+    data class SubmitOnlineMatchResult(
+        val campaignId: String,
+        val roundNumber: Int,
+        val gameNumber: Int,
+        val playerStats: List<OnlinePlayerStat>,
+        val winnerId: String?       // device ID of winner, null for draw
+    ) : CharacterEvent
+    data object DismissMatchResultSubmitted : CharacterEvent
+
+    // LunaChron API — campaign deletion (host only)
+    data class DeleteOnlineCampaign(val campaignId: String) : CharacterEvent
+    data object DismissCampaignDeleted : CharacterEvent
+
+    // LunaChron API — match result verification (opponent approves or contests)
+    data class VerifyMatchResult(val campaignId: String, val resultId: String, val agree: Boolean) : CharacterEvent
+
+    // LunaChron API — machinations phase
+    data class SubmitMachination(
+        val campaignId: String,
+        val machinations: List<OnlineMachinationChoice>,
+        val attack: OnlineMachinationAttack? = null
+    ) : CharacterEvent
+    data class SubmitLocalMachination(
+        val campaignId: String,
+        val targetDeviceId: String,
+        val machinations: List<OnlineMachinationChoice>,
+        val attack: OnlineMachinationAttack? = null
+    ) : CharacterEvent
 }

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
@@ -108,6 +108,130 @@ data class TournamentRound(
     val status: TournamentRoundStatus = TournamentRoundStatus.SELECTION
 )
 
+// ── Online campaign models ────────────────────────────────────────────────────
+
+@Serializable
+data class OnlineCampaignSettings(
+    val attacksEnabled: Boolean = true,
+    val startingCharacters: Int = 4,
+    /** A new character is earned every this many rounds (0 = never). */
+    val characterGrowthEvery: Int = 2,
+    /** A new upgrade card is earned every this many rounds (0 = never). */
+    val upgradeGrowthEvery: Int = 1
+)
+
+@Serializable
+data class OnlineCampaignSummary(
+    val id: String,
+    val name: String,
+    val description: String? = null,
+    val status: String,                        // "OPEN", "LOCKED", "DISBANDED"
+    val joinCode: String? = null,              // only for host of an OPEN campaign
+    val isHost: Boolean,
+    val memberCount: Int,
+    val membershipStatus: String = "APPROVED", // "APPROVED" or "PENDING"
+    val settings: OnlineCampaignSettings? = null
+)
+
+@Serializable
+data class OnlineCampaignMember(
+    val id: String,                         // campaign_members.id — used for approve/reject
+    val deviceId: String,
+    val username: String,
+    val role: String,                       // "HOST" or "MEMBER"
+    val status: String,                     // "PENDING", "APPROVED", "REJECTED"
+    val troupeData: String? = null,
+    val troupeUpdatedAt: String? = null,
+    val isReady: Boolean = false,
+    val isLocal: Boolean = false,
+    val wins: Int = 0,
+    val draws: Int = 0,
+    val losses: Int = 0,
+    val victoryPoints: Int = 0,
+    val matchPoints: Int = 0,
+    val powerPoints: Int = 0
+)
+
+@Serializable
+data class OnlineCampaignDetail(
+    val id: String,
+    val name: String,
+    val description: String? = null,
+    val status: String,
+    val joinCode: String? = null,
+    val currentUserRole: String = "MEMBER",  // "HOST" or "MEMBER"
+    val settings: OnlineCampaignSettings? = null,
+    val members: List<OnlineCampaignMember> = emptyList(),
+    // round1 → { game1 → [deviceId1, deviceId2], ... }
+    val schedule: Map<String, Map<String, List<String>>>? = null,
+    val currentRound: Int = 1,
+    val phase: String = "GAME",
+    val machinations: List<OnlineMachinationEntry> = emptyList(),
+    val matchResults: List<OnlineMatchResult> = emptyList()
+)
+
+/** A single SUPPORT/SABOTAGE machination choice within a submitted entry. */
+@Serializable
+data class OnlineMachinationChoice(
+    val targetDeviceId: String,
+    val type: String   // "SUPPORT" or "SABOTAGE"
+)
+
+/** An optional attack declaration submitted alongside machinations. */
+@Serializable
+data class OnlineMachinationAttack(
+    val targetDeviceId: String,
+    val targetCharId: Int,
+    val type: String   // "ASSAULT" or "ABDUCTION"
+)
+
+/** A single member's machination submission for a round. */
+@Serializable
+data class OnlineMachinationEntry(
+    val deviceId: String,
+    val username: String,
+    val choices: List<OnlineMachinationChoice> = emptyList(),
+    val attack: OnlineMachinationAttack? = null
+)
+
+/** Result data embedded within a match result. */
+@Serializable
+data class OnlineMatchResultData(
+    val playerStats: List<OnlinePlayerStat> = emptyList(),
+    val winnerId: String? = null
+)
+
+/** A match result record returned inside campaign detail. */
+@Serializable
+data class OnlineMatchResult(
+    val id: String,
+    val roundNumber: Int,
+    val gameNumber: Int,
+    val player1Id: String,
+    val player2Id: String,
+    val submittedBy: String,
+    val resultData: OnlineMatchResultData? = null,
+    val winnerId: String? = null,
+    val verifyStatus: String   // "PENDING", "VERIFIED", "DISPUTED"
+)
+
+/** One player's stats in an online match result. */
+@Serializable
+data class OnlinePlayerStat(
+    val deviceId: String,
+    val playerName: String,
+    val moonstones: Int = 0,
+    /** VP adjustment from campaign cards (can be negative). */
+    val campaignCardVp: Int = 0,
+    /** Share codes of campaign cards used this game. */
+    val campaignCardCodes: List<String> = emptyList()
+)
+
+/** Returned to the UI after a successful campaign creation. */
+data class CreatedCampaignResult(val id: String, val joinCode: String)
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 data class CharacterState(
     val characters: List<Character> = emptyList(),
     val troupes: List<Troupe> = emptyList(),
@@ -186,7 +310,55 @@ data class CharacterState(
     // App update state (opt-in, off by default — F-Droid manages updates for F-Droid installs)
     val autoCheckAppUpdates: Boolean = false,
     val pendingAppUpdate: AppRelease? = null,
-    val installerSource: InstallerSource = InstallerSource.DIRECT
+    val installerSource: InstallerSource = InstallerSource.DIRECT,
+
+    // LunaChron API registration
+    val isRegistered: Boolean = false,
+    val isRegisteringDevice: Boolean = false,
+    val registrationError: String? = null,
+    /** Backend's internal device UUID (devices.id) — used to identify this device in schedules/results. */
+    val backendDeviceId: String = "",
+
+    // Online campaign state
+    val onlineCampaigns: List<OnlineCampaignSummary> = emptyList(),
+    val isLoadingOnlineCampaigns: Boolean = false,
+    val isCreatingCampaign: Boolean = false,
+    val isJoiningCampaign: Boolean = false,
+    val onlineCampaignError: String? = null,
+    val createdCampaignResult: CreatedCampaignResult? = null,
+    val pendingJoinCampaignId: String? = null,
+
+    // Online campaign detail
+    val selectedOnlineCampaign: OnlineCampaignDetail? = null,
+    val isLoadingCampaignDetail: Boolean = false,
+    val isApprovingMember: Boolean = false,
+
+    // Online campaign schedule flow
+    val isLockingCampaign: Boolean = false,
+    val isPublishingSchedule: Boolean = false,
+    val pendingOnlineSchedule: List<CampaignRound>? = null,
+    val onlineScheduleRoundCount: Int = 0,
+
+    // Online campaign troupe + ready
+    val isUploadingTroupe: Boolean = false,
+    val isSettingReady: Boolean = false,
+    val isAddingLocalMember: Boolean = false,
+
+    // Online campaign rankings + round management
+    val isUpdatingRankings: Boolean = false,
+    val isAdvancingRound: Boolean = false,
+
+    // Online match result submission
+    val isSubmittingMatchResult: Boolean = false,
+    val matchResultSubmitted: Boolean = false,
+    val isVerifyingMatchResult: Boolean = false,
+
+    // Online machinations phase
+    val isSubmittingMachination: Boolean = false,
+
+    // Online campaign deletion
+    val isDeletingCampaign: Boolean = false,
+    val onlineCampaignDeleted: Boolean = false
 )
 
 @Serializable

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -14,6 +14,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import io.github.garemat.lunachron.api.ApiResult
+import io.github.garemat.lunachron.api.LunaChronApi
 import io.github.garemat.lunachron.ui.CampaignSubScreen
 import io.github.garemat.lunachron.ui.theme.ThemeRepository
 import io.ktor.client.*
@@ -64,6 +66,7 @@ class CharacterViewModel(
     }
     private val themeRepository = ThemeRepository(application)
     private val nearbyManager = NearbyManager(application)
+    private val apiClient = LunaChronApi(application)
     private val client = newsClient ?: HttpClient(Android) {
         install(HttpTimeout) {
             requestTimeoutMillis = 15000
@@ -98,7 +101,9 @@ class CharacterViewModel(
         installedDataVersion = CharacterData.getInstalledVersion(application),
         imageDownloadPreference = dataUpdateRepository.loadImagePreference(),
         autoCheckAppUpdates = dataUpdateRepository.loadAutoCheckApp(),
-        installerSource = dataUpdateRepository.getInstallerSource()
+        installerSource = dataUpdateRepository.getInstallerSource(),
+        isRegistered = prefs.getString("api_session_token", null) != null,
+        backendDeviceId = prefs.getString("api_backend_device_id", "") ?: ""
     ))
     
     private val _characters = repository.getCharacters()
@@ -148,6 +153,15 @@ class CharacterViewModel(
         if (_state.value.autoFetchNews) fetchNews()
         checkForUpdatesOnStartup()
         nearbyManager.setPayloadListener { endpointId, message -> handleSessionMessage(endpointId, message) }
+        // Backfill backendDeviceId for users who registered before it was added to the auth response
+        if (_state.value.isRegistered && _state.value.backendDeviceId.isEmpty()) {
+            viewModelScope.launch {
+                val result = apiClient.login(persistentDeviceId)
+                if (result is ApiResult.Success && result.data.deviceId != null) {
+                    _state.update { it.copy(backendDeviceId = result.data.deviceId) }
+                }
+            }
+        }
     }
 
     private fun checkForUpdatesOnStartup() {
@@ -291,6 +305,248 @@ class CharacterViewModel(
                 val old = _state.value.name; _state.update { it.copy(name = event.name) }
                 prefs.edit { putString("player_name", event.name) }
                 if (event.name != old) nearbyManager.sendPayloadToAll(MessageParser.encode(SessionMessage.PlayerInfoUpdate(persistentDeviceId, event.name)))
+            }
+            is CharacterEvent.RegisterDevice -> viewModelScope.launch {
+                _state.update { it.copy(isRegisteringDevice = true, registrationError = null) }
+                when (val result = apiClient.register(persistentDeviceId, event.username)) {
+                    is ApiResult.Success -> {
+                        // Persist username locally so it survives app restarts without re-hitting the API.
+                        prefs.edit { putString("player_name", event.username) }
+                        _state.update {
+                            it.copy(
+                                isRegisteringDevice = false,
+                                isRegistered = true,
+                                name = event.username,
+                                backendDeviceId = result.data.deviceId ?: it.backendDeviceId
+                            )
+                        }
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isRegisteringDevice = false, registrationError = result.message) }
+                }
+            }
+            CharacterEvent.DismissRegistrationError -> _state.update { it.copy(registrationError = null) }
+            CharacterEvent.LoadOnlineCampaigns -> viewModelScope.launch {
+                _state.update { it.copy(isLoadingOnlineCampaigns = true, onlineCampaignError = null) }
+                when (val r = apiClient.getMyCampaigns()) {
+                    is ApiResult.Success -> _state.update { it.copy(isLoadingOnlineCampaigns = false, onlineCampaigns = r.data) }
+                    is ApiResult.Error   -> _state.update { it.copy(isLoadingOnlineCampaigns = false, onlineCampaignError = r.message) }
+                }
+            }
+            is CharacterEvent.CreateOnlineCampaign -> viewModelScope.launch {
+                _state.update { it.copy(isCreatingCampaign = true, onlineCampaignError = null) }
+                when (val r = apiClient.createCampaign(event.name, event.description, event.settings)) {
+                    is ApiResult.Success -> _state.update { it.copy(isCreatingCampaign = false, createdCampaignResult = CreatedCampaignResult(r.data.id, r.data.joinCode)) }
+                    is ApiResult.Error   -> _state.update { it.copy(isCreatingCampaign = false, onlineCampaignError = r.message) }
+                }
+            }
+            is CharacterEvent.RequestJoinCampaign -> viewModelScope.launch {
+                _state.update { it.copy(isJoiningCampaign = true, onlineCampaignError = null) }
+                when (val r = apiClient.joinCampaign(event.joinCode)) {
+                    is ApiResult.Success -> _state.update { it.copy(isJoiningCampaign = false, pendingJoinCampaignId = r.data.campaignId) }
+                    is ApiResult.Error   -> _state.update { it.copy(isJoiningCampaign = false, onlineCampaignError = r.message) }
+                }
+            }
+            CharacterEvent.DismissOnlineCampaignError   -> _state.update { it.copy(onlineCampaignError = null) }
+            CharacterEvent.DismissCreatedCampaignResult -> _state.update { it.copy(createdCampaignResult = null) }
+            is CharacterEvent.LoadOnlineCampaign -> viewModelScope.launch {
+                _state.update { it.copy(isLoadingCampaignDetail = true, onlineCampaignError = null) }
+                when (val r = apiClient.getCampaign(event.campaignId)) {
+                    is ApiResult.Success -> _state.update { it.copy(isLoadingCampaignDetail = false, selectedOnlineCampaign = r.data) }
+                    is ApiResult.Error   -> _state.update { it.copy(isLoadingCampaignDetail = false, onlineCampaignError = r.message) }
+                }
+            }
+            is CharacterEvent.ApproveMember -> viewModelScope.launch {
+                _state.update { it.copy(isApprovingMember = true, onlineCampaignError = null) }
+                when (val r = apiClient.approveMember(event.campaignId, event.memberId)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isApprovingMember = false) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isApprovingMember = false, onlineCampaignError = r.message) }
+                }
+            }
+            is CharacterEvent.RejectMember -> viewModelScope.launch {
+                _state.update { it.copy(isApprovingMember = true, onlineCampaignError = null) }
+                when (val r = apiClient.rejectMember(event.campaignId, event.memberId)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isApprovingMember = false) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isApprovingMember = false, onlineCampaignError = r.message) }
+                }
+            }
+            CharacterEvent.ClearSelectedOnlineCampaign -> _state.update { it.copy(selectedOnlineCampaign = null, pendingOnlineSchedule = null, onlineScheduleRoundCount = 0) }
+            is CharacterEvent.DeleteOnlineCampaign -> viewModelScope.launch {
+                _state.update { it.copy(isDeletingCampaign = true, onlineCampaignError = null) }
+                when (val r = apiClient.deleteOnlineCampaign(event.campaignId)) {
+                    is ApiResult.Success -> _state.update { it.copy(isDeletingCampaign = false, onlineCampaignDeleted = true, selectedOnlineCampaign = null) }
+                    is ApiResult.Error   -> _state.update { it.copy(isDeletingCampaign = false, onlineCampaignError = r.message) }
+                }
+            }
+            CharacterEvent.DismissCampaignDeleted -> _state.update { it.copy(onlineCampaignDeleted = false) }
+            is CharacterEvent.LockOnlineCampaign -> viewModelScope.launch {
+                _state.update { it.copy(isLockingCampaign = true, onlineCampaignError = null) }
+                when (val r = apiClient.lockCampaign(event.campaignId)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isLockingCampaign = false) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isLockingCampaign = false, onlineCampaignError = r.message) }
+                }
+            }
+            is CharacterEvent.UnlockOnlineCampaign -> viewModelScope.launch {
+                _state.update { it.copy(isLockingCampaign = true, onlineCampaignError = null) }
+                when (val r = apiClient.unlockCampaign(event.campaignId)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isLockingCampaign = false, pendingOnlineSchedule = null) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isLockingCampaign = false, onlineCampaignError = r.message) }
+                }
+            }
+            is CharacterEvent.SetOnlineScheduleRoundCount -> _state.update { it.copy(onlineScheduleRoundCount = event.count) }
+            is CharacterEvent.GenerateOnlineSchedule -> {
+                val members = _state.value.selectedOnlineCampaign
+                    ?.members?.filter { it.status == "APPROVED" } ?: return
+                val playerIds = members.map { it.deviceId }
+                val schedule = generateRoundRobinSchedule(playerIds, event.totalRounds)
+                _state.update { it.copy(pendingOnlineSchedule = schedule) }
+            }
+            is CharacterEvent.UploadOnlineTroupe -> viewModelScope.launch {
+                _state.update { it.copy(isUploadingTroupe = true, onlineCampaignError = null) }
+                when (val r = apiClient.uploadTroupe(event.campaignId, event.troupeData)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isUploadingTroupe = false) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isUploadingTroupe = false, onlineCampaignError = r.message) }
+                }
+            }
+            is CharacterEvent.SetOnlineCampaignReady -> viewModelScope.launch {
+                _state.update { it.copy(isSettingReady = true, onlineCampaignError = null) }
+                when (val r = apiClient.setReady(event.campaignId, event.isReady)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isSettingReady = false) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isSettingReady = false, onlineCampaignError = r.message) }
+                }
+            }
+            is CharacterEvent.AddLocalCampaignMember -> viewModelScope.launch {
+                _state.update { it.copy(isAddingLocalMember = true, onlineCampaignError = null) }
+                when (val r = apiClient.addLocalMember(event.campaignId, event.name)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isAddingLocalMember = false) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isAddingLocalMember = false, onlineCampaignError = r.message) }
+                }
+            }
+            is CharacterEvent.UploadLocalMemberTroupe -> viewModelScope.launch {
+                _state.update { it.copy(isUploadingTroupe = true, onlineCampaignError = null) }
+                when (val r = apiClient.uploadTroupe(event.campaignId, event.troupeData, event.targetDeviceId)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isUploadingTroupe = false) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isUploadingTroupe = false, onlineCampaignError = r.message) }
+                }
+            }
+            is CharacterEvent.SetLocalMemberReady -> viewModelScope.launch {
+                _state.update { it.copy(isSettingReady = true, onlineCampaignError = null) }
+                when (val r = apiClient.setReady(event.campaignId, event.isReady, event.targetDeviceId)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isSettingReady = false) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isSettingReady = false, onlineCampaignError = r.message) }
+                }
+            }
+            is CharacterEvent.UpdateOnlineRankings -> viewModelScope.launch {
+                _state.update { it.copy(isUpdatingRankings = true, onlineCampaignError = null) }
+                when (val r = apiClient.updateRankings(event.campaignId)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isUpdatingRankings = false) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isUpdatingRankings = false, onlineCampaignError = r.message) }
+                }
+            }
+            is CharacterEvent.AdvanceOnlineRound -> viewModelScope.launch {
+                _state.update { it.copy(isAdvancingRound = true, onlineCampaignError = null) }
+                when (val r = apiClient.advanceRound(event.campaignId)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isAdvancingRound = false) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isAdvancingRound = false, onlineCampaignError = r.message) }
+                }
+            }
+            is CharacterEvent.SubmitOnlineMatchResult -> viewModelScope.launch {
+                _state.update { it.copy(isSubmittingMatchResult = true, onlineCampaignError = null) }
+                when (val r = apiClient.submitMatchResult(event.campaignId, event.roundNumber, event.gameNumber, event.playerStats, event.winnerId)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isSubmittingMatchResult = false, matchResultSubmitted = true) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> {
+                        // Both players submitted simultaneously — reload so the opponent sees the pending verification UI
+                        if (r.code == "ALREADY_SUBMITTED") {
+                            _state.update { it.copy(isSubmittingMatchResult = false) }
+                            onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                        } else {
+                            _state.update { it.copy(isSubmittingMatchResult = false, onlineCampaignError = r.message) }
+                        }
+                    }
+                }
+            }
+            CharacterEvent.DismissMatchResultSubmitted -> _state.update { it.copy(matchResultSubmitted = false) }
+            is CharacterEvent.SubmitMachination -> viewModelScope.launch {
+                _state.update { it.copy(isSubmittingMachination = true, onlineCampaignError = null) }
+                when (val r = apiClient.submitMachination(event.campaignId, event.machinations, event.attack)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isSubmittingMachination = false) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isSubmittingMachination = false, onlineCampaignError = r.message) }
+                }
+            }
+            is CharacterEvent.SubmitLocalMachination -> viewModelScope.launch {
+                _state.update { it.copy(isSubmittingMachination = true, onlineCampaignError = null) }
+                when (val r = apiClient.submitMachination(event.campaignId, event.machinations, event.attack, event.targetDeviceId)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isSubmittingMachination = false) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isSubmittingMachination = false, onlineCampaignError = r.message) }
+                }
+            }
+            is CharacterEvent.VerifyMatchResult -> viewModelScope.launch {
+                _state.update { it.copy(isVerifyingMatchResult = true, onlineCampaignError = null) }
+                when (val r = apiClient.verifyMatchResult(event.campaignId, event.resultId, event.agree)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isVerifyingMatchResult = false) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isVerifyingMatchResult = false, onlineCampaignError = r.message) }
+                }
+            }
+            is CharacterEvent.PublishOnlineSchedule -> viewModelScope.launch {
+                val rounds = _state.value.pendingOnlineSchedule ?: return@launch
+                _state.update { it.copy(isPublishingSchedule = true, onlineCampaignError = null) }
+                // Convert List<CampaignRound> → Map<String, Map<String, List<String>>>
+                val backendSchedule = rounds.associate { round ->
+                    "round${round.roundNumber}" to round.games.mapIndexed { idx, game ->
+                        "game${idx + 1}" to game.playerIds
+                    }.toMap()
+                }
+                when (val r = apiClient.publishSchedule(event.campaignId, backendSchedule)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isPublishingSchedule = false, pendingOnlineSchedule = null) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isPublishingSchedule = false, onlineCampaignError = r.message) }
+                }
             }
             is CharacterEvent.SetActiveTheme -> {
                 _state.update { it.copy(activeThemeId = event.themeId) }

--- a/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
@@ -99,8 +99,13 @@ class MainActivity : ComponentActivity() {
                         Screen.AddEditTroupe.route,
                         Screen.GameSetup.route,
                         Screen.SoloTroupeSelect.route,
+                        Screen.CampaignHub.route,
                         Screen.CampaignManagement.route,
                         Screen.AddEditCampaign.route,
+                        Screen.HostOnlineCampaign.route,
+                        Screen.JoinOnlineCampaign.route,
+                        Screen.ActiveOnlineCampaigns.route,
+                        "online_campaign_detail",
                         "edit_campaign",
                         "campaign_details"
                     )
@@ -223,7 +228,12 @@ class MainActivity : ComponentActivity() {
                                                     currentDestination?.route == Screen.Troupes.route -> "My Troupes"
                                                     currentDestination?.route == Screen.AddEditTroupe.route -> viewModel.newTroupeName.ifBlank { if (viewModel.editingTroupeId == null) "New Troupe" else "Edit Troupe" }
                                                     currentDestination?.route == Screen.GameSetup.route -> "Game Setup"
-                                                    currentDestination?.route == Screen.CampaignManagement.route -> "Wizard Chamberlain"
+                                                    currentDestination?.route == Screen.CampaignHub.route -> "Campaigns"
+                                                    currentDestination?.route == Screen.CampaignManagement.route -> "Local Tracking"
+                                                    currentDestination?.route == Screen.HostOnlineCampaign.route -> "New Campaign"
+                                                    currentDestination?.route == Screen.JoinOnlineCampaign.route -> "Join Campaign"
+                                                    currentDestination?.route == Screen.ActiveOnlineCampaigns.route -> "Active Campaigns"
+                                                    currentDestination?.route?.startsWith("online_campaign_detail") == true -> state.selectedOnlineCampaign?.name ?: "Campaign"
                                                     currentDestination?.route == Screen.AddEditCampaign.route -> "New Campaign"
                                                     currentDestination?.route?.startsWith("edit_campaign") == true -> "Campaign Settings"
                                                     currentDestination?.route?.startsWith("campaign_details") == true -> {
@@ -245,7 +255,7 @@ class MainActivity : ComponentActivity() {
                                         }
                                     },
                                     navigationIcon = {
-                                        if (currentDestination?.route in listOf(Screen.AddEditTroupe.route, Screen.Characters.route, Screen.Upgrades.route, Screen.CampaignCards.route, Screen.Rules.route, Screen.Settings.route, Screen.TournamentSetup.route, Screen.AddEditCampaign.route) || currentDestination?.route?.startsWith("edit_campaign") == true || currentDestination?.route?.startsWith("campaign_details") == true) {
+                                        if (currentDestination?.route in listOf(Screen.AddEditTroupe.route, Screen.Characters.route, Screen.Upgrades.route, Screen.CampaignCards.route, Screen.Rules.route, Screen.Settings.route, Screen.TournamentSetup.route, Screen.AddEditCampaign.route, Screen.CampaignManagement.route, Screen.HostOnlineCampaign.route, Screen.JoinOnlineCampaign.route, Screen.ActiveOnlineCampaigns.route) || currentDestination?.route?.startsWith("edit_campaign") == true || currentDestination?.route?.startsWith("campaign_details") == true || currentDestination?.route?.startsWith("online_campaign_detail") == true) {
                                             IconButton(onClick = { backDispatcher?.onBackPressed() }) {
                                                 Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                                             }
@@ -292,7 +302,7 @@ class MainActivity : ComponentActivity() {
                                         BottomNavItem("Compendium", Screen.Compendium.route, Icons.Default.MenuBook),
                                         BottomNavItem("Play", playRoute, Icons.Default.PlayArrow),
                                         BottomNavItem("Troupes", Screen.Troupes.route, Icons.Default.Groups),
-                                        BottomNavItem("Campaigns", Screen.CampaignManagement.route, Icons.Default.HistoryEdu)
+                                        BottomNavItem("Campaigns", Screen.CampaignHub.route, Icons.Default.HistoryEdu)
                                     )
                                     items.forEach { item ->
                                         val isPlayButton = item.label == "Play"
@@ -578,6 +588,15 @@ class MainActivity : ComponentActivity() {
                                         onNavigateBack = { navController.safePopBackStack() }
                                     )
                                 }
+                                composable(Screen.CampaignHub.route) {
+                                    CampaignHubScreen(
+                                        state = state,
+                                        onLocalTrackingSelected = { navController.navigate(Screen.CampaignManagement.route) },
+                                        onHostCampaignSelected = { navController.navigate(Screen.HostOnlineCampaign.route) },
+                                        onJoinCampaignSelected = { navController.navigate(Screen.JoinOnlineCampaign.route) },
+                                        onActiveCampaignsSelected = { navController.navigate(Screen.ActiveOnlineCampaigns.route) }
+                                    )
+                                }
                                 composable(Screen.CampaignManagement.route) {
                                     CampaignManagementScreen(
                                         state = state,
@@ -590,6 +609,44 @@ class MainActivity : ComponentActivity() {
                                             viewModel.resetNewCampaignFields()
                                             navController.navigate(Screen.AddEditCampaign.route)
                                         }
+                                    )
+                                }
+                                composable(Screen.HostOnlineCampaign.route) {
+                                    HostOnlineCampaignScreen(
+                                        state = state,
+                                        onEvent = viewModel::onEvent,
+                                        onNavigateBack = { navController.safePopBackStack() }
+                                    )
+                                }
+                                composable(Screen.JoinOnlineCampaign.route) {
+                                    JoinOnlineCampaignScreen(
+                                        state = state,
+                                        onEvent = viewModel::onEvent,
+                                        onNavigateBack = { navController.safePopBackStack() }
+                                    )
+                                }
+                                composable(Screen.ActiveOnlineCampaigns.route) {
+                                    ActiveOnlineCampaignsScreen(
+                                        state = state,
+                                        onEvent = viewModel::onEvent,
+                                        onNavigateBack = { navController.safePopBackStack() },
+                                        onCampaignSelected = { id ->
+                                            navController.navigate(Screen.OnlineCampaignDetail.createRoute(id))
+                                        }
+                                    )
+                                }
+                                composable(
+                                    route = Screen.OnlineCampaignDetail.route,
+                                    arguments = listOf(navArgument("campaignId") { type = NavType.StringType })
+                                ) { backStackEntry ->
+                                    val campaignId = backStackEntry.arguments?.getString("campaignId") ?: return@composable
+                                    OnlineCampaignDetailScreen(
+                                        campaignId = campaignId,
+                                        state = state,
+                                        onEvent = viewModel::onEvent,
+                                        onNavigateBack = { navController.safePopBackStack() },
+                                        onDecodeTroupe = { code -> viewModel.importTroupe(code, state.characters, state.upgradeCards) },
+                                        onEncodeTroupe = { troupe -> viewModel.generateFullShareCode(troupe, state.characters, state.upgradeCards) }
                                     )
                                 }
                                 composable(Screen.AddEditCampaign.route) {

--- a/app/src/main/java/io/github/garemat/lunachron/api/LunaChronApi.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/api/LunaChronApi.kt
@@ -1,0 +1,594 @@
+package io.github.garemat.lunachron.api
+
+import android.content.Context
+import android.content.Context.MODE_PRIVATE
+import androidx.core.content.edit
+import io.ktor.client.*
+import io.ktor.client.engine.android.Android
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.github.garemat.lunachron.BuildConfig
+import io.github.garemat.lunachron.OnlineCampaignDetail
+import io.github.garemat.lunachron.OnlineCampaignSettings
+import io.github.garemat.lunachron.OnlineCampaignSummary
+import io.github.garemat.lunachron.OnlineMachinationAttack
+import io.github.garemat.lunachron.OnlineMachinationChoice
+import io.github.garemat.lunachron.OnlinePlayerStat
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+private const val PREFS_NAME = "lunachron_prefs"
+private const val KEY_SESSION_TOKEN = "api_session_token"
+private const val KEY_SESSION_EXPIRES = "api_session_expires"
+private const val KEY_BACKEND_DEVICE_ID = "api_backend_device_id"
+
+// Resolved from BuildConfig at compile time:
+//   debug   → http://10.0.2.2:3000  (emulator) — change to your LAN IP for a physical device
+//   release → https://api.garemat.co.uk
+private val BASE_URL = BuildConfig.LUNACHRON_API_URL
+
+/** Wraps an API call result — either a parsed success body or an error with a machine-readable code. */
+sealed class ApiResult<out T> {
+    data class Success<T>(val data: T) : ApiResult<T>()
+    data class Error(val code: String, val message: String) : ApiResult<Nothing>()
+}
+
+// ── Request / response models ─────────────────────────────────────────────────
+
+@Serializable
+private data class RegisterRequest(val deviceId: String, val username: String)
+
+@Serializable
+private data class LoginRequest(val deviceId: String)
+
+@Serializable
+data class AuthResponse(
+    val token: String,
+    @SerialName("expiresAt") val expiresAt: String,
+    /** Present on login responses; absent on fresh registration. */
+    val username: String? = null,
+    /** The backend's internal device UUID (devices.id). Used to identify this device in schedules/results. */
+    val deviceId: String? = null
+)
+
+@Serializable
+private data class CreateCampaignRequest(
+    val name: String,
+    val description: String? = null,
+    val settings: OnlineCampaignSettings? = null
+)
+
+@Serializable
+data class CreateCampaignResponse(val id: String, val joinCode: String)
+
+@Serializable
+private data class JoinCampaignRequest(val joinCode: String)
+
+@Serializable
+data class JoinCampaignResponse(val campaignId: String, val status: String)
+
+@Serializable
+data class UnlockCampaignResponse(val status: String, val joinCode: String)
+
+@Serializable
+data class AddLocalMemberResponse(val id: String, val deviceId: String, val username: String)
+
+@Serializable
+private data class MatchResultRequest(
+    val roundNumber: Int,
+    val gameNumber: Int,
+    val playerStats: List<OnlinePlayerStat>,
+    val winnerId: String?
+)
+
+@Serializable
+private data class ApiErrorBody(
+    val error: String = "Unknown error",
+    val code: String = "UNKNOWN",
+    val details: List<String> = emptyList()
+) {
+    /** Human-readable message, appending AJV detail lines when present. */
+    val message: String get() = if (details.isEmpty()) error else "$error\n${details.joinToString("\n")}"
+}
+
+// ── Client ────────────────────────────────────────────────────────────────────
+
+/**
+ * Thin wrapper around the LunaChron backend REST API.
+ *
+ * Responsibilities:
+ *  - Serialize/deserialize request and response bodies
+ *  - Persist the session token in SharedPreferences
+ *  - Return [ApiResult] — callers never see raw HTTP or exceptions
+ *
+ * Adding new endpoints: add a method here, a request/response model above, and
+ * wire the call through a new [CharacterEvent] in the ViewModel.
+ */
+class LunaChronApi(
+    context: Context,
+    /** Inject a mock client in tests; production code uses the default. */
+    client: HttpClient? = null
+) {
+    private val prefs = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+    private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true; encodeDefaults = true }
+    private val http = client ?: HttpClient(Android) {
+        install(HttpTimeout) {
+            requestTimeoutMillis = 15_000
+            connectTimeoutMillis = 15_000
+            socketTimeoutMillis  = 15_000
+        }
+    }
+
+    /** The currently stored session token, or null if the device is not registered. */
+    val savedToken: String? get() = prefs.getString(KEY_SESSION_TOKEN, null)
+
+    /** The backend's internal device UUID (devices.id), stored after first successful auth. */
+    val savedBackendDeviceId: String? get() = prefs.getString(KEY_BACKEND_DEVICE_ID, null)
+
+    /** Attaches the saved session token as a Bearer header. */
+    private fun HttpRequestBuilder.authorize() {
+        val token = savedToken ?: return
+        header(HttpHeaders.Authorization, "Bearer $token")
+    }
+
+    private fun saveToken(token: String, expiresAt: String, backendDeviceId: String? = null) {
+        prefs.edit {
+            putString(KEY_SESSION_TOKEN, token)
+            putString(KEY_SESSION_EXPIRES, expiresAt)
+            if (backendDeviceId != null) putString(KEY_BACKEND_DEVICE_ID, backendDeviceId)
+        }
+    }
+
+    /**
+     * Register this device with [username].
+     *
+     * If the device is already registered (DEVICE_EXISTS), automatically falls
+     * through to [login] so the caller always gets a fresh token on success.
+     *
+     * Errors surfaced to callers:
+     *  - USERNAME_TAKEN  — choose a different username
+     *  - NETWORK_ERROR   — connectivity problem
+     */
+    suspend fun register(deviceId: String, username: String): ApiResult<AuthResponse> = try {
+        val body = json.encodeToString(RegisterRequest(deviceId, username))
+        val response = http.post("$BASE_URL/auth/register") {
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+        handleAuthResponse(response, onDeviceExists = { login(deviceId) })
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    /**
+     * Refresh the session token for an already-registered device.
+     * Returns DEVICE_NOT_FOUND if the device has never been registered.
+     */
+    suspend fun login(deviceId: String): ApiResult<AuthResponse> = try {
+        val body = json.encodeToString(LoginRequest(deviceId))
+        val response = http.post("$BASE_URL/auth/login") {
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+        handleAuthResponse(response, onDeviceExists = null)
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    // ── Campaign endpoints ────────────────────────────────────────────────────
+
+    /** Create a new campaign and return its ID and 6-char join code. */
+    suspend fun createCampaign(
+        name: String,
+        description: String?,
+        settings: OnlineCampaignSettings
+    ): ApiResult<CreateCampaignResponse> = try {
+        val body = json.encodeToString(CreateCampaignRequest(name, description, settings))
+        val response = http.post("$BASE_URL/campaigns") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            201 -> ApiResult.Success(json.decodeFromString<CreateCampaignResponse>(text))
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    /** Request to join a campaign via its 6-char join code. */
+    suspend fun joinCampaign(joinCode: String): ApiResult<JoinCampaignResponse> = try {
+        val body = json.encodeToString(JoinCampaignRequest(joinCode))
+        val response = http.post("$BASE_URL/campaigns/join") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            201 -> ApiResult.Success(json.decodeFromString<JoinCampaignResponse>(text))
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    /** Returns full detail for a single campaign, including its member list. */
+    suspend fun getCampaign(campaignId: String): ApiResult<OnlineCampaignDetail> = try {
+        val response = http.get("$BASE_URL/campaigns/$campaignId") { authorize() }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            200 -> ApiResult.Success(json.decodeFromString<OnlineCampaignDetail>(text))
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    /** Approve a pending member (host only). */
+    suspend fun approveMember(campaignId: String, memberId: String): ApiResult<Unit> = try {
+        val body = """{"memberId":"$memberId"}"""
+        val response = http.post("$BASE_URL/campaigns/$campaignId/approve-member") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            200 -> ApiResult.Success(Unit)
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    /** Reject a pending member (host only). */
+    suspend fun rejectMember(campaignId: String, memberId: String): ApiResult<Unit> = try {
+        val body = """{"memberId":"$memberId"}"""
+        val response = http.post("$BASE_URL/campaigns/$campaignId/reject-member") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            200 -> ApiResult.Success(Unit)
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    /** Lock the campaign — auto-rejects pending members, prevents new joins. */
+    suspend fun lockCampaign(campaignId: String): ApiResult<Unit> = try {
+        val response = http.post("$BASE_URL/campaigns/$campaignId/lock") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody("{}")
+        }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            200 -> ApiResult.Success(Unit)
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    /** Re-open a locked campaign with a fresh join code. */
+    suspend fun unlockCampaign(campaignId: String): ApiResult<UnlockCampaignResponse> = try {
+        val response = http.post("$BASE_URL/campaigns/$campaignId/unlock") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody("{}")
+        }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            200 -> ApiResult.Success(json.decodeFromString<UnlockCampaignResponse>(text))
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    /** Publish a round-robin schedule for a locked campaign. */
+    suspend fun publishSchedule(
+        campaignId: String,
+        schedule: Map<String, Map<String, List<String>>>
+    ): ApiResult<Unit> = try {
+        val body = buildString {
+            append("""{"schedule":{""")
+            schedule.entries.joinTo(this, ",") { (roundKey, games) ->
+                """"$roundKey":{${games.entries.joinToString(",") { (gameKey, players) ->
+                    """"$gameKey":[${players.joinToString(",") { "\"$it\"" }}]"""
+                }}}"""
+            }
+            append("}}")
+        }
+        val response = http.post("$BASE_URL/campaigns/$campaignId/schedule") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            200 -> ApiResult.Success(Unit)
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    /** Upload troupe data for a campaign. Pass [targetDeviceId] (host only) to upload for a local player. */
+    suspend fun uploadTroupe(campaignId: String, troupeData: String, targetDeviceId: String? = null): ApiResult<Unit> = try {
+        val bodyMap = buildMap<String, String> {
+            put("troupeData", troupeData)
+            if (targetDeviceId != null) put("targetDeviceId", targetDeviceId)
+        }
+        val body = json.encodeToString(bodyMap)
+        val response = http.put("$BASE_URL/campaigns/$campaignId/troupe") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            200 -> ApiResult.Success(Unit)
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    /** Set or clear ready state. Pass [targetDeviceId] (host only) to act on a local player. */
+    suspend fun setReady(campaignId: String, isReady: Boolean, targetDeviceId: String? = null): ApiResult<Unit> = try {
+        val body = if (targetDeviceId != null)
+            """{"isReady":$isReady,"targetDeviceId":"$targetDeviceId"}"""
+        else
+            """{"isReady":$isReady}"""
+        val response = http.post("$BASE_URL/campaigns/$campaignId/ready") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            200 -> ApiResult.Success(Unit)
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    /** Trigger server-side ranking recalculation (host only). */
+    suspend fun updateRankings(campaignId: String): ApiResult<Unit> = try {
+        val response = http.post("$BASE_URL/campaigns/$campaignId/rankings") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody("{}")
+        }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            200 -> ApiResult.Success(Unit)
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    /** Advance to the next round (host only). */
+    suspend fun advanceRound(campaignId: String): ApiResult<Unit> = try {
+        val response = http.post("$BASE_URL/campaigns/$campaignId/advance-round") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody("{}")
+        }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            200 -> ApiResult.Success(Unit)
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    /** Delete a campaign (host only). */
+    suspend fun deleteOnlineCampaign(campaignId: String): ApiResult<Unit> = try {
+        val response = http.delete("$BASE_URL/campaigns/$campaignId") { authorize() }
+        when (response.status.value) {
+            204 -> ApiResult.Success(Unit)
+            else -> {
+                val text = response.bodyAsText()
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    /** Submit a match result for a game in the current round. */
+    suspend fun submitMatchResult(
+        campaignId: String,
+        roundNumber: Int,
+        gameNumber: Int,
+        playerStats: List<OnlinePlayerStat>,
+        winnerId: String?
+    ): ApiResult<Unit> = try {
+        val body = json.encodeToString(MatchResultRequest(roundNumber, gameNumber, playerStats, winnerId))
+        val response = http.post("$BASE_URL/campaigns/$campaignId/match-result") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            200, 201 -> ApiResult.Success(Unit)
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    /** Agree or dispute a pending match result as the opponent. */
+    suspend fun verifyMatchResult(campaignId: String, resultId: String, agree: Boolean): ApiResult<Unit> = try {
+        val body = """{"resultId":"$resultId","agree":$agree}"""
+        val response = http.post("$BASE_URL/campaigns/$campaignId/verify-result") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            200 -> ApiResult.Success(Unit)
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    /** Add a named local (unattended) player to a campaign (host only). */
+    suspend fun addLocalMember(campaignId: String, name: String): ApiResult<AddLocalMemberResponse> = try {
+        val body = """{"name":${json.encodeToString(name)}}"""
+        val response = http.post("$BASE_URL/campaigns/$campaignId/add-local-member") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            200, 201 -> ApiResult.Success(json.decodeFromString<AddLocalMemberResponse>(text))
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    /** Submit SUPPORT/SABOTAGE machination choices (and optional attack) for the machinations phase. */
+    suspend fun submitMachination(
+        campaignId: String,
+        machinations: List<OnlineMachinationChoice>,
+        attack: OnlineMachinationAttack? = null,
+        targetDeviceId: String? = null
+    ): ApiResult<Unit> = try {
+        val machinationsJson = json.encodeToString(machinations)
+        val attackJson = if (attack != null) json.encodeToString(attack) else null
+        val body = buildString {
+            append("""{"machinations":$machinationsJson""")
+            if (attackJson != null) append(""","attack":$attackJson""")
+            if (targetDeviceId != null) append(""","targetDeviceId":"$targetDeviceId"""")
+            append("}")
+        }
+        val response = http.post("$BASE_URL/campaigns/$campaignId/submit-machination") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            200, 201 -> ApiResult.Success(Unit)
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    /** Returns all campaigns the device is an approved member of. */
+    suspend fun getMyCampaigns(): ApiResult<List<OnlineCampaignSummary>> = try {
+        val response = http.get("$BASE_URL/campaigns/mine") { authorize() }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            200 -> ApiResult.Success(json.decodeFromString<List<OnlineCampaignSummary>>(text))
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    private suspend fun handleAuthResponse(
+        response: HttpResponse,
+        onDeviceExists: (suspend () -> ApiResult<AuthResponse>)?
+    ): ApiResult<AuthResponse> {
+        val text = response.bodyAsText()
+        return when (response.status.value) {
+            200, 201 -> {
+                val result = json.decodeFromString<AuthResponse>(text)
+                saveToken(result.token, result.expiresAt, result.deviceId)
+                ApiResult.Success(result)
+            }
+            409 -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }
+                    .getOrDefault(ApiErrorBody())
+                if (err.code == "DEVICE_EXISTS" && onDeviceExists != null) {
+                    onDeviceExists()
+                } else {
+                    ApiResult.Error(err.code, err.message)
+                }
+            }
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }
+                    .getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveOnlineCampaignsScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveOnlineCampaignsScreen.kt
@@ -1,0 +1,260 @@
+package io.github.garemat.lunachron.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import io.github.garemat.lunachron.CharacterEvent
+import io.github.garemat.lunachron.CharacterState
+import io.github.garemat.lunachron.OnlineCampaignSummary
+import io.github.garemat.lunachron.ui.theme.LocalAppThemeProperties
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ActiveOnlineCampaignsScreen(
+    state: CharacterState,
+    onEvent: (CharacterEvent) -> Unit,
+    onNavigateBack: () -> Unit,
+    onCampaignSelected: (String) -> Unit = {}
+) {
+    val theme = LocalAppThemeProperties.current
+
+    // Load campaigns when the screen first appears
+    LaunchedEffect(Unit) { onEvent(CharacterEvent.LoadOnlineCampaigns) }
+
+    if (state.onlineCampaignError != null) {
+        AlertDialog(
+            onDismissRequest = { onEvent(CharacterEvent.DismissOnlineCampaignError) },
+            title = { Text("Error", style = theme.headerStyle) },
+            text = { Text(state.onlineCampaignError, style = MaterialTheme.typography.bodyMedium) },
+            confirmButton = {
+                TextButton(onClick = { onEvent(CharacterEvent.DismissOnlineCampaignError) }) { Text("OK") }
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Active Campaigns", style = theme.titleStyle) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { onEvent(CharacterEvent.LoadOnlineCampaigns) }) {
+                        Icon(Icons.Default.Refresh, contentDescription = "Refresh", tint = MaterialTheme.colorScheme.primary)
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    titleContentColor = MaterialTheme.colorScheme.primary,
+                    navigationIconContentColor = MaterialTheme.colorScheme.primary
+                )
+            )
+        }
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when {
+                state.isLoadingOnlineCampaigns -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+                state.onlineCampaigns.isEmpty() -> {
+                    Column(
+                        modifier = Modifier.align(Alignment.Center),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Icon(Icons.Default.Campaign, contentDescription = null, modifier = Modifier.size(64.dp), tint = MaterialTheme.colorScheme.outline)
+                        Spacer(modifier = Modifier.height(theme.verticalSpacing))
+                        Text("No active campaigns", style = theme.headerStyle, color = MaterialTheme.colorScheme.outline)
+                        Text("Host or join a campaign to get started.", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.outline)
+                    }
+                }
+                else -> {
+                    val approved = state.onlineCampaigns.filter { it.membershipStatus == "APPROVED" }
+                    val pending  = state.onlineCampaigns.filter { it.membershipStatus == "PENDING" }
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(theme.screenPadding),
+                        verticalArrangement = Arrangement.spacedBy(theme.verticalSpacing)
+                    ) {
+                        if (pending.isNotEmpty()) {
+                            item {
+                                Text(
+                                    "Awaiting Approval",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.tertiary,
+                                    modifier = Modifier.padding(vertical = 4.dp)
+                                )
+                            }
+                            items(pending) { campaign ->
+                                PendingCampaignCard(campaign = campaign)
+                            }
+                        }
+                        if (approved.isNotEmpty()) {
+                            if (pending.isNotEmpty()) {
+                                item {
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                    Text(
+                                        "Active Campaigns",
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.padding(vertical = 4.dp)
+                                    )
+                                }
+                            }
+                            items(approved) { campaign ->
+                                OnlineCampaignCard(
+                                    campaign = campaign,
+                                    onClick = { onCampaignSelected(campaign.id) }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun OnlineCampaignCard(campaign: OnlineCampaignSummary, onClick: () -> Unit = {}) {
+    val theme = LocalAppThemeProperties.current
+    val clipboard = LocalClipboardManager.current
+
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        shape = theme.cardShape,
+        elevation = CardDefaults.cardElevation(defaultElevation = theme.surfaceElevation),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    if (campaign.isHost) Icons.Default.Star else Icons.Default.Person,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp).padding(end = 4.dp)
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    campaign.name,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.weight(1f)
+                )
+                CampaignStatusChip(status = campaign.status)
+            }
+
+            if (!campaign.description.isNullOrBlank()) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(campaign.description, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text("${campaign.memberCount} members", style = MaterialTheme.typography.bodySmall)
+                Text(if (campaign.isHost) "You are the Chamberlain" else "Member", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
+            }
+
+            // Show join code with copy button for the host of an open campaign
+            if (campaign.isHost && campaign.joinCode != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        "Join code: ",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        campaign.joinCode,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    IconButton(
+                        onClick = { clipboard.setText(AnnotatedString(campaign.joinCode)) },
+                        modifier = Modifier.size(20.dp)
+                    ) {
+                        Icon(Icons.Default.ContentCopy, contentDescription = "Copy", modifier = Modifier.size(16.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PendingCampaignCard(campaign: OnlineCampaignSummary) {
+    val theme = LocalAppThemeProperties.current
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = theme.cardShape,
+        elevation = CardDefaults.cardElevation(defaultElevation = theme.surfaceElevation),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.5f),
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer
+        )
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                Icons.Default.HourglassTop,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.tertiary,
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    campaign.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    "Awaiting Chamberlain approval",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.tertiary
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CampaignStatusChip(status: String) {
+    val (label, color) = when (status) {
+        "OPEN"      -> "Open"      to MaterialTheme.colorScheme.primary
+        "LOCKED"    -> "Locked"    to MaterialTheme.colorScheme.tertiary
+        "DISBANDED" -> "Disbanded" to MaterialTheme.colorScheme.error
+        else        -> status      to MaterialTheme.colorScheme.outline
+    }
+    Surface(
+        shape = MaterialTheme.shapes.small,
+        color = color.copy(alpha = 0.12f)
+    ) {
+        Text(
+            label,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+            style = MaterialTheme.typography.labelSmall,
+            color = color
+        )
+    }
+}

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CampaignHubScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CampaignHubScreen.kt
@@ -1,0 +1,88 @@
+package io.github.garemat.lunachron.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.garemat.lunachron.CharacterState
+import io.github.garemat.lunachron.ui.theme.LocalAppThemeProperties
+
+@Composable
+fun CampaignHubScreen(
+    state: CharacterState,
+    onLocalTrackingSelected: () -> Unit,
+    onHostCampaignSelected: () -> Unit,
+    onJoinCampaignSelected: () -> Unit,
+    onActiveCampaignsSelected: () -> Unit
+) {
+    val isMoonstone = LocalAppThemeProperties.current.showExpandedStatsHeader
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Campaigns",
+            style = if (isMoonstone) MaterialTheme.typography.displayLarge.copy(fontSize = 32.sp)
+                    else MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            color = if (isMoonstone) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onBackground
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        SetupOptionCard(
+            title = "Local Tracking",
+            description = "Manage local campaign records and results.",
+            icon = Icons.Default.HistoryEdu,
+            backgroundType = "commonwealth",
+            onClick = onLocalTrackingSelected
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        SetupOptionCard(
+            title = "Host Campaign",
+            description = "I am the Wizard Chamberlain.",
+            icon = Icons.Default.AddCircle,
+            backgroundType = "dominion",
+            onClick = { if (state.isRegistered) onHostCampaignSelected() }
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        SetupOptionCard(
+            title = "Join Campaign",
+            description = "I'll be gathering the stones.",
+            icon = Icons.Default.GroupAdd,
+            backgroundType = "leshavult",
+            onClick = { if (state.isRegistered) onJoinCampaignSelected() }
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        SetupOptionCard(
+            title = "Active Campaigns",
+            description = "View and manage your online campaigns.",
+            icon = Icons.Default.Campaign,
+            backgroundType = "shades",
+            onClick = { if (state.isRegistered) onActiveCampaignsSelected() }
+        )
+
+        if (!state.isRegistered) {
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "Register your device in Settings to access online campaigns.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/app/src/main/java/io/github/garemat/lunachron/ui/HostOnlineCampaignScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/HostOnlineCampaignScreen.kt
@@ -1,0 +1,275 @@
+package io.github.garemat.lunachron.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.garemat.lunachron.CharacterEvent
+import io.github.garemat.lunachron.CharacterState
+import io.github.garemat.lunachron.OnlineCampaignSettings
+import io.github.garemat.lunachron.ui.theme.AppThemeProperties
+import io.github.garemat.lunachron.ui.theme.LocalAppThemeProperties
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HostOnlineCampaignScreen(
+    state: CharacterState,
+    onEvent: (CharacterEvent) -> Unit,
+    onNavigateBack: () -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    val clipboard = LocalClipboardManager.current
+
+    var name by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
+    var attacksEnabled by remember { mutableStateOf(true) }
+    var startingCharacters by remember { mutableIntStateOf(4) }
+    var characterGrowthEvery by remember { mutableIntStateOf(2) }
+    var upgradeGrowthEvery by remember { mutableIntStateOf(1) }
+
+    // Clear the created result when leaving so stale data doesn't re-show
+    DisposableEffect(Unit) { onDispose { onEvent(CharacterEvent.DismissCreatedCampaignResult) } }
+
+    // Show join code dialog on successful creation
+    if (state.createdCampaignResult != null) {
+        val joinCode = state.createdCampaignResult.joinCode
+        AlertDialog(
+            onDismissRequest = {},
+            title = { Text("Campaign created!", style = theme.headerStyle) },
+            text = {
+                Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.fillMaxWidth()) {
+                    Text("Share this join code with players:", style = MaterialTheme.typography.bodyMedium)
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = joinCode,
+                        style = MaterialTheme.typography.displaySmall.copy(
+                            fontWeight = FontWeight.Bold,
+                            letterSpacing = 8.sp
+                        ),
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedButton(
+                        onClick = { clipboard.setText(AnnotatedString(joinCode)) },
+                        shape = theme.cardShape
+                    ) {
+                        Icon(Icons.Default.ContentCopy, contentDescription = null, modifier = Modifier.padding(end = 8.dp))
+                        Text("Copy code")
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    onEvent(CharacterEvent.DismissCreatedCampaignResult)
+                    onNavigateBack()
+                }) {
+                    Text("Done")
+                }
+            }
+        )
+    }
+
+    // Error dialog
+    if (state.onlineCampaignError != null) {
+        AlertDialog(
+            onDismissRequest = { onEvent(CharacterEvent.DismissOnlineCampaignError) },
+            title = { Text("Could not create campaign", style = theme.headerStyle) },
+            text = { Text(state.onlineCampaignError, style = MaterialTheme.typography.bodyMedium) },
+            confirmButton = {
+                TextButton(onClick = { onEvent(CharacterEvent.DismissOnlineCampaignError) }) { Text("OK") }
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("New Campaign", style = theme.titleStyle) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    titleContentColor = MaterialTheme.colorScheme.primary,
+                    navigationIconContentColor = MaterialTheme.colorScheme.primary
+                )
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(theme.screenPadding)
+        ) {
+            // ── Campaign name ─────────────────────────────────────────────────
+            Text("Campaign Details", style = theme.titleStyle.copy(fontSize = 20.sp), color = MaterialTheme.colorScheme.primary)
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Campaign name") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                shape = theme.cardShape,
+                keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Words)
+            )
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+            OutlinedTextField(
+                value = description,
+                onValueChange = { description = it },
+                label = { Text("Description (optional)") },
+                modifier = Modifier.fillMaxWidth(),
+                minLines = 2,
+                maxLines = 4,
+                shape = theme.cardShape
+            )
+
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+
+            // ── Game rules ────────────────────────────────────────────────────
+            Text("Rules", style = theme.titleStyle.copy(fontSize = 20.sp), color = MaterialTheme.colorScheme.primary)
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Attacks enabled", style = theme.headerStyle.copy(fontSize = 18.sp))
+                    Text("Allow campaign attack and assault actions between rounds.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                Switch(checked = attacksEnabled, onCheckedChange = { attacksEnabled = it })
+            }
+
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+            StepperRow(
+                label = "Starting characters",
+                subtitle = "Number of characters each player begins the campaign with",
+                value = startingCharacters,
+                onDecrement = { if (startingCharacters > 3) startingCharacters-- },
+                onIncrement = { if (startingCharacters < 10) startingCharacters++ },
+                theme = theme
+            )
+
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+
+            Text("Troupe growth", style = theme.titleStyle.copy(fontSize = 20.sp), color = MaterialTheme.colorScheme.primary)
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+
+            StepperRow(
+                label = "New character every",
+                subtitle = "Rounds between each character unlock (0 = never)",
+                value = characterGrowthEvery,
+                onDecrement = { if (characterGrowthEvery > 0) characterGrowthEvery-- },
+                onIncrement = { characterGrowthEvery++ },
+                unit = "rounds",
+                theme = theme
+            )
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+            StepperRow(
+                label = "New upgrade every",
+                subtitle = "Rounds between each upgrade card unlock (0 = never)",
+                value = upgradeGrowthEvery,
+                onDecrement = { if (upgradeGrowthEvery > 0) upgradeGrowthEvery-- },
+                onIncrement = { upgradeGrowthEvery++ },
+                unit = "rounds",
+                theme = theme
+            )
+
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+
+            Button(
+                onClick = {
+                    onEvent(CharacterEvent.CreateOnlineCampaign(
+                        name = name.trim(),
+                        description = description.trim().takeIf { it.isNotEmpty() },
+                        settings = OnlineCampaignSettings(
+                            attacksEnabled = attacksEnabled,
+                            startingCharacters = startingCharacters,
+                            characterGrowthEvery = characterGrowthEvery,
+                            upgradeGrowthEvery = upgradeGrowthEvery
+                        )
+                    ))
+                },
+                enabled = name.isNotBlank() && !state.isCreatingCampaign,
+                modifier = Modifier.fillMaxWidth(),
+                shape = theme.cardShape
+            ) {
+                if (state.isCreatingCampaign) {
+                    CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Creating…", style = theme.buttonTextStyle)
+                } else {
+                    Text("Create Campaign", style = theme.buttonTextStyle)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(88.dp))
+        }
+    }
+}
+
+@Composable
+private fun StepperRow(
+    label: String,
+    value: Int,
+    onDecrement: () -> Unit,
+    onIncrement: () -> Unit,
+    theme: AppThemeProperties,
+    subtitle: String? = null,
+    unit: String? = null
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Column(modifier = Modifier.weight(1f).padding(end = 8.dp)) {
+            Text(label, style = theme.headerStyle.copy(fontSize = 16.sp))
+            if (subtitle != null) {
+                Text(subtitle, style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2, overflow = TextOverflow.Ellipsis)
+            }
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onDecrement) {
+                Text("−", style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.primary)
+            }
+            Text(
+                text = if (unit != null) "$value $unit" else "$value",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.widthIn(min = if (unit != null) 72.dp else 32.dp)
+            )
+            IconButton(onClick = onIncrement) {
+                Text("+", style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.primary)
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/github/garemat/lunachron/ui/JoinOnlineCampaignScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/JoinOnlineCampaignScreen.kt
@@ -1,0 +1,142 @@
+package io.github.garemat.lunachron.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.HourglassTop
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.garemat.lunachron.CharacterEvent
+import io.github.garemat.lunachron.CharacterState
+import io.github.garemat.lunachron.ui.theme.LocalAppThemeProperties
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun JoinOnlineCampaignScreen(
+    state: CharacterState,
+    onEvent: (CharacterEvent) -> Unit,
+    onNavigateBack: () -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    var joinCode by remember { mutableStateOf("") }
+
+    // Clear pending join state when leaving so stale data doesn't re-show
+    DisposableEffect(Unit) { onDispose { /* pendingJoinCampaignId naturally superseded on next join */ } }
+
+    // Error dialog
+    if (state.onlineCampaignError != null) {
+        AlertDialog(
+            onDismissRequest = { onEvent(CharacterEvent.DismissOnlineCampaignError) },
+            title = { Text("Could not join campaign", style = theme.headerStyle) },
+            text = { Text(state.onlineCampaignError, style = MaterialTheme.typography.bodyMedium) },
+            confirmButton = {
+                TextButton(onClick = { onEvent(CharacterEvent.DismissOnlineCampaignError) }) { Text("OK") }
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Join Campaign", style = theme.titleStyle) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    titleContentColor = MaterialTheme.colorScheme.primary,
+                    navigationIconContentColor = MaterialTheme.colorScheme.primary
+                )
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(theme.screenPadding),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            if (state.pendingJoinCampaignId != null) {
+                // ── Request sent state ────────────────────────────────────────
+                Icon(
+                    Icons.Default.HourglassTop,
+                    contentDescription = null,
+                    modifier = Modifier.size(64.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    "Request sent!",
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    "The Wizard Chamberlain will review your request. Once approved you'll appear in the Active Campaigns list.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                OutlinedButton(onClick = onNavigateBack, shape = theme.cardShape) {
+                    Text("Done")
+                }
+            } else {
+                // ── Code entry state ──────────────────────────────────────────
+                Text(
+                    "Enter join code",
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    "Ask the Wizard Chamberlain for the 6-character code.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                OutlinedTextField(
+                    value = joinCode,
+                    onValueChange = { joinCode = it.uppercase().take(6) },
+                    label = { Text("Join code") },
+                    modifier = Modifier.widthIn(max = 240.dp).fillMaxWidth(),
+                    singleLine = true,
+                    shape = theme.cardShape,
+                    textStyle = MaterialTheme.typography.headlineMedium.copy(
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = 6.sp,
+                        textAlign = TextAlign.Center
+                    )
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                Button(
+                    onClick = { onEvent(CharacterEvent.RequestJoinCampaign(joinCode)) },
+                    enabled = joinCode.length == 6 && !state.isJoiningCampaign,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = theme.cardShape
+                ) {
+                    if (state.isJoiningCampaign) {
+                        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Sending request…", style = theme.buttonTextStyle)
+                    } else {
+                        Text("Request to join", style = theme.buttonTextStyle)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
@@ -1,0 +1,2583 @@
+package io.github.garemat.lunachron.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import io.github.garemat.lunachron.CampaignRound
+import io.github.garemat.lunachron.Character
+import io.github.garemat.lunachron.CharacterEvent
+import io.github.garemat.lunachron.CharacterState
+import io.github.garemat.lunachron.Faction
+import io.github.garemat.lunachron.CampaignCard
+import io.github.garemat.lunachron.OnlineCampaignDetail
+import io.github.garemat.lunachron.OnlineCampaignMember
+import io.github.garemat.lunachron.OnlineMachinationAttack
+import io.github.garemat.lunachron.OnlineMachinationChoice
+import io.github.garemat.lunachron.OnlineMachinationEntry
+import io.github.garemat.lunachron.OnlineMatchResult
+import io.github.garemat.lunachron.OnlinePlayerStat
+import io.github.garemat.lunachron.Troupe
+import io.github.garemat.lunachron.UpgradeCard
+import io.github.garemat.lunachron.ui.theme.LocalAppThemeProperties
+
+// ── Campaign phase detection ──────────────────────────────────────────────────
+
+private enum class CampaignPhase {
+    RECRUITING,         // OPEN
+    TROUPE_SELECTION,   // LOCKED + not all ready
+    SCHEDULE_PENDING,   // LOCKED + all ready + no schedule
+    ACTIVE              // LOCKED + schedule published
+}
+
+private fun detectPhase(campaign: OnlineCampaignDetail): CampaignPhase {
+    if (campaign.status != "LOCKED") return CampaignPhase.RECRUITING
+    if (campaign.schedule != null) return CampaignPhase.ACTIVE
+    val approved = campaign.members.filter { it.status == "APPROVED" }
+    val allReady = approved.isNotEmpty() && approved.all { it.isReady }
+    return if (allReady) CampaignPhase.SCHEDULE_PENDING else CampaignPhase.TROUPE_SELECTION
+}
+
+private enum class ActiveTab { RANKINGS, SCHEDULE, MACHINATIONS }
+
+// ── Main screen ───────────────────────────────────────────────────────────────
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OnlineCampaignDetailScreen(
+    campaignId: String,
+    state: CharacterState,
+    onEvent: (CharacterEvent) -> Unit,
+    onNavigateBack: () -> Unit,
+    /** Decode a base64 troupe share code into a Troupe object (from ViewModel). */
+    onDecodeTroupe: (String) -> Troupe?,
+    /** Encode a Troupe to its share code for uploading. */
+    onEncodeTroupe: (Troupe) -> String
+) {
+    val theme = LocalAppThemeProperties.current
+
+    LaunchedEffect(campaignId) { onEvent(CharacterEvent.LoadOnlineCampaign(campaignId)) }
+    DisposableEffect(Unit) { onDispose { onEvent(CharacterEvent.ClearSelectedOnlineCampaign) } }
+
+    val campaign = state.selectedOnlineCampaign
+    val isHost = campaign?.currentUserRole == "HOST"
+    val approvedMembers = campaign?.members?.filter { it.status == "APPROVED" } ?: emptyList()
+    val phase = campaign?.let { detectPhase(it) } ?: CampaignPhase.RECRUITING
+
+    var showAdminPanel by remember { mutableStateOf(false) }
+    if (showAdminPanel && campaign != null) {
+        AdminPanelSheet(
+            campaign = campaign,
+            state = state,
+            onEvent = onEvent,
+            onDismiss = { showAdminPanel = false },
+            onDecodeTroupe = onDecodeTroupe,
+            onEncodeTroupe = onEncodeTroupe
+        )
+    }
+
+    var showDeleteDialog by remember { mutableStateOf(false) }
+    if (showDeleteDialog && campaign != null) {
+        DeleteCampaignDialog(
+            campaignName = campaign.name,
+            isDeleting = state.isDeletingCampaign,
+            onConfirm = { onEvent(CharacterEvent.DeleteOnlineCampaign(campaign.id)) },
+            onDismiss = { showDeleteDialog = false }
+        )
+    }
+
+    // Navigate back after successful deletion
+    LaunchedEffect(state.onlineCampaignDeleted) {
+        if (state.onlineCampaignDeleted) {
+            onEvent(CharacterEvent.DismissCampaignDeleted)
+            onNavigateBack()
+        }
+    }
+
+    // Default round count when members first load
+    LaunchedEffect(approvedMembers.size) {
+        if (state.onlineScheduleRoundCount == 0 && approvedMembers.size >= 2) {
+            val n = approvedMembers.size
+            onEvent(CharacterEvent.SetOnlineScheduleRoundCount(if (n % 2 == 0) n - 1 else n))
+        }
+    }
+
+    if (state.onlineCampaignError != null) {
+        AlertDialog(
+            onDismissRequest = { onEvent(CharacterEvent.DismissOnlineCampaignError) },
+            title = { Text("Error", style = theme.headerStyle) },
+            text = { Text(state.onlineCampaignError, style = MaterialTheme.typography.bodyMedium) },
+            confirmButton = {
+                TextButton(onClick = { onEvent(CharacterEvent.DismissOnlineCampaignError) }) { Text("OK") }
+            }
+        )
+    }
+
+    if (state.matchResultSubmitted) {
+        AlertDialog(
+            onDismissRequest = { onEvent(CharacterEvent.DismissMatchResultSubmitted) },
+            icon = { Icon(Icons.Default.CheckCircle, contentDescription = null, tint = MaterialTheme.colorScheme.primary) },
+            title = { Text("Result Submitted") },
+            text = { Text("Your result has been submitted. Waiting for your opponent to verify it.") },
+            confirmButton = {
+                TextButton(onClick = { onEvent(CharacterEvent.DismissMatchResultSubmitted) }) { Text("OK") }
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(campaign?.name ?: "Campaign", style = theme.titleStyle) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    if (isHost) {
+                        IconButton(onClick = { showAdminPanel = true }) {
+                            Icon(Icons.Default.AdminPanelSettings, contentDescription = "Admin",
+                                tint = MaterialTheme.colorScheme.tertiary)
+                        }
+                        IconButton(onClick = { showDeleteDialog = true }) {
+                            Icon(Icons.Default.DeleteForever, contentDescription = "Delete campaign",
+                                tint = MaterialTheme.colorScheme.error)
+                        }
+                    }
+                    IconButton(onClick = { onEvent(CharacterEvent.LoadOnlineCampaign(campaignId)) }) {
+                        Icon(Icons.Default.Refresh, contentDescription = "Refresh", tint = MaterialTheme.colorScheme.primary)
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    titleContentColor = MaterialTheme.colorScheme.primary,
+                    navigationIconContentColor = MaterialTheme.colorScheme.primary
+                )
+            )
+        }
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when {
+                state.isLoadingCampaignDetail && campaign == null -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+                campaign == null -> {
+                    Text("Campaign not found.", modifier = Modifier.align(Alignment.Center),
+                        style = theme.headerStyle, color = MaterialTheme.colorScheme.outline)
+                }
+                phase == CampaignPhase.ACTIVE -> {
+                    ActiveCampaignHome(
+                        campaign = campaign,
+                        state = state,
+                        isHost = isHost,
+                        onEvent = onEvent,
+                        onDecodeTroupe = onDecodeTroupe
+                    )
+                }
+                else -> {
+                    PreGamePhaseContent(
+                        campaign = campaign,
+                        state = state,
+                        campaignId = campaignId,
+                        phase = phase,
+                        isHost = isHost,
+                        approvedMembers = approvedMembers,
+                        onEvent = onEvent,
+                        onDecodeTroupe = onDecodeTroupe,
+                        onEncodeTroupe = onEncodeTroupe
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ── Pre-game phases (Recruiting, Troupe Selection, Schedule Pending) ──────────
+
+@Composable
+private fun PreGamePhaseContent(
+    campaign: OnlineCampaignDetail,
+    state: CharacterState,
+    campaignId: String,
+    phase: CampaignPhase,
+    isHost: Boolean,
+    approvedMembers: List<OnlineCampaignMember>,
+    onEvent: (CharacterEvent) -> Unit,
+    onDecodeTroupe: (String) -> Troupe?,
+    onEncodeTroupe: (Troupe) -> String
+) {
+    val theme = LocalAppThemeProperties.current
+    val pending = campaign.members.filter { it.status == "PENDING" }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(theme.screenPadding),
+        verticalArrangement = Arrangement.spacedBy(theme.verticalSpacing)
+    ) {
+        // Campaign info
+        item { CampaignInfoCard(campaign = campaign) }
+
+        // Lock / Unlock (host, OPEN or LOCKED pre-schedule)
+        if (isHost) {
+            item {
+                Spacer(Modifier.height(4.dp))
+                LockUnlockSection(
+                    campaign = campaign,
+                    isLoading = state.isLockingCampaign,
+                    pendingCount = pending.size,
+                    onLock = { onEvent(CharacterEvent.LockOnlineCampaign(campaignId)) },
+                    onUnlock = { onEvent(CharacterEvent.UnlockOnlineCampaign(campaignId)) }
+                )
+            }
+        }
+
+        // Pending member requests (host, OPEN)
+        if (isHost && phase == CampaignPhase.RECRUITING && pending.isNotEmpty()) {
+            item {
+                Spacer(Modifier.height(4.dp))
+                Text("Pending Requests", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.tertiary)
+            }
+            items(pending) { member ->
+                PendingMemberCard(member = member, campaignId = campaignId,
+                    isProcessing = state.isApprovingMember, onEvent = onEvent)
+            }
+        }
+
+        // Troupe selection section (when LOCKED)
+        if (phase == CampaignPhase.TROUPE_SELECTION || phase == CampaignPhase.SCHEDULE_PENDING) {
+            item {
+                Spacer(Modifier.height(4.dp))
+                TroupeSelectionSection(
+                    campaign = campaign,
+                    state = state,
+                    campaignId = campaignId,
+                    approvedMembers = approvedMembers,
+                    onEvent = onEvent,
+                    onDecodeTroupe = onDecodeTroupe,
+                    onEncodeTroupe = onEncodeTroupe
+                )
+            }
+        }
+
+        // Schedule generation (host, all ready, no schedule)
+        if (phase == CampaignPhase.SCHEDULE_PENDING) {
+            item {
+                Spacer(Modifier.height(4.dp))
+                if (isHost) {
+                    ScheduleGenerationSection(
+                        state = state,
+                        campaignId = campaignId,
+                        approvedMembers = approvedMembers,
+                        onEvent = onEvent
+                    )
+                } else {
+                    WaitingCard(text = "The Chamberlain is preparing the schedule.")
+                }
+            }
+        }
+    }
+}
+
+// ── Troupe selection section ──────────────────────────────────────────────────
+
+@Composable
+private fun TroupeSelectionSection(
+    campaign: OnlineCampaignDetail,
+    state: CharacterState,
+    campaignId: String,
+    approvedMembers: List<OnlineCampaignMember>,
+    onEvent: (CharacterEvent) -> Unit,
+    onDecodeTroupe: (String) -> Troupe?,
+    onEncodeTroupe: (Troupe) -> String
+) {
+    val theme = LocalAppThemeProperties.current
+    val myDeviceId = state.backendDeviceId // current device's ID in state
+    val myMember = approvedMembers.find { it.deviceId == myDeviceId }
+    val allReady = approvedMembers.isNotEmpty() && approvedMembers.all { it.isReady }
+
+    // Troupe picker dialog
+    var showTroupePicker by remember { mutableStateOf(false) }
+    // Member detail dialog (tap to see troupe)
+    var viewingMember by remember { mutableStateOf<OnlineCampaignMember?>(null) }
+
+    if (showTroupePicker) {
+        TroupePickerDialog(
+            troupes = state.troupes,
+            onDismiss = { showTroupePicker = false },
+            onSelect = { troupe ->
+                showTroupePicker = false
+                val encoded = onEncodeTroupe(troupe)
+                onEvent(CharacterEvent.UploadOnlineTroupe(campaignId, encoded))
+            }
+        )
+    }
+
+    viewingMember?.let { member ->
+        val troupe = member.troupeData?.let { onDecodeTroupe(it) }
+        MemberTroupeDialog(
+            member = member,
+            troupe = troupe,
+            characters = state.characters,
+            onDismiss = { viewingMember = null }
+        )
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = theme.cardShape,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Icon(Icons.Default.Groups, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Troupe Selection", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+                    val readyCount = approvedMembers.count { it.isReady }
+                    Text("$readyCount / ${approvedMembers.size} ready", style = MaterialTheme.typography.bodySmall,
+                        color = if (allReady) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+
+            // My troupe + ready controls
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(
+                    onClick = { showTroupePicker = true },
+                    enabled = !state.isUploadingTroupe,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    if (state.isUploadingTroupe) {
+                        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                    } else {
+                        Icon(Icons.Default.Upload, contentDescription = null, modifier = Modifier.size(16.dp))
+                        Spacer(Modifier.width(4.dp))
+                        Text(if (myMember?.troupeData != null) "Change Troupe" else "Select Troupe",
+                            maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    }
+                }
+                Button(
+                    onClick = { onEvent(CharacterEvent.SetOnlineCampaignReady(campaignId, !(myMember?.isReady ?: false))) },
+                    enabled = myMember?.troupeData != null && !state.isSettingReady,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = if (myMember?.isReady == true) MaterialTheme.colorScheme.tertiary
+                        else MaterialTheme.colorScheme.primary
+                    )
+                ) {
+                    if (state.isSettingReady) {
+                        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
+                    } else {
+                        Text(if (myMember?.isReady == true) "Unready" else "Ready!")
+                    }
+                }
+            }
+
+            HorizontalDivider()
+
+            // Member list with troupe status
+            approvedMembers.forEach { member ->
+                val troupe = member.troupeData?.let { runCatching { onDecodeTroupe(it) }.getOrNull() }
+                MemberTroupeRow(
+                    member = member,
+                    troupe = troupe,
+                    characters = state.characters,
+                    onClick = { viewingMember = member }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MemberTroupeRow(
+    member: OnlineCampaignMember,
+    troupe: Troupe?,
+    characters: List<Character>,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        // Ready indicator
+        Icon(
+            if (member.isReady) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked,
+            contentDescription = null,
+            tint = if (member.isReady) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(18.dp)
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(member.username, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
+                if (member.isLocal) {
+                    Text("Local", style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.tertiary,
+                        modifier = Modifier.background(
+                            MaterialTheme.colorScheme.tertiaryContainer,
+                            shape = MaterialTheme.shapes.extraSmall
+                        ).padding(horizontal = 4.dp, vertical = 1.dp))
+                }
+            }
+            if (troupe != null) {
+                Text(troupe.troupeName, style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+            } else {
+                Text("No troupe set", style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f))
+            }
+        }
+        // Character portrait row (up to 4)
+        if (troupe != null) {
+            Row(horizontalArrangement = Arrangement.spacedBy((-6).dp)) {
+                troupe.characterIds.take(4).forEach { charId ->
+                    val char = characters.find { it.id == charId }
+                    if (char != null) {
+                        CharacterPortrait(character = char, size = 28.dp,
+                            modifier = Modifier.clip(CircleShape))
+                    } else {
+                        Box(modifier = Modifier.size(28.dp).clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TroupePickerDialog(
+    troupes: List<io.github.garemat.lunachron.Troupe>,
+    onDismiss: () -> Unit,
+    onSelect: (io.github.garemat.lunachron.Troupe) -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Select Your Troupe") },
+        text = {
+            if (troupes.isEmpty()) {
+                Text("No troupes found. Create a troupe in the Troupes section first.")
+            } else {
+                LazyColumn {
+                    items(troupes) { troupe ->
+                        TextButton(onClick = { onSelect(troupe) }, modifier = Modifier.fillMaxWidth()) {
+                            Text(troupe.troupeName, modifier = Modifier.weight(1f))
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = { TextButton(onClick = onDismiss) { Text("Cancel") } }
+    )
+}
+
+@Composable
+private fun MemberTroupeDialog(
+    member: OnlineCampaignMember,
+    troupe: Troupe?,
+    characters: List<Character>,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(member.username, style = MaterialTheme.typography.titleMedium) },
+        text = {
+            if (troupe == null) {
+                Text("No troupe has been shared yet.")
+            } else {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(troupe.troupeName, style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
+                    Text(troupe.faction.name.lowercase().replaceFirstChar { it.uppercase() },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Spacer(Modifier.height(4.dp))
+                    troupe.characterIds.forEach { charId ->
+                        val char = characters.find { it.id == charId }
+                        if (char != null) {
+                            Row(verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                CharacterPortrait(character = char, size = 40.dp)
+                                Text(char.name, style = MaterialTheme.typography.bodyMedium)
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = { TextButton(onClick = onDismiss) { Text("Close") } }
+    )
+}
+
+// ── Active campaign home (tabs) ───────────────────────────────────────────────
+
+@Composable
+private fun ActiveCampaignHome(
+    campaign: OnlineCampaignDetail,
+    state: CharacterState,
+    isHost: Boolean,
+    onEvent: (CharacterEvent) -> Unit,
+    onDecodeTroupe: (String) -> Troupe?
+) {
+    val theme = LocalAppThemeProperties.current
+    var activeTab by remember { mutableStateOf(ActiveTab.RANKINGS) }
+
+    val inMachinationsPhase = campaign.phase == "MACHINATIONS"
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        // Tab row
+        TabRow(selectedTabIndex = activeTab.ordinal, containerColor = MaterialTheme.colorScheme.surfaceVariant) {
+            ActiveTab.entries.forEach { tab ->
+                Tab(
+                    selected = activeTab == tab,
+                    onClick = { activeTab = tab },
+                    text = {
+                        Text(when (tab) {
+                            ActiveTab.RANKINGS    -> "Rankings"
+                            ActiveTab.SCHEDULE    -> "Schedule"
+                            ActiveTab.MACHINATIONS -> if (inMachinationsPhase) "Machinations" else "Submit"
+                        }, style = MaterialTheme.typography.labelMedium)
+                    },
+                    icon = {
+                        Icon(when (tab) {
+                            ActiveTab.RANKINGS    -> Icons.Default.EmojiEvents
+                            ActiveTab.SCHEDULE    -> Icons.Default.CalendarMonth
+                            ActiveTab.MACHINATIONS -> if (inMachinationsPhase) Icons.Default.Star else Icons.Default.Send
+                        }, contentDescription = null, modifier = Modifier.size(18.dp))
+                    }
+                )
+            }
+        }
+
+        when (activeTab) {
+            ActiveTab.RANKINGS    -> OnlineRankingsTab(
+                campaign = campaign, state = state, isHost = isHost, onEvent = onEvent, onDecodeTroupe = onDecodeTroupe)
+            ActiveTab.SCHEDULE    -> OnlineScheduleTabContent(
+                campaign = campaign,
+                showCurrentRoundScores = inMachinationsPhase
+            )
+            ActiveTab.MACHINATIONS -> if (inMachinationsPhase) {
+                OnlineMachinationsTab(campaign = campaign, state = state, onEvent = onEvent, onDecodeTroupe = onDecodeTroupe)
+            } else {
+                OnlineResultsTab(campaign = campaign, state = state, onEvent = onEvent, onDecodeTroupe = onDecodeTroupe)
+            }
+        }
+    }
+}
+
+// ── Rankings tab ──────────────────────────────────────────────────────────────
+
+@Composable
+private fun OnlineRankingsTab(
+    campaign: OnlineCampaignDetail,
+    state: CharacterState,
+    isHost: Boolean,
+    onEvent: (CharacterEvent) -> Unit,
+    onDecodeTroupe: (String) -> Troupe?
+) {
+    val theme = LocalAppThemeProperties.current
+    val approved = campaign.members.filter { it.status == "APPROVED" }
+        .sortedByDescending { it.powerPoints }
+
+    if (approved.isEmpty()) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("No ranking data yet.", color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        return
+    }
+
+    val n = approved.size
+    val tierSize = (n / 3).coerceAtLeast(1)
+    val topBoundary = approved[tierSize - 1].powerPoints
+    val actualTop = approved.count { it.powerPoints >= topBoundary }
+    val remaining = approved.drop(actualTop)
+    val bottomIdx = (remaining.size - tierSize).coerceAtLeast(0)
+    val bottomBoundary = remaining.getOrNull(bottomIdx)?.powerPoints ?: Int.MIN_VALUE
+    val prevBoundary = remaining.getOrNull(bottomIdx - 1)?.powerPoints
+    val tiedAtBottom = prevBoundary == bottomBoundary
+    fun tier(pp: Int) = when {
+        pp >= topBoundary -> "Top"
+        tiedAtBottom && pp == bottomBoundary -> "Middle"
+        pp <= bottomBoundary -> "Bottom"
+        else -> "Middle"
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(theme.screenPadding),
+        verticalArrangement = Arrangement.spacedBy(theme.verticalSpacing)
+    ) {
+        // Header
+        item {
+            Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 2.dp),
+                verticalAlignment = Alignment.CenterVertically) {
+                Spacer(Modifier.width(52.dp))
+                Spacer(Modifier.weight(1f))
+                Spacer(Modifier.width(8.dp))
+                listOf("W" to theme.positiveColor, "D" to MaterialTheme.colorScheme.onSurfaceVariant, "L" to MaterialTheme.colorScheme.error).forEach { (lbl, clr) ->
+                    Box(Modifier.width(32.dp), Alignment.Center) {
+                        Text(lbl, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold, color = clr)
+                    }
+                }
+                Spacer(Modifier.width(12.dp))
+                Box(Modifier.width(48.dp), Alignment.CenterEnd) {
+                    Text("PP", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        }
+
+        // Tier sections
+        val tiers = listOf(
+            Triple("Top Tier", theme.rankingGoldColor, Icons.Default.KeyboardArrowUp),
+            Triple("Middle Tier", theme.rankingSilverColor, Icons.Default.Remove),
+            Triple("Bottom Tier", theme.rankingBronzeColor, Icons.Default.KeyboardArrowDown)
+        )
+        val tierNames = listOf("Top", "Middle", "Bottom")
+        val positions = approved.mapIndexed { i, m -> m.deviceId to i + 1 }.toMap()
+
+        tierNames.zip(tiers).forEach { (tierName, tierInfo) ->
+            val tierMembers = approved.filter { tier(it.powerPoints) == tierName }
+            if (tierMembers.isNotEmpty()) {
+                item {
+                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(vertical = 2.dp)) {
+                        Icon(tierInfo.third, contentDescription = null, tint = tierInfo.second, modifier = Modifier.size(18.dp))
+                        Spacer(Modifier.width(6.dp))
+                        Text(tierInfo.first, style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Bold, color = tierInfo.second)
+                    }
+                }
+                itemsIndexed(tierMembers) { idx, member ->
+                    OnlineRankingCard(member = member, position = positions[member.deviceId] ?: 0,
+                        rankColor = tierInfo.second, rowIndex = idx, theme = theme)
+                }
+            }
+        }
+
+    }
+}
+
+@Composable
+private fun OnlineRankingCard(
+    member: OnlineCampaignMember,
+    position: Int,
+    rankColor: Color,
+    rowIndex: Int,
+    theme: io.github.garemat.lunachron.ui.theme.AppThemeProperties
+) {
+    val bgAlpha = if (rowIndex % 2 == 0) 0.07f else 0.13f
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = theme.cardShape,
+        colors = CardDefaults.cardColors(containerColor = rankColor.copy(alpha = bgAlpha))
+    ) {
+        Row(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp), verticalAlignment = Alignment.CenterVertically) {
+            Box(Modifier.size(40.dp), Alignment.Center) {
+                if (position == 1) Icon(Icons.Default.EmojiEvents, "1st", tint = rankColor, modifier = Modifier.size(30.dp))
+                else Text("#$position", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.ExtraBold, color = rankColor)
+            }
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(member.username, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold,
+                    maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("${member.victoryPoints} VP", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    if (member.matchPoints > 0) {
+                        Text("+${member.matchPoints} MP", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.tertiary)
+                    }
+                }
+            }
+            Spacer(Modifier.width(8.dp))
+            Box(Modifier.width(32.dp), Alignment.Center) { Text("${member.wins}", style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.Bold, color = theme.positiveColor) }
+            Box(Modifier.width(32.dp), Alignment.Center) { Text("${member.draws}", style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+            Box(Modifier.width(32.dp), Alignment.Center) { Text("${member.losses}", style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.error) }
+            Spacer(Modifier.width(12.dp))
+            Box(Modifier.width(48.dp), Alignment.CenterEnd) {
+                Text("${member.powerPoints}", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.ExtraBold, color = MaterialTheme.colorScheme.onSurface)
+            }
+        }
+    }
+}
+
+// ── Schedule tab ──────────────────────────────────────────────────────────────
+
+@Composable
+private fun OnlineScheduleTabContent(campaign: OnlineCampaignDetail, showCurrentRoundScores: Boolean = false) {
+    val theme = LocalAppThemeProperties.current
+    val schedule = campaign.schedule
+    if (schedule == null) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("Schedule not yet published.", color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        return
+    }
+
+    val sortedRounds = schedule.entries
+        .mapNotNull { (key, games) -> key.removePrefix("round").toIntOrNull()?.let { it to games } }
+        .sortedBy { it.first }
+
+    var expandedRounds by remember { mutableStateOf(setOf(campaign.currentRound)) }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(theme.screenPadding),
+        verticalArrangement = Arrangement.spacedBy(theme.verticalSpacing)
+    ) {
+        items(sortedRounds) { (roundNum, games) ->
+            val isExpanded = roundNum in expandedRounds
+            val isCurrent = roundNum == campaign.currentRound
+            val sortedGames = games.entries.sortedBy { it.key }
+
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = theme.cardShape,
+                colors = CardDefaults.cardColors(
+                    containerColor = if (isCurrent)
+                        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+                    else MaterialTheme.colorScheme.surfaceVariant
+                )
+            ) {
+                Column {
+                    Row(
+                        modifier = Modifier.fillMaxWidth()
+                            .clickable { expandedRounds = if (isExpanded) expandedRounds - roundNum else expandedRounds + roundNum }
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(Modifier.weight(1f)) {
+                            Text(
+                                "Round $roundNum${if (isCurrent) " — Current" else ""}",
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.Bold,
+                                color = if (isCurrent) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+                            )
+                            Text("${sortedGames.size} game(s)", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                        Icon(if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore, null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                    if (isExpanded) {
+                        HorizontalDivider()
+                        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                            sortedGames.forEach { (gameKey, playerIds) ->
+                                val gameNum = gameKey.removePrefix("game").toIntOrNull() ?: 0
+                                val p1Id = playerIds.getOrNull(0)
+                                val p2Id = playerIds.getOrNull(1)
+                                val p1Name = campaign.members.find { it.deviceId == p1Id }?.username ?: "?"
+                                val p2Name = campaign.members.find { it.deviceId == p2Id }?.username ?: "?"
+                                val roundComplete = roundNum < campaign.currentRound ||
+                                    (roundNum == campaign.currentRound && showCurrentRoundScores)
+                                val result = if (roundComplete) campaign.matchResults.firstOrNull {
+                                    it.roundNumber == roundNum && it.gameNumber == gameNum
+                                } else null
+                                GameResultRow(
+                                    p1Name = p1Name,
+                                    p2Name = p2Name,
+                                    result = result,
+                                    p1Id = p1Id,
+                                    p2Id = p2Id
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GameResultRow(
+    p1Name: String,
+    p2Name: String,
+    result: OnlineMatchResult?,
+    p1Id: String?,
+    p2Id: String?
+) {
+    if (result == null) {
+        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            Text(p1Name, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Medium)
+            Text("vs", style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 8.dp))
+            Text(p2Name, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Medium)
+        }
+        return
+    }
+
+    val p1Stats = result.resultData?.playerStats?.find { it.deviceId == p1Id }
+    val p2Stats = result.resultData?.playerStats?.find { it.deviceId == p2Id }
+    val p1Vp = (p1Stats?.moonstones ?: 0) + (p1Stats?.campaignCardVp ?: 0)
+    val p2Vp = (p2Stats?.moonstones ?: 0) + (p2Stats?.campaignCardVp ?: 0)
+    val p1Won = result.winnerId == p1Id
+    val p2Won = result.winnerId == p2Id
+    val isDraw = result.winnerId == null
+
+    val statusColor = when (result.verifyStatus) {
+        "VERIFIED" -> MaterialTheme.colorScheme.primary
+        "DISPUTED" -> MaterialTheme.colorScheme.error
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.small,
+        colors = CardDefaults.cardColors(
+            containerColor = when (result.verifyStatus) {
+                "DISPUTED" -> MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.25f)
+                "VERIFIED" -> MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.18f)
+                else -> MaterialTheme.colorScheme.surface
+            }
+        )
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            // Score row: P1 name | VP — VP | P2 name
+            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    p1Name,
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = if (p1Won) FontWeight.Bold else FontWeight.Normal,
+                    color = if (p1Won) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    "$p1Vp — $p2Vp",
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(horizontal = 8.dp)
+                )
+                Text(
+                    p2Name,
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = if (p2Won) FontWeight.Bold else FontWeight.Normal,
+                    color = if (p2Won) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+                )
+            }
+            // Status row
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                Icon(
+                    when (result.verifyStatus) {
+                        "VERIFIED" -> Icons.Default.CheckCircle
+                        "DISPUTED" -> Icons.Default.Warning
+                        else -> Icons.Default.HourglassTop
+                    },
+                    contentDescription = null,
+                    modifier = Modifier.size(11.dp),
+                    tint = statusColor
+                )
+                Text(
+                    when {
+                        result.verifyStatus == "VERIFIED" && isDraw  -> "Draw · Verified"
+                        result.verifyStatus == "VERIFIED" && p1Won   -> "$p1Name won · Verified"
+                        result.verifyStatus == "VERIFIED" && p2Won   -> "$p2Name won · Verified"
+                        result.verifyStatus == "VERIFIED"            -> "Verified"
+                        result.verifyStatus == "DISPUTED"            -> "Disputed · Contact Chamberlain"
+                        else                                         -> "Pending verification"
+                    },
+                    style = MaterialTheme.typography.labelSmall,
+                    color = statusColor
+                )
+            }
+        }
+    }
+}
+
+// ── Record Results tab ────────────────────────────────────────────────────────
+
+@Composable
+private fun OnlineResultsTab(
+    campaign: OnlineCampaignDetail,
+    state: CharacterState,
+    onEvent: (CharacterEvent) -> Unit,
+    onDecodeTroupe: (String) -> Troupe?
+) {
+    val myDeviceId = state.backendDeviceId
+    val currentRound = campaign.currentRound
+    val roundKey = "round$currentRound"
+    val games = campaign.schedule?.get(roundKey) ?: emptyMap()
+
+    // Find this player's game in the current round
+    val myGameEntry = games.entries.firstOrNull { (_, players) -> myDeviceId in players }
+    val myGameNumber = myGameEntry?.key?.removePrefix("game")?.toIntOrNull() ?: 0
+    val myGamePlayers = myGameEntry?.value ?: emptyList()
+
+    val opponentId = myGamePlayers.firstOrNull { it != myDeviceId }
+    val opponentMember = campaign.members.find { it.deviceId == opponentId }
+    val myMember = campaign.members.find { it.deviceId == myDeviceId }
+
+    // Find any existing match result for this game
+    val existingResult = campaign.matchResults.firstOrNull {
+        it.roundNumber == currentRound && it.gameNumber == myGameNumber
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        when {
+            myGameEntry == null -> {
+                Column(
+                    modifier = Modifier.align(Alignment.Center).padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Icon(Icons.Default.Pause, null, Modifier.size(48.dp), tint = MaterialTheme.colorScheme.outline)
+                    Spacer(Modifier.height(8.dp))
+                    Text("No game scheduled for you in Round $currentRound.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("You have a bye this round.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+            existingResult == null -> {
+                // No result yet — show submission form
+                RecordResultCard(
+                    campaignId = campaign.id,
+                    roundNumber = currentRound,
+                    gameNumber = myGameNumber,
+                    myMember = myMember,
+                    opponentMember = opponentMember,
+                    myDeviceId = myDeviceId,
+                    campaignCards = state.campaignCards,
+                    isSubmitting = state.isSubmittingMatchResult,
+                    onDecodeTroupe = onDecodeTroupe,
+                    onEvent = onEvent
+                )
+            }
+            existingResult.verifyStatus == "VERIFIED" -> {
+                ResultStatusCard(
+                    roundNumber = currentRound,
+                    gameNumber = myGameNumber,
+                    result = existingResult,
+                    myMember = myMember,
+                    opponentMember = opponentMember,
+                    myDeviceId = myDeviceId
+                )
+            }
+            existingResult.verifyStatus == "DISPUTED" -> {
+                DisputedResultCard(
+                    roundNumber = currentRound,
+                    gameNumber = myGameNumber,
+                    result = existingResult,
+                    myMember = myMember,
+                    opponentMember = opponentMember,
+                    myDeviceId = myDeviceId
+                )
+            }
+            existingResult.submittedBy == myDeviceId -> {
+                // I submitted — waiting for opponent
+                WaitingVerificationCard(
+                    roundNumber = currentRound,
+                    gameNumber = myGameNumber,
+                    result = existingResult,
+                    myMember = myMember,
+                    opponentMember = opponentMember,
+                    myDeviceId = myDeviceId,
+                    onRefresh = { onEvent(CharacterEvent.LoadOnlineCampaign(campaign.id)) }
+                )
+            }
+            else -> {
+                // Opponent submitted — I need to verify
+                VerifyResultCard(
+                    campaignId = campaign.id,
+                    roundNumber = currentRound,
+                    gameNumber = myGameNumber,
+                    result = existingResult,
+                    myMember = myMember,
+                    opponentMember = opponentMember,
+                    myDeviceId = myDeviceId,
+                    isVerifying = state.isVerifyingMatchResult,
+                    onEvent = onEvent
+                )
+            }
+        }
+    }
+}
+
+// ── Machinations phase tab ────────────────────────────────────────────────────
+
+/** Composable for one SUPPORT/SABOTAGE entry in the machination form. */
+@Composable
+private fun MachinationChoiceRow(
+    index: Int,
+    choice: OnlineMachinationChoice?,
+    otherMembers: List<OnlineCampaignMember>,
+    onChoiceChanged: (OnlineMachinationChoice?) -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    val selectedTarget = choice?.targetDeviceId ?: ""
+    val selectedType = choice?.type ?: "SUPPORT"
+
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text("Machination ${index + 1}", style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant)
+        // Target picker
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            FilterChip(
+                selected = choice == null,
+                onClick = { onChoiceChanged(null) },
+                label = { Text("None", style = MaterialTheme.typography.labelSmall) }
+            )
+            otherMembers.forEach { member ->
+                FilterChip(
+                    selected = selectedTarget == member.deviceId,
+                    onClick = {
+                        onChoiceChanged(OnlineMachinationChoice(member.deviceId, selectedType))
+                    },
+                    label = { Text(member.username, style = MaterialTheme.typography.labelSmall) }
+                )
+            }
+        }
+        if (choice != null) {
+            // Type picker
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                FilterChip(
+                    selected = selectedType == "SUPPORT",
+                    onClick = { onChoiceChanged(choice.copy(type = "SUPPORT")) },
+                    leadingIcon = if (selectedType == "SUPPORT") {
+                        { Icon(Icons.Default.Favorite, null, Modifier.size(14.dp)) }
+                    } else null,
+                    label = { Text("Support", style = MaterialTheme.typography.labelSmall) }
+                )
+                FilterChip(
+                    selected = selectedType == "SABOTAGE",
+                    onClick = { onChoiceChanged(choice.copy(type = "SABOTAGE")) },
+                    leadingIcon = if (selectedType == "SABOTAGE") {
+                        { Icon(Icons.Default.Dangerous, null, Modifier.size(14.dp)) }
+                    } else null,
+                    label = { Text("Sabotage", style = MaterialTheme.typography.labelSmall) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun OnlineMachinationsTab(
+    campaign: OnlineCampaignDetail,
+    state: CharacterState,
+    onEvent: (CharacterEvent) -> Unit,
+    onDecodeTroupe: (String) -> Troupe?
+) {
+    val myDeviceId = state.backendDeviceId
+    val approvedMembers = campaign.members.filter { it.status == "APPROVED" }
+    val mySubmission = campaign.machinations.find { it.deviceId == myDeviceId }
+    val attacksEnabled = campaign.settings?.attacksEnabled == true
+
+    // Find my upcoming opponent (round N+1) — they can't be a machination target
+    val nextRoundKey = "round${campaign.currentRound + 1}"
+    val nextRoundGames = campaign.schedule?.get(nextRoundKey) ?: emptyMap()
+    val myNextOpponentId = nextRoundGames.values
+        .firstOrNull { myDeviceId in it }
+        ?.firstOrNull { it != myDeviceId }
+
+    // Members I can target: approved, not me, not my upcoming opponent
+    val machinationTargets = approvedMembers.filter {
+        it.deviceId != myDeviceId && it.deviceId != myNextOpponentId
+    }
+
+    var choice1 by remember(mySubmission) { mutableStateOf(mySubmission?.choices?.getOrNull(0)) }
+    var choice2 by remember(mySubmission) { mutableStateOf(mySubmission?.choices?.getOrNull(1)) }
+
+    // Attack state
+    var isAttacking by remember(mySubmission) { mutableStateOf(mySubmission?.attack != null) }
+    var attackTargetId by remember(mySubmission) { mutableStateOf(mySubmission?.attack?.targetDeviceId ?: "") }
+    var attackType by remember(mySubmission) { mutableStateOf(mySubmission?.attack?.type ?: "ASSAULT") }
+    var attackCharId by remember(mySubmission) { mutableStateOf(mySubmission?.attack?.targetCharId ?: -1) }
+
+    // Decode the attack target's troupe to show their characters
+    val attackTargetMember = approvedMembers.find { it.deviceId == attackTargetId }
+    val attackTargetTroupe = remember(attackTargetMember?.troupeData) {
+        attackTargetMember?.troupeData?.let { runCatching { onDecodeTroupe(it) }.getOrNull() }
+    }
+    val attackTargetChars = remember(attackTargetTroupe, state.characters) {
+        attackTargetTroupe?.characterIds?.mapNotNull { cid -> state.characters.find { it.id == cid } } ?: emptyList()
+    }
+
+    // Attack targets: approved, not me (can target upcoming opponent for attacks)
+    val attackTargets = approvedMembers.filter { it.deviceId != myDeviceId }
+
+    val submittedCount = campaign.machinations.size
+    val totalCount = approvedMembers.size
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        item {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Icon(Icons.Default.Star, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.primary)
+                Text("Round ${campaign.currentRound} — Machinations",
+                    style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+                Spacer(Modifier.weight(1f))
+                Text("$submittedCount / $totalCount submitted",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+
+        // My submission form
+        if (myDeviceId.isNotEmpty() && approvedMembers.size > 1) {
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f))
+                ) {
+                    Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                        Text("Your Machinations",
+                            style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.Bold)
+                        Text("Support or sabotage other players — your tier and the outcome of their game determines your MP gain or loss.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant)
+
+                        if (myNextOpponentId != null) {
+                            val opponentName = approvedMembers.find { it.deviceId == myNextOpponentId }?.username
+                            if (opponentName != null) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                                ) {
+                                    Icon(Icons.Default.Info, null, Modifier.size(12.dp),
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                                    Text("You cannot target $opponentName (your round ${campaign.currentRound + 1} opponent).",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                }
+                            }
+                        }
+
+                        if (machinationTargets.isNotEmpty()) {
+                            MachinationChoiceRow(0, choice1, machinationTargets) {
+                                choice1 = it; if (it == null) choice2 = null
+                            }
+                            if (choice1 != null) {
+                                HorizontalDivider()
+                                // Only exclude row-1 target when both choices share the same type
+                                // (same player can be targeted with SUPPORT+SABOTAGE, not SUPPORT+SUPPORT)
+                                val row2Targets = if (choice2 != null && choice1?.type == choice2?.type)
+                                    machinationTargets.filter { it.deviceId != choice1?.targetDeviceId }
+                                else machinationTargets
+                                MachinationChoiceRow(1, choice2, row2Targets) { choice2 = it }
+                            }
+                        } else {
+                            Text("No valid machination targets this round.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+
+                        // Attack section
+                        if (attacksEnabled && attackTargets.isNotEmpty()) {
+                            HorizontalDivider()
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(Icons.Default.GppBad, null, Modifier.size(14.dp),
+                                    tint = MaterialTheme.colorScheme.error)
+                                Spacer(Modifier.width(6.dp))
+                                Text("Attack", style = MaterialTheme.typography.labelMedium,
+                                    fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
+                                Switch(
+                                    checked = isAttacking,
+                                    onCheckedChange = {
+                                        isAttacking = it
+                                        if (!it) { attackTargetId = ""; attackCharId = -1 }
+                                    }
+                                )
+                            }
+                            if (isAttacking) {
+                                Text("Target player", style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                    verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                                    attackTargets.forEach { member ->
+                                        FilterChip(
+                                            selected = attackTargetId == member.deviceId,
+                                            onClick = { attackTargetId = member.deviceId; attackCharId = -1 },
+                                            label = { Text(member.username, style = MaterialTheme.typography.labelSmall) }
+                                        )
+                                    }
+                                }
+                                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                                    FilterChip(
+                                        selected = attackType == "ASSAULT",
+                                        onClick = { attackType = "ASSAULT" },
+                                        label = { Text("Assault (1 AP)", style = MaterialTheme.typography.labelSmall) }
+                                    )
+                                    FilterChip(
+                                        selected = attackType == "ABDUCTION",
+                                        onClick = { attackType = "ABDUCTION" },
+                                        label = { Text("Abduction (2 AP)", style = MaterialTheme.typography.labelSmall) }
+                                    )
+                                }
+                                if (attackTargetId.isNotEmpty() && attackTargetChars.isNotEmpty()) {
+                                    Text("Target character", style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                    FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                        verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                                        attackTargetChars.forEach { char ->
+                                            FilterChip(
+                                                selected = attackCharId == char.id,
+                                                onClick = { attackCharId = char.id },
+                                                label = { Text(char.name, style = MaterialTheme.typography.labelSmall) }
+                                            )
+                                        }
+                                    }
+                                } else if (attackTargetId.isNotEmpty()) {
+                                    Text("Target has no troupe set — character selection unavailable.",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                }
+                            }
+                        }
+
+                        val attack = if (isAttacking && attackTargetId.isNotEmpty() && attackCharId != -1)
+                            OnlineMachinationAttack(attackTargetId, attackCharId, attackType) else null
+                        val canSubmit = !state.isSubmittingMachination && (!isAttacking || attack != null)
+
+                        Button(
+                            onClick = { onEvent(CharacterEvent.SubmitMachination(
+                                campaign.id, listOfNotNull(choice1, choice2), attack)) },
+                            enabled = canSubmit,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            if (state.isSubmittingMachination) {
+                                CircularProgressIndicator(Modifier.size(16.dp), strokeWidth = 2.dp,
+                                    color = MaterialTheme.colorScheme.onPrimary)
+                            } else {
+                                Icon(if (mySubmission != null) Icons.Default.Refresh else Icons.Default.Send,
+                                    null, Modifier.size(14.dp))
+                                Spacer(Modifier.width(4.dp))
+                                Text(if (mySubmission != null) "Update Machinations" else "Submit Machinations",
+                                    style = MaterialTheme.typography.labelMedium)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        item {
+            HorizontalDivider()
+            Spacer(Modifier.height(2.dp))
+            Text("Submission Status", style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.Bold)
+        }
+
+        items(approvedMembers) { member ->
+            val submission = campaign.machinations.find { it.deviceId == member.deviceId }
+            val isMe = member.deviceId == myDeviceId
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Icon(
+                    if (submission != null) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked,
+                    null, Modifier.size(18.dp),
+                    tint = if (submission != null) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
+                )
+                Text(member.username,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = if (isMe) FontWeight.Bold else FontWeight.Normal,
+                    modifier = Modifier.weight(1f))
+                if (isMe) Text("You", style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary)
+                if (member.isLocal) Text("Local", style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.tertiary)
+                Text(if (submission != null) "Ready" else "Waiting…",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (submission != null) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline)
+            }
+        }
+    }
+}
+
+/** Stone counter + winner selection — shown when no result has been submitted yet. */
+@Composable
+private fun RecordResultCard(
+    campaignId: String,
+    roundNumber: Int,
+    gameNumber: Int,
+    myMember: OnlineCampaignMember?,
+    opponentMember: OnlineCampaignMember?,
+    myDeviceId: String,
+    campaignCards: List<io.github.garemat.lunachron.CampaignCard>,
+    isSubmitting: Boolean,
+    onDecodeTroupe: (String) -> Troupe?,
+    onEvent: (CharacterEvent) -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+
+    // Stone counts
+    var myStones by remember { mutableIntStateOf(0) }
+    var opponentStones by remember { mutableIntStateOf(0) }
+    // Campaign card VP modifiers
+    var myCardVp by remember { mutableIntStateOf(0) }
+    var opponentCardVp by remember { mutableIntStateOf(0) }
+    // Campaign cards used (set of share codes)
+    var myUsedCardCodes by remember { mutableStateOf(setOf<String>()) }
+    var opponentUsedCardCodes by remember { mutableStateOf(setOf<String>()) }
+
+    // Decode troupes to get campaign card lists
+    val myTroupe = remember(myMember?.troupeData) {
+        myMember?.troupeData?.let { runCatching { onDecodeTroupe(it) }.getOrNull() }
+    }
+    val opponentTroupe = remember(opponentMember?.troupeData) {
+        opponentMember?.troupeData?.let { runCatching { onDecodeTroupe(it) }.getOrNull() }
+    }
+
+    // Resolve CampaignCard objects from troupe card IDs
+    val myCampaignCards = remember(myTroupe, campaignCards) {
+        myTroupe?.campaignCards?.mapNotNull { tcc -> campaignCards.find { it.id == tcc.cardId } } ?: emptyList()
+    }
+    val opponentCampaignCards = remember(opponentTroupe, campaignCards) {
+        opponentTroupe?.campaignCards?.mapNotNull { tcc -> campaignCards.find { it.id == tcc.cardId } } ?: emptyList()
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(theme.screenPadding),
+        verticalArrangement = Arrangement.spacedBy(theme.verticalSpacing)
+    ) {
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = theme.cardShape,
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+            ) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Text("Round $roundNumber · Game $gameNumber",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.Bold)
+
+                    // ── Moonstones ────────────────────────────────────────────
+                    Text("Moonstones gathered", style = MaterialTheme.typography.labelMedium)
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        PlayerResultSide(myMember?.username ?: "You", myStones, { myStones = it }, Modifier.weight(1f))
+                        Box(Modifier.align(Alignment.CenterVertically)) {
+                            Text("vs", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                        PlayerResultSide(opponentMember?.username ?: "Opponent", opponentStones, { opponentStones = it }, Modifier.weight(1f))
+                    }
+
+                    HorizontalDivider()
+
+                    // ── Campaign cards ────────────────────────────────────────
+                    Text("Campaign cards used", style = MaterialTheme.typography.labelMedium)
+
+                    // My cards
+                    if (myCampaignCards.isNotEmpty()) {
+                        Text(myMember?.username ?: "You",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            myCampaignCards.forEach { card ->
+                                FilterChip(
+                                    selected = card.shareCode in myUsedCardCodes,
+                                    onClick = {
+                                        myUsedCardCodes = if (card.shareCode in myUsedCardCodes)
+                                            myUsedCardCodes - card.shareCode
+                                        else
+                                            myUsedCardCodes + card.shareCode
+                                    },
+                                    label = { Text(card.name, style = MaterialTheme.typography.labelSmall) }
+                                )
+                            }
+                        }
+                    }
+
+                    // Opponent cards
+                    if (opponentCampaignCards.isNotEmpty()) {
+                        Text(opponentMember?.username ?: "Opponent",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            opponentCampaignCards.forEach { card ->
+                                FilterChip(
+                                    selected = card.shareCode in opponentUsedCardCodes,
+                                    onClick = {
+                                        opponentUsedCardCodes = if (card.shareCode in opponentUsedCardCodes)
+                                            opponentUsedCardCodes - card.shareCode
+                                        else
+                                            opponentUsedCardCodes + card.shareCode
+                                    },
+                                    label = { Text(card.name, style = MaterialTheme.typography.labelSmall) }
+                                )
+                            }
+                        }
+                    }
+
+                    if (myCampaignCards.isEmpty() && opponentCampaignCards.isEmpty()) {
+                        Text("No campaign cards in either troupe.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+
+                    HorizontalDivider()
+
+                    // ── Campaign card VP modifier ─────────────────────────────
+                    Text("Campaign card VP modifier", style = MaterialTheme.typography.labelMedium)
+                    Text("Adjust VP for campaign cards that grant or deduct victory points.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        VpModifierSide(myMember?.username ?: "You", myCardVp, { myCardVp = it }, Modifier.weight(1f))
+                        Spacer(Modifier.width(8.dp))
+                        VpModifierSide(opponentMember?.username ?: "Opponent", opponentCardVp, { opponentCardVp = it }, Modifier.weight(1f))
+                    }
+
+                    HorizontalDivider()
+
+                    // ── Winner preview (auto-calculated from VP) ──────────────
+                    val myTotalVp = myStones + myCardVp
+                    val opponentTotalVp = opponentStones + opponentCardVp
+                    val projectedWinner = when {
+                        myTotalVp > opponentTotalVp -> myMember?.username ?: "You"
+                        opponentTotalVp > myTotalVp -> opponentMember?.username ?: "Opponent"
+                        else -> null // draw
+                    }
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                        Icon(Icons.Default.EmojiEvents, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.primary)
+                        Text(
+                            if (projectedWinner != null) "Winner: $projectedWinner ($myTotalVp — $opponentTotalVp VP)"
+                            else "Draw ($myTotalVp — $opponentTotalVp VP)",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.primary,
+                            fontWeight = FontWeight.Medium
+                        )
+                    }
+
+                    Button(
+                        onClick = {
+                            val winnerId = when {
+                                myTotalVp > opponentTotalVp -> myDeviceId
+                                opponentTotalVp > myTotalVp -> opponentMember?.deviceId
+                                else -> null
+                            }
+                            val playerStats = listOf(
+                                OnlinePlayerStat(myDeviceId, myMember?.username ?: "",
+                                    myStones, myCardVp, myUsedCardCodes.toList()),
+                                OnlinePlayerStat(opponentMember?.deviceId ?: "", opponentMember?.username ?: "",
+                                    opponentStones, opponentCardVp, opponentUsedCardCodes.toList())
+                            )
+                            onEvent(CharacterEvent.SubmitOnlineMatchResult(campaignId, roundNumber, gameNumber, playerStats, winnerId))
+                        },
+                        enabled = !isSubmitting,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        if (isSubmitting) {
+                            CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
+                        } else {
+                            Icon(Icons.Default.Send, null, Modifier.size(18.dp))
+                            Spacer(Modifier.width(6.dp))
+                            Text("Submit Result")
+                        }
+                    }
+
+                    Text("Your opponent will need to verify the result.",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun VpModifierSide(
+    name: String,
+    vp: Int,
+    onVpChange: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(name, style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Bold,
+            maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = { onVpChange(vp - 1) }, modifier = Modifier.size(28.dp)) {
+                Icon(Icons.Default.Remove, null, modifier = Modifier.size(14.dp))
+            }
+            Text(
+                text = if (vp > 0) "+$vp" else "$vp",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = when {
+                    vp > 0 -> MaterialTheme.colorScheme.primary
+                    vp < 0 -> MaterialTheme.colorScheme.error
+                    else   -> MaterialTheme.colorScheme.onSurface
+                },
+                modifier = Modifier.padding(horizontal = 4.dp)
+            )
+            IconButton(onClick = { onVpChange(vp + 1) }, modifier = Modifier.size(28.dp)) {
+                Icon(Icons.Default.Add, null, modifier = Modifier.size(14.dp))
+            }
+        }
+    }
+}
+
+/** Shown to the submitter while they wait for the opponent to verify. */
+@Composable
+private fun WaitingVerificationCard(
+    roundNumber: Int,
+    gameNumber: Int,
+    result: OnlineMatchResult,
+    myMember: OnlineCampaignMember?,
+    opponentMember: OnlineCampaignMember?,
+    myDeviceId: String,
+    onRefresh: () -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    val myStats = result.resultData?.playerStats?.find { it.deviceId == myDeviceId }
+    val oppStats = result.resultData?.playerStats?.find { it.deviceId != myDeviceId }
+    val winnerLabel = when (result.winnerId) {
+        myDeviceId -> myMember?.username ?: "You"
+        null       -> "Draw"
+        else       -> opponentMember?.username ?: "Opponent"
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(theme.screenPadding),
+        verticalArrangement = Arrangement.spacedBy(theme.verticalSpacing)
+    ) {
+        item {
+            Card(modifier = Modifier.fillMaxWidth(), shape = theme.cardShape,
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+            ) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Icon(Icons.Default.HourglassTop, null, tint = MaterialTheme.colorScheme.primary)
+                        Text("Result Submitted", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+                    }
+                    Text("Round $roundNumber · Game $gameNumber",
+                        style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+
+                    HorizontalDivider()
+
+                    // Summary of submitted result
+                    ResultSummaryRow(
+                        myName = myMember?.username ?: "You",
+                        opponentName = opponentMember?.username ?: "Opponent",
+                        myStones = myStats?.moonstones ?: 0,
+                        opponentStones = oppStats?.moonstones ?: 0,
+                        winnerLabel = winnerLabel,
+                        myCardVp = myStats?.campaignCardVp ?: 0,
+                        opponentCardVp = oppStats?.campaignCardVp ?: 0
+                    )
+
+                    HorizontalDivider()
+
+                    Text("Waiting for ${opponentMember?.username ?: "your opponent"} to verify…",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+
+                    OutlinedButton(onClick = onRefresh, modifier = Modifier.fillMaxWidth()) {
+                        Icon(Icons.Default.Refresh, null, Modifier.size(16.dp))
+                        Spacer(Modifier.width(6.dp))
+                        Text("Check for Update")
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** Shown to the opponent — lets them approve or contest the submitted result. */
+@Composable
+private fun VerifyResultCard(
+    campaignId: String,
+    roundNumber: Int,
+    gameNumber: Int,
+    result: OnlineMatchResult,
+    myMember: OnlineCampaignMember?,
+    opponentMember: OnlineCampaignMember?,
+    myDeviceId: String,
+    isVerifying: Boolean,
+    onEvent: (CharacterEvent) -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    val myStats = result.resultData?.playerStats?.find { it.deviceId == myDeviceId }
+    val oppStats = result.resultData?.playerStats?.find { it.deviceId != myDeviceId }
+    val winnerLabel = when (result.winnerId) {
+        myDeviceId -> myMember?.username ?: "You"
+        null       -> "Draw"
+        else       -> opponentMember?.username ?: "Opponent"
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(theme.screenPadding),
+        verticalArrangement = Arrangement.spacedBy(theme.verticalSpacing)
+    ) {
+        item {
+            Card(modifier = Modifier.fillMaxWidth(), shape = theme.cardShape,
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
+            ) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Icon(Icons.Default.Gavel, null, tint = MaterialTheme.colorScheme.onSecondaryContainer)
+                        Text("Verify Result", style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSecondaryContainer)
+                    }
+                    Text("${opponentMember?.username ?: "Your opponent"} has submitted the result for Round $roundNumber · Game $gameNumber.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer)
+
+                    HorizontalDivider()
+
+                    ResultSummaryRow(
+                        myName = myMember?.username ?: "You",
+                        opponentName = opponentMember?.username ?: "Opponent",
+                        myStones = myStats?.moonstones ?: 0,
+                        opponentStones = oppStats?.moonstones ?: 0,
+                        winnerLabel = winnerLabel,
+                        myCardVp = myStats?.campaignCardVp ?: 0,
+                        opponentCardVp = oppStats?.campaignCardVp ?: 0
+                    )
+
+                    HorizontalDivider()
+
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedButton(
+                            onClick = { onEvent(CharacterEvent.VerifyMatchResult(campaignId, result.id, agree = false)) },
+                            enabled = !isVerifying,
+                            modifier = Modifier.weight(1f),
+                            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error)
+                        ) {
+                            if (isVerifying) {
+                                CircularProgressIndicator(Modifier.size(16.dp), strokeWidth = 2.dp)
+                            } else {
+                                Icon(Icons.Default.Close, null, Modifier.size(16.dp))
+                                Spacer(Modifier.width(4.dp))
+                                Text("Contest")
+                            }
+                        }
+                        Button(
+                            onClick = { onEvent(CharacterEvent.VerifyMatchResult(campaignId, result.id, agree = true)) },
+                            enabled = !isVerifying,
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            if (isVerifying) {
+                                CircularProgressIndicator(Modifier.size(16.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
+                            } else {
+                                Icon(Icons.Default.Check, null, Modifier.size(16.dp))
+                                Spacer(Modifier.width(4.dp))
+                                Text("Approve")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** Shown when the result has been verified. */
+@Composable
+private fun ResultStatusCard(
+    roundNumber: Int,
+    gameNumber: Int,
+    result: OnlineMatchResult,
+    myMember: OnlineCampaignMember?,
+    opponentMember: OnlineCampaignMember?,
+    myDeviceId: String
+) {
+    val theme = LocalAppThemeProperties.current
+    val myStats = result.resultData?.playerStats?.find { it.deviceId == myDeviceId }
+    val oppStats = result.resultData?.playerStats?.find { it.deviceId != myDeviceId }
+    val winnerLabel = when (result.winnerId) {
+        myDeviceId -> myMember?.username ?: "You"
+        null       -> "Draw"
+        else       -> opponentMember?.username ?: "Opponent"
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(theme.screenPadding),
+        verticalArrangement = Arrangement.spacedBy(theme.verticalSpacing)
+    ) {
+        item {
+            Card(modifier = Modifier.fillMaxWidth(), shape = theme.cardShape,
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+            ) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Icon(Icons.Default.CheckCircle, null, tint = MaterialTheme.colorScheme.primary)
+                        Text("Result Confirmed", style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.primary)
+                    }
+                    Text("Round $roundNumber · Game $gameNumber",
+                        style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+
+                    HorizontalDivider()
+
+                    ResultSummaryRow(
+                        myName = myMember?.username ?: "You",
+                        opponentName = opponentMember?.username ?: "Opponent",
+                        myStones = myStats?.moonstones ?: 0,
+                        opponentStones = oppStats?.moonstones ?: 0,
+                        winnerLabel = winnerLabel,
+                        myCardVp = myStats?.campaignCardVp ?: 0,
+                        opponentCardVp = oppStats?.campaignCardVp ?: 0
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** Shown when the result has been disputed — host must resolve. */
+@Composable
+private fun DisputedResultCard(
+    roundNumber: Int,
+    gameNumber: Int,
+    result: OnlineMatchResult,
+    myMember: OnlineCampaignMember?,
+    opponentMember: OnlineCampaignMember?,
+    myDeviceId: String
+) {
+    val theme = LocalAppThemeProperties.current
+    val myStats = result.resultData?.playerStats?.find { it.deviceId == myDeviceId }
+    val oppStats = result.resultData?.playerStats?.find { it.deviceId != myDeviceId }
+    val winnerLabel = when (result.winnerId) {
+        myDeviceId -> myMember?.username ?: "You"
+        null       -> "Draw"
+        else       -> opponentMember?.username ?: "Opponent"
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(theme.screenPadding),
+        verticalArrangement = Arrangement.spacedBy(theme.verticalSpacing)
+    ) {
+        item {
+            Card(modifier = Modifier.fillMaxWidth(), shape = theme.cardShape,
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer)
+            ) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Icon(Icons.Default.Warning, null, tint = MaterialTheme.colorScheme.onErrorContainer)
+                        Text("Result Disputed", style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onErrorContainer)
+                    }
+                    Text("Round $roundNumber · Game $gameNumber",
+                        style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onErrorContainer)
+                    Text("The submitted result has been contested. Please contact your Chamberlain to resolve this.",
+                        style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onErrorContainer)
+
+                    HorizontalDivider()
+
+                    ResultSummaryRow(
+                        myName = myMember?.username ?: "You",
+                        opponentName = opponentMember?.username ?: "Opponent",
+                        myStones = myStats?.moonstones ?: 0,
+                        opponentStones = oppStats?.moonstones ?: 0,
+                        winnerLabel = winnerLabel,
+                        myCardVp = myStats?.campaignCardVp ?: 0,
+                        opponentCardVp = oppStats?.campaignCardVp ?: 0
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** Reusable two-column stone count + winner summary row. */
+@Composable
+private fun ResultSummaryRow(
+    myName: String,
+    opponentName: String,
+    myStones: Int,
+    opponentStones: Int,
+    winnerLabel: String,
+    myCardVp: Int = 0,
+    opponentCardVp: Int = 0
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(myName, style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text("$myStones \uD83C\uDF19", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                if (myCardVp != 0) {
+                    Text(
+                        text = if (myCardVp > 0) "+$myCardVp VP (cards)" else "$myCardVp VP (cards)",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (myCardVp > 0) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+            Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(opponentName, style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text("$opponentStones \uD83C\uDF19", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                if (opponentCardVp != 0) {
+                    Text(
+                        text = if (opponentCardVp > 0) "+$opponentCardVp VP (cards)" else "$opponentCardVp VP (cards)",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (opponentCardVp > 0) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+        }
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center, verticalAlignment = Alignment.CenterVertically) {
+            Icon(Icons.Default.EmojiEvents, null, Modifier.size(14.dp), tint = MaterialTheme.colorScheme.primary)
+            Spacer(Modifier.width(4.dp))
+            Text("Winner: $winnerLabel", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Medium)
+        }
+    }
+}
+
+@Composable
+private fun PlayerResultSide(
+    name: String,
+    stones: Int,
+    onStonesChange: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(name, style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Text("Moonstones", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = { if (stones > 0) onStonesChange(stones - 1) }, modifier = Modifier.size(28.dp)) {
+                Icon(Icons.Default.Remove, null, modifier = Modifier.size(14.dp))
+            }
+            Text("$stones", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, modifier = Modifier.padding(horizontal = 4.dp))
+            IconButton(onClick = { onStonesChange(stones + 1) }, modifier = Modifier.size(28.dp)) {
+                Icon(Icons.Default.Add, null, modifier = Modifier.size(14.dp))
+            }
+        }
+    }
+}
+
+// ── Schedule generation section (host, all ready, no schedule) ────────────────
+
+@Composable
+private fun ScheduleGenerationSection(
+    state: CharacterState,
+    campaignId: String,
+    approvedMembers: List<OnlineCampaignMember>,
+    onEvent: (CharacterEvent) -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    val roundCount = state.onlineScheduleRoundCount
+    val maxRounds = approvedMembers.size.coerceAtLeast(1) * 2
+    val pendingSchedule = state.pendingOnlineSchedule
+
+    Card(modifier = Modifier.fillMaxWidth(), shape = theme.cardShape,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Icon(Icons.Default.CalendarMonth, null, tint = MaterialTheme.colorScheme.primary)
+                Text("Generate Schedule", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("Rounds:", style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
+                IconButton(onClick = { if (roundCount > 1) onEvent(CharacterEvent.SetOnlineScheduleRoundCount(roundCount - 1)) }, enabled = roundCount > 1) {
+                    Icon(Icons.Default.Remove, null)
+                }
+                Text("$roundCount", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, modifier = Modifier.padding(horizontal = 4.dp))
+                IconButton(onClick = { if (roundCount < maxRounds) onEvent(CharacterEvent.SetOnlineScheduleRoundCount(roundCount + 1)) }, enabled = roundCount < maxRounds) {
+                    Icon(Icons.Default.Add, null)
+                }
+            }
+            OutlinedButton(onClick = { onEvent(CharacterEvent.GenerateOnlineSchedule(campaignId, roundCount)) },
+                modifier = Modifier.fillMaxWidth(), enabled = approvedMembers.size >= 2 && roundCount > 0) {
+                Icon(Icons.Default.Shuffle, null, Modifier.size(18.dp)); Spacer(Modifier.width(6.dp))
+                Text(if (pendingSchedule != null) "Regenerate" else "Auto-Generate Schedule")
+            }
+            if (pendingSchedule != null) {
+                HorizontalDivider()
+                Text("Preview", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                SchedulePreview(rounds = pendingSchedule, members = approvedMembers)
+                Button(onClick = { onEvent(CharacterEvent.PublishOnlineSchedule(campaignId)) },
+                    enabled = !state.isPublishingSchedule, modifier = Modifier.fillMaxWidth()) {
+                    if (state.isPublishingSchedule) CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
+                    else { Icon(Icons.Default.Publish, null, Modifier.size(18.dp)); Spacer(Modifier.width(6.dp)); Text("Publish Schedule") }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SchedulePreview(rounds: List<CampaignRound>, members: List<OnlineCampaignMember>) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        rounds.forEach { round ->
+            Text("Round ${round.roundNumber}", style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant, fontWeight = FontWeight.Bold)
+            round.games.forEach { game ->
+                val p1 = members.find { it.deviceId == game.playerIds.getOrNull(0) }?.username ?: "?"
+                val p2 = members.find { it.deviceId == game.playerIds.getOrNull(1) }?.username ?: "?"
+                Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    Text(p1, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Medium)
+                    Text("vs", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.padding(horizontal = 8.dp))
+                    Text(p2, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Medium)
+                }
+            }
+            if (round.skipPlayerIds.isNotEmpty()) {
+                val byeNames = round.skipPlayerIds.mapNotNull { id -> members.find { it.deviceId == id }?.username }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.Pause, null, Modifier.size(14.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Spacer(Modifier.width(4.dp))
+                    Text("Bye: ${byeNames.joinToString(", ")}", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        }
+    }
+}
+
+// ── Shared composables ────────────────────────────────────────────────────────
+
+// ── Admin panel (host only) ───────────────────────────────────────────────────
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AdminPanelSheet(
+    campaign: OnlineCampaignDetail,
+    state: CharacterState,
+    onEvent: (CharacterEvent) -> Unit,
+    onDismiss: () -> Unit,
+    onDecodeTroupe: (String) -> Troupe?,
+    onEncodeTroupe: (Troupe) -> String
+) {
+    val theme = LocalAppThemeProperties.current
+    var localPlayerName by remember { mutableStateOf("") }
+    val localMembers = campaign.members.filter { it.isLocal && it.status == "APPROVED" }
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        LazyColumn(
+            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 4.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.navigationBarsPadding()
+        ) {
+            // Header
+            item {
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Icon(Icons.Default.AdminPanelSettings, null, tint = MaterialTheme.colorScheme.tertiary)
+                    Text("Chamberlain Admin", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                }
+            }
+
+            item { HorizontalDivider() }
+
+            // Add local player
+            item {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Add Local Player", style = MaterialTheme.typography.labelMedium)
+                    Text("Add a player who doesn't have the app. They appear in the schedule and member list.",
+                        style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedTextField(
+                            value = localPlayerName,
+                            onValueChange = { localPlayerName = it },
+                            label = { Text("Player name") },
+                            singleLine = true,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Button(
+                            onClick = {
+                                val trimmed = localPlayerName.trim()
+                                if (trimmed.isNotEmpty()) {
+                                    onEvent(CharacterEvent.AddLocalCampaignMember(campaign.id, trimmed))
+                                    localPlayerName = ""
+                                }
+                            },
+                            enabled = localPlayerName.isNotBlank() && !state.isAddingLocalMember
+                        ) {
+                            if (state.isAddingLocalMember) {
+                                CircularProgressIndicator(Modifier.size(16.dp), strokeWidth = 2.dp,
+                                    color = MaterialTheme.colorScheme.onPrimary)
+                            } else {
+                                Text("Add")
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Existing local players (troupe + ready management — pre-game phases)
+            if (localMembers.isNotEmpty() && campaign.schedule == null) {
+                item { HorizontalDivider() }
+                item { Text("Manage Local Players", style = MaterialTheme.typography.labelMedium) }
+                items(localMembers) { member ->
+                    LocalPlayerAdminRow(
+                        member = member,
+                        campaignId = campaign.id,
+                        troupes = state.troupes,
+                        state = state,
+                        onEvent = onEvent,
+                        onDecodeTroupe = onDecodeTroupe,
+                        onEncodeTroupe = onEncodeTroupe,
+                        theme = theme
+                    )
+                }
+            }
+
+            // Active phase — result submission for local player games
+            if (campaign.schedule != null && localMembers.isNotEmpty()) {
+                val localMemberIds = localMembers.map { it.deviceId }.toSet()
+                val roundKey = "round${campaign.currentRound}"
+                val roundGames = campaign.schedule[roundKey] ?: emptyMap()
+                val localGames = roundGames.entries
+                    .filter { (_, players) -> players.any { it in localMemberIds } }
+                    .sortedBy { it.key }
+
+                if (localGames.isNotEmpty()) {
+                    item { HorizontalDivider() }
+                    item {
+                        Text("Round ${campaign.currentRound} — Local Player Games",
+                            style = MaterialTheme.typography.labelMedium)
+                    }
+                    items(localGames) { (gameKey, playerIds) ->
+                        val gameNum = gameKey.removePrefix("game").toIntOrNull() ?: 0
+                        val localPlayerId  = playerIds.firstOrNull { it in localMemberIds } ?: ""
+                        val opponentId     = playerIds.firstOrNull { it != localPlayerId } ?: ""
+                        val localMember    = localMembers.find { it.deviceId == localPlayerId }
+                        val opponentMember = campaign.members.find { it.deviceId == opponentId }
+                        val existingResult = campaign.matchResults.firstOrNull {
+                            it.roundNumber == campaign.currentRound && it.gameNumber == gameNum
+                        }
+                        AdminLocalGameCard(
+                            campaignId      = campaign.id,
+                            roundNumber     = campaign.currentRound,
+                            gameNumber      = gameNum,
+                            localMember     = localMember,
+                            opponentMember  = opponentMember,
+                            localPlayerId   = localPlayerId,
+                            opponentId      = opponentId,
+                            existingResult  = existingResult,
+                            campaignCards   = state.campaignCards,
+                            isSubmitting    = state.isSubmittingMatchResult,
+                            onDecodeTroupe  = onDecodeTroupe,
+                            onEvent         = onEvent,
+                            theme           = theme
+                        )
+                    }
+                }
+            }
+
+            // Machinations phase — host submits on behalf of local players
+            if (campaign.phase == "MACHINATIONS" && localMembers.isNotEmpty()) {
+                item { HorizontalDivider() }
+                item {
+                    Text("Round ${campaign.currentRound} — Local Player Machinations",
+                        style = MaterialTheme.typography.labelMedium)
+                }
+                items(localMembers) { localMember ->
+                    val submitted = campaign.machinations.find { it.deviceId == localMember.deviceId }
+                    val otherApproved = campaign.members.filter {
+                        it.status == "APPROVED" && it.deviceId != localMember.deviceId
+                    }
+                    AdminLocalMachinationCard(
+                        member        = localMember,
+                        campaignId    = campaign.id,
+                        otherMembers  = otherApproved,
+                        submitted     = submitted,
+                        isSubmitting  = state.isSubmittingMachination,
+                        onEvent       = onEvent,
+                        theme         = theme
+                    )
+                }
+            }
+
+            item { Spacer(Modifier.height(8.dp)) }
+        }
+    }
+}
+
+@Composable
+private fun LocalPlayerAdminRow(
+    member: OnlineCampaignMember,
+    campaignId: String,
+    troupes: List<Troupe>,
+    state: CharacterState,
+    onEvent: (CharacterEvent) -> Unit,
+    onDecodeTroupe: (String) -> Troupe?,
+    onEncodeTroupe: (Troupe) -> String,
+    theme: io.github.garemat.lunachron.ui.theme.AppThemeProperties
+) {
+    var showTroupePicker by remember { mutableStateOf(false) }
+
+    if (showTroupePicker) {
+        TroupePickerDialog(
+            troupes = troupes,
+            onDismiss = { showTroupePicker = false },
+            onSelect = { troupe ->
+                showTroupePicker = false
+                val encoded = onEncodeTroupe(troupe)
+                onEvent(CharacterEvent.UploadLocalMemberTroupe(campaignId, member.deviceId, encoded))
+            }
+        )
+    }
+
+    val troupe = member.troupeData?.let { runCatching { onDecodeTroupe(it) }.getOrNull() }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = theme.cardShape,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Icon(Icons.Default.PersonOff, null, Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(member.username, style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
+                Icon(
+                    if (member.isReady) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked,
+                    null, Modifier.size(16.dp),
+                    tint = if (member.isReady) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Text(
+                troupe?.troupeName ?: "No troupe selected",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(
+                    onClick = { showTroupePicker = true },
+                    enabled = !state.isUploadingTroupe,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    if (state.isUploadingTroupe) {
+                        CircularProgressIndicator(Modifier.size(14.dp), strokeWidth = 2.dp)
+                    } else {
+                        Text(if (member.troupeData != null) "Change Troupe" else "Set Troupe",
+                            style = MaterialTheme.typography.labelSmall)
+                    }
+                }
+                Button(
+                    onClick = { onEvent(CharacterEvent.SetLocalMemberReady(campaignId, member.deviceId, !member.isReady)) },
+                    enabled = member.troupeData != null && !state.isSettingReady,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = if (member.isReady) MaterialTheme.colorScheme.tertiary
+                        else MaterialTheme.colorScheme.primary
+                    ),
+                    modifier = Modifier.weight(1f)
+                ) {
+                    if (state.isSettingReady) {
+                        CircularProgressIndicator(Modifier.size(14.dp), strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.onPrimary)
+                    } else {
+                        Text(if (member.isReady) "Unready" else "Ready",
+                            style = MaterialTheme.typography.labelSmall)
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** Compact result-entry card shown in the admin panel for each local player game. */
+@Composable
+private fun AdminLocalGameCard(
+    campaignId: String,
+    roundNumber: Int,
+    gameNumber: Int,
+    localMember: OnlineCampaignMember?,
+    opponentMember: OnlineCampaignMember?,
+    localPlayerId: String,
+    opponentId: String,
+    existingResult: OnlineMatchResult?,
+    campaignCards: List<CampaignCard>,
+    isSubmitting: Boolean,
+    onDecodeTroupe: (String) -> Troupe?,
+    onEvent: (CharacterEvent) -> Unit,
+    theme: io.github.garemat.lunachron.ui.theme.AppThemeProperties
+) {
+    // If the result is already verified, just show a summary
+    if (existingResult?.verifyStatus == "VERIFIED") {
+        val localStats = existingResult.resultData?.playerStats?.find { it.deviceId == localPlayerId }
+        val oppStats   = existingResult.resultData?.playerStats?.find { it.deviceId == opponentId }
+        val localVp    = (localStats?.moonstones ?: 0) + (localStats?.campaignCardVp ?: 0)
+        val oppVp      = (oppStats?.moonstones ?: 0) + (oppStats?.campaignCardVp ?: 0)
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = theme.cardShape,
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.2f))
+        ) {
+            Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Icon(Icons.Default.CheckCircle, null, Modifier.size(14.dp), tint = MaterialTheme.colorScheme.primary)
+                    Text("Game $gameNumber · Result recorded",
+                        style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary)
+                }
+                Text("${localMember?.username ?: "Local"} $localVp — $oppVp ${opponentMember?.username ?: "Opponent"}",
+                    style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Medium)
+            }
+        }
+        return
+    }
+
+    // Entry form
+    var localStones       by remember { mutableIntStateOf(0) }
+    var opponentStones    by remember { mutableIntStateOf(0) }
+    var localCardVp       by remember { mutableIntStateOf(0) }
+    var opponentCardVp    by remember { mutableIntStateOf(0) }
+    var localUsedCards    by remember { mutableStateOf(setOf<String>()) }
+    var opponentUsedCards by remember { mutableStateOf(setOf<String>()) }
+
+    val localTroupe    = remember(localMember?.troupeData)    { localMember?.troupeData?.let    { runCatching { onDecodeTroupe(it) }.getOrNull() } }
+    val opponentTroupe = remember(opponentMember?.troupeData) { opponentMember?.troupeData?.let { runCatching { onDecodeTroupe(it) }.getOrNull() } }
+    val localCards    = remember(localTroupe, campaignCards)    { localTroupe?.campaignCards?.mapNotNull    { tc -> campaignCards.find { it.id == tc.cardId } } ?: emptyList() }
+    val opponentCards = remember(opponentTroupe, campaignCards) { opponentTroupe?.campaignCards?.mapNotNull { tc -> campaignCards.find { it.id == tc.cardId } } ?: emptyList() }
+
+    val localVp    = localStones + localCardVp
+    val oppVp      = opponentStones + opponentCardVp
+    val winnerId   = when {
+        localVp > oppVp -> localPlayerId
+        oppVp > localVp -> opponentId.ifEmpty { null }
+        else            -> null
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = theme.cardShape,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Text("Game $gameNumber · ${localMember?.username ?: "Local"} vs ${opponentMember?.username ?: "Opponent"}",
+                style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.Bold)
+
+            // Moonstone steppers
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                PlayerResultSide(localMember?.username ?: "Local", localStones,    { localStones = it },    Modifier.weight(1f))
+                Box(Modifier.align(Alignment.CenterVertically)) {
+                    Text("vs", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                PlayerResultSide(opponentMember?.username ?: "Opponent", opponentStones, { opponentStones = it }, Modifier.weight(1f))
+            }
+
+            // Campaign card chips
+            if (localCards.isNotEmpty() || opponentCards.isNotEmpty()) {
+                HorizontalDivider()
+                Text("Campaign cards used", style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+                if (localCards.isNotEmpty()) {
+                    Text(localMember?.username ?: "Local", style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                        localCards.forEach { card ->
+                            FilterChip(
+                                selected = card.shareCode in localUsedCards,
+                                onClick  = { localUsedCards = if (card.shareCode in localUsedCards) localUsedCards - card.shareCode else localUsedCards + card.shareCode },
+                                label    = { Text(card.name, style = MaterialTheme.typography.labelSmall) }
+                            )
+                        }
+                    }
+                }
+                if (opponentCards.isNotEmpty()) {
+                    Text(opponentMember?.username ?: "Opponent", style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                        opponentCards.forEach { card ->
+                            FilterChip(
+                                selected = card.shareCode in opponentUsedCards,
+                                onClick  = { opponentUsedCards = if (card.shareCode in opponentUsedCards) opponentUsedCards - card.shareCode else opponentUsedCards + card.shareCode },
+                                label    = { Text(card.name, style = MaterialTheme.typography.labelSmall) }
+                            )
+                        }
+                    }
+                }
+            }
+
+            // VP modifiers
+            HorizontalDivider()
+            Text("Campaign card VP modifier", style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                VpModifierSide(localMember?.username ?: "Local", localCardVp,    { localCardVp = it },    Modifier.weight(1f))
+                VpModifierSide(opponentMember?.username ?: "Opponent", opponentCardVp, { opponentCardVp = it }, Modifier.weight(1f))
+            }
+
+            // Winner preview
+            HorizontalDivider()
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                Icon(Icons.Default.EmojiEvents, null, Modifier.size(14.dp), tint = MaterialTheme.colorScheme.primary)
+                Text(
+                    when {
+                        localVp > oppVp -> "${localMember?.username ?: "Local"} wins ($localVp — $oppVp VP)"
+                        oppVp > localVp -> "${opponentMember?.username ?: "Opponent"} wins ($localVp — $oppVp VP)"
+                        else            -> "Draw ($localVp — $oppVp VP)"
+                    },
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+
+            Button(
+                onClick = {
+                    val stats = listOf(
+                        OnlinePlayerStat(localPlayerId, localMember?.username ?: "",
+                            localStones, localCardVp, localUsedCards.toList()),
+                        OnlinePlayerStat(opponentId, opponentMember?.username ?: "",
+                            opponentStones, opponentCardVp, opponentUsedCards.toList())
+                    )
+                    onEvent(CharacterEvent.SubmitOnlineMatchResult(campaignId, roundNumber, gameNumber, stats, winnerId))
+                },
+                enabled = !isSubmitting && localPlayerId.isNotEmpty() && opponentId.isNotEmpty(),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                if (isSubmitting) {
+                    CircularProgressIndicator(Modifier.size(16.dp), strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary)
+                } else {
+                    Icon(Icons.Default.Send, null, Modifier.size(14.dp))
+                    Spacer(Modifier.width(4.dp))
+                    Text("Submit", style = MaterialTheme.typography.labelMedium)
+                }
+            }
+        }
+    }
+}
+
+/** Admin panel card: host submits SUPPORT/SABOTAGE machinations for a local player. */
+@Composable
+private fun AdminLocalMachinationCard(
+    member: OnlineCampaignMember,
+    campaignId: String,
+    otherMembers: List<OnlineCampaignMember>,
+    submitted: OnlineMachinationEntry?,
+    isSubmitting: Boolean,
+    onEvent: (CharacterEvent) -> Unit,
+    theme: io.github.garemat.lunachron.ui.theme.AppThemeProperties
+) {
+    var choice1 by remember(submitted) { mutableStateOf(submitted?.choices?.getOrNull(0)) }
+    var choice2 by remember(submitted) { mutableStateOf(submitted?.choices?.getOrNull(1)) }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = theme.cardShape,
+        colors = CardDefaults.cardColors(
+            containerColor = if (submitted != null)
+                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.2f)
+            else
+                MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                if (submitted != null) {
+                    Icon(Icons.Default.CheckCircle, null, Modifier.size(14.dp),
+                        tint = MaterialTheme.colorScheme.primary)
+                }
+                Text(member.username,
+                    style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.Bold)
+            }
+
+            MachinationChoiceRow(0, choice1, otherMembers.filter { it.deviceId != member.deviceId }) {
+                choice1 = it; if (it == null) choice2 = null
+            }
+            if (choice1 != null) {
+                val row2Targets = otherMembers.filter {
+                    it.deviceId != member.deviceId &&
+                    (choice2 == null || choice1?.type != choice2?.type || it.deviceId != choice1?.targetDeviceId)
+                }
+                MachinationChoiceRow(1, choice2, row2Targets) { choice2 = it }
+            }
+
+            Button(
+                onClick = {
+                    onEvent(CharacterEvent.SubmitLocalMachination(
+                        campaignId, member.deviceId, listOfNotNull(choice1, choice2)))
+                },
+                enabled = !isSubmitting,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                if (isSubmitting) {
+                    CircularProgressIndicator(Modifier.size(16.dp), strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary)
+                } else {
+                    Icon(if (submitted != null) Icons.Default.Refresh else Icons.Default.Send,
+                        null, Modifier.size(14.dp))
+                    Spacer(Modifier.width(4.dp))
+                    Text(if (submitted != null) "Update" else "Submit Machinations",
+                        style = MaterialTheme.typography.labelMedium)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LockUnlockSection(
+    campaign: OnlineCampaignDetail,
+    isLoading: Boolean,
+    pendingCount: Int,
+    onLock: () -> Unit,
+    onUnlock: () -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    val isLocked = campaign.status == "LOCKED"
+    Card(modifier = Modifier.fillMaxWidth(), shape = theme.cardShape,
+        colors = CardDefaults.cardColors(containerColor = if (isLocked) MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.4f) else MaterialTheme.colorScheme.surfaceVariant)) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Icon(if (isLocked) Icons.Default.Lock else Icons.Default.LockOpen, null,
+                    tint = if (isLocked) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.primary)
+                Column(Modifier.weight(1f)) {
+                    Text(if (isLocked) "Campaign Locked" else "Open to new members",
+                        style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+                    Text(if (isLocked) "Unlock to allow more members to join (new join code)."
+                        else if (pendingCount > 0) "$pendingCount pending request(s). Lock when everyone has joined."
+                        else "Lock when everyone has joined.",
+                        style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+            Button(
+                onClick = if (isLocked) onUnlock else onLock, enabled = !isLoading,
+                colors = ButtonDefaults.buttonColors(containerColor = if (isLocked) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.primary),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                if (isLoading) CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
+                else Text(if (isLocked) "Unlock Campaign" else "Lock Campaign")
+            }
+        }
+    }
+}
+
+@Composable
+private fun WaitingCard(text: String) {
+    val theme = LocalAppThemeProperties.current
+    Card(modifier = Modifier.fillMaxWidth(), shape = theme.cardShape,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+        Row(modifier = Modifier.padding(16.dp), verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            Icon(Icons.Default.Schedule, null, tint = MaterialTheme.colorScheme.outline)
+            Text(text, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun CampaignInfoCard(campaign: OnlineCampaignDetail) {
+    val theme = LocalAppThemeProperties.current
+    Card(modifier = Modifier.fillMaxWidth(), shape = theme.cardShape,
+        elevation = CardDefaults.cardElevation(defaultElevation = theme.surfaceElevation),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            if (!campaign.description.isNullOrBlank()) {
+                Text(campaign.description, style = MaterialTheme.typography.bodyMedium)
+                Spacer(Modifier.height(8.dp))
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text("${campaign.members.size} members", style = MaterialTheme.typography.bodySmall)
+                Text(if (campaign.currentUserRole == "HOST") "You are the Chamberlain" else "Member",
+                    style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
+            }
+            if (campaign.settings != null) {
+                Spacer(Modifier.height(8.dp))
+                val s = campaign.settings
+                Text(buildString {
+                    append("Starting: ${s.startingCharacters} chars")
+                    append(" · Char every ${s.characterGrowthEvery}r · Upgrade every ${s.upgradeGrowthEvery}r")
+                    if (!s.attacksEnabled) append(" · Attacks off")
+                }, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            if (campaign.currentUserRole == "HOST" && campaign.joinCode != null) {
+                Spacer(Modifier.height(8.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("Join code: ", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text(campaign.joinCode, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.primary)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeleteCampaignDialog(
+    campaignName: String,
+    isDeleting: Boolean,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    var typed by remember { mutableStateOf("") }
+    val confirmed = typed.trim().equals(campaignName, ignoreCase = false)
+
+    AlertDialog(
+        onDismissRequest = { if (!isDeleting) onDismiss() },
+        icon = { Icon(Icons.Default.DeleteForever, contentDescription = null, tint = MaterialTheme.colorScheme.error) },
+        title = { Text("Delete Campaign") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    "This will permanently delete \"$campaignName\" and all its members, results, and history. This cannot be undone.",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    "Type the campaign name to confirm:",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                OutlinedTextField(
+                    value = typed,
+                    onValueChange = { typed = it },
+                    placeholder = { Text(campaignName, color = MaterialTheme.colorScheme.outline) },
+                    singleLine = true,
+                    isError = typed.isNotEmpty() && !confirmed,
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = !isDeleting
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = onConfirm,
+                enabled = confirmed && !isDeleting,
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+            ) {
+                if (isDeleting) {
+                    CircularProgressIndicator(Modifier.size(16.dp), strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onError)
+                } else {
+                    Text("Delete")
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !isDeleting) { Text("Cancel") }
+        }
+    )
+}
+
+@Composable
+private fun PendingMemberCard(
+    member: OnlineCampaignMember,
+    campaignId: String,
+    isProcessing: Boolean,
+    onEvent: (CharacterEvent) -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    Card(modifier = Modifier.fillMaxWidth(), shape = theme.cardShape,
+        elevation = CardDefaults.cardElevation(defaultElevation = theme.surfaceElevation),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f))) {
+        Row(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp), verticalAlignment = Alignment.CenterVertically) {
+            Icon(Icons.Default.Person, null, Modifier.size(20.dp))
+            Spacer(Modifier.width(8.dp))
+            Text(member.username, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
+            IconButton(onClick = { onEvent(CharacterEvent.ApproveMember(campaignId, member.id)) }, enabled = !isProcessing) {
+                Icon(Icons.Default.Check, "Approve", tint = MaterialTheme.colorScheme.primary)
+            }
+            IconButton(onClick = { onEvent(CharacterEvent.RejectMember(campaignId, member.id)) }, enabled = !isProcessing) {
+                Icon(Icons.Default.Close, "Reject", tint = MaterialTheme.colorScheme.error)
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/github/garemat/lunachron/ui/Screen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/Screen.kt
@@ -18,8 +18,15 @@ sealed class Screen(val route: String) {
     data object TournamentSetup : Screen("tournament_setup")
     data object TournamentWaitingRoom : Screen("tournament_waiting_room")
     data object TournamentRound : Screen("tournament_round")
+    data object CampaignHub : Screen("campaign_hub")
     data object CampaignManagement : Screen("campaign_management")
     data object AddEditCampaign : Screen("add_edit_campaign")
+    data object HostOnlineCampaign : Screen("host_online_campaign")
+    data object JoinOnlineCampaign : Screen("join_online_campaign")
+    data object ActiveOnlineCampaigns : Screen("active_online_campaigns")
+    data object OnlineCampaignDetail : Screen("online_campaign_detail/{campaignId}") {
+        fun createRoute(campaignId: String) = "online_campaign_detail/$campaignId"
+    }
     data object EditCampaign : Screen("edit_campaign/{campaignId}") {
         fun createRoute(campaignId: Int) = "edit_campaign/$campaignId"
     }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/SettingsScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/SettingsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -32,6 +33,7 @@ fun SettingsScreen(
     onNavigateBack: () -> Unit
 ) {
     var name by remember { mutableStateOf(state.name) }
+    var showRegisterDialog by remember { mutableStateOf(false) }
     val theme = LocalAppThemeProperties.current
     val scrollState = rememberScrollState()
     val context = LocalContext.current
@@ -77,11 +79,47 @@ fun SettingsScreen(
             OutlinedTextField(
                 value = name,
                 onValueChange = { name = it },
-                label = { Text("Player Name") },
+                label = { Text("Username") },
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
                 shape = theme.cardShape
             )
+
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+
+            if (state.isRegistered) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(vertical = theme.verticalSpacing / 4)
+                ) {
+                    Icon(
+                        Icons.Default.CheckCircle,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(end = 8.dp)
+                    )
+                    Text(
+                        "Device registered",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            } else {
+                OutlinedButton(
+                    onClick = { showRegisterDialog = true },
+                    enabled = name.isNotBlank() && !state.isRegisteringDevice,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = theme.cardShape
+                ) {
+                    if (state.isRegisteringDevice) {
+                        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Registering…", style = theme.buttonTextStyle)
+                    } else {
+                        Text("Register device", style = theme.buttonTextStyle)
+                    }
+                }
+            }
 
             Spacer(modifier = Modifier.height(theme.verticalSpacing))
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
@@ -317,6 +355,48 @@ fun SettingsScreen(
             // Extra bottom padding so the FAB never covers the last item
             Spacer(modifier = Modifier.height(88.dp))
         }
+    }
+
+    if (showRegisterDialog) {
+        AlertDialog(
+            onDismissRequest = { showRegisterDialog = false },
+            title = { Text("Register this device?", style = theme.headerStyle) },
+            text = {
+                Text(
+                    "A pseudonymous hash of your device ID — unique to this app install — and " +
+                    "your username \"$name\" will be stored on a private Oracle Cloud database. " +
+                    "This data is used solely for Lunachron campaign coordination and is never " +
+                    "shared with third parties.",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showRegisterDialog = false
+                    onEvent(CharacterEvent.RegisterDevice(name))
+                }) {
+                    Text("Register")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showRegisterDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
+    if (state.registrationError != null) {
+        AlertDialog(
+            onDismissRequest = { onEvent(CharacterEvent.DismissRegistrationError) },
+            title = { Text("Registration failed", style = theme.headerStyle) },
+            text = { Text(state.registrationError, style = MaterialTheme.typography.bodyMedium) },
+            confirmButton = {
+                TextButton(onClick = { onEvent(CharacterEvent.DismissRegistrationError) }) {
+                    Text("OK")
+                }
+            }
+        )
     }
 }
 


### PR DESCRIPTION
## Description
Wires the Android app to the LunaChron backend API (`api.garemat.co.uk`), enabling device registration and full online campaign management from within the app.

## Type of Change
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Chore (Non functional changes, documentation, etc.)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)

## Changes

**New screens:**
- `CampaignHubScreen` — entry point; register device or browse active campaigns
- `HostOnlineCampaignScreen` — create a campaign with configurable settings
- `JoinOnlineCampaignScreen` — join an existing campaign via join code
- `ActiveOnlineCampaignsScreen` — list of joined/hosted campaigns with status
- `OnlineCampaignDetailScreen` — full campaign view: members, schedule, match results, machinations phase, host controls (approve/reject/lock/disband)

**New API layer (`api/LunaChronApi.kt`):**
- Retrofit + kotlinx.serialization HTTP client
- Covers all backend endpoints: register, login, campaigns CRUD, member management, match result submit/verify, machinations
- Session token persisted in DataStore; backend device UUID stored across launches

**State/event additions:**
- `CharacterState` — online campaign state: registration, campaign list, detail, schedule, match results, machinations, rankings
- `CharacterEvent` — full set of online campaign events including host-only local member management
- `CharacterViewModel` — handlers for all new events wired to the API layer

**Build config:**
- `LUNACHRON_API_URL` BuildConfigField: debug → emulator loopback (`http://10.0.2.2:3000`), release → `https://api.garemat.co.uk`
- Debug network security config permits plain HTTP to emulator host
- `buildConfig = true` added to buildFeatures