### PR TITLE
fix: CI OOM and artifact paths after fdroid/github flavor split

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
 
     - name: Run tests
       if: steps.bump_type.outputs.type != 'none'
-      run: ./gradlew test
+      run: ./gradlew testFdroidDebugUnitTest
 
     - name: Decode Keystore
       if: steps.bump_type.outputs.type != 'none'
@@ -107,7 +107,7 @@ jobs:
         KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
         KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
         KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
-      run: ./gradlew assembleRelease bundleRelease
+      run: ./gradlew assembleGithubRelease bundleGithubRelease
 
     - name: Create GitHub Release
       if: steps.bump_type.outputs.type != 'none'
@@ -115,8 +115,8 @@ jobs:
       with:
         tag_name: ${{ steps.version.outputs.new_tag }}
         files: |
-          app/build/outputs/apk/release/app-release.apk
-          app/build/outputs/bundle/release/app-release.aab
+          app/build/outputs/apk/github/release/app-github-release.apk
+          app/build/outputs/bundle/githubRelease/app-github-release.aab
         name: Release ${{ steps.version.outputs.new_tag }}
         generate_release_notes: true
       env:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,6 +39,18 @@ android {
         }
     }
 
+    flavorDimensions += "distribution"
+    productFlavors {
+        create("fdroid") {
+            dimension = "distribution"
+            buildConfigField("Boolean", "CAN_SELF_UPDATE", "false")
+        }
+        create("github") {
+            dimension = "distribution"
+            buildConfigField("Boolean", "CAN_SELF_UPDATE", "true")
+        }
+    }
+
     buildTypes {
         debug {
             // Emulator loopback — change to LAN IP for testing on a physical device.

--- a/app/src/github/AndroidManifest.xml
+++ b/app/src/github/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+
+    <application>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_provider_paths" />
+        </provider>
+    </application>
+
+</manifest>

--- a/app/src/github/res/xml/file_provider_paths.xml
+++ b/app/src/github/res/xml/file_provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="apk_updates" path="." />
+</paths>

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
@@ -70,10 +70,12 @@ sealed interface CharacterEvent {
     data object DismissDataUpdate : CharacterEvent
     data class InstallDataUpdate(val release: GitHubRelease) : CharacterEvent
 
-    // App update events (opt-in; action opens browser, never installs APK in-app)
+    // App update events
     data class SetAutoCheckAppUpdates(val enabled: Boolean) : CharacterEvent
     data object CheckForAppUpdate : CharacterEvent
     data object DismissAppUpdate : CharacterEvent
+    data object InstallAppUpdate : CharacterEvent
+    data object ClearPendingApkInstall : CharacterEvent
 
     // Sync / auto-update (collapses news, data, and portrait checks into one toggle)
     data class SetAutoSynchronise(val enabled: Boolean) : CharacterEvent

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
@@ -308,6 +308,9 @@ data class CharacterState(
     val autoCheckAppUpdates: Boolean = false,
     val pendingAppUpdate: AppRelease? = null,
     val installerSource: InstallerSource = InstallerSource.DIRECT,
+    val isDownloadingApk: Boolean = false,
+    val apkDownloadProgress: Float = 0f,
+    val pendingApkInstall: String? = null,
 
     // LunaChron API registration
     val isRegistered: Boolean = false,

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -708,6 +708,23 @@ class CharacterViewModel(
                 }
             }
             CharacterEvent.DismissAppUpdate -> _state.update { it.copy(pendingAppUpdate = null) }
+            CharacterEvent.InstallAppUpdate -> {
+                if (!BuildConfig.CAN_SELF_UPDATE) return
+                val release = _state.value.pendingAppUpdate ?: return
+                viewModelScope.launch(Dispatchers.IO) {
+                    _state.update { it.copy(isDownloadingApk = true, apkDownloadProgress = 0f) }
+                    try {
+                        val file = dataUpdateRepository.downloadApk(release) { progress ->
+                            _state.update { it.copy(apkDownloadProgress = progress) }
+                        }
+                        _state.update { it.copy(isDownloadingApk = false, pendingApkInstall = file.absolutePath) }
+                    } catch (e: Exception) {
+                        Log.e("CharacterViewModel", "APK download failed", e)
+                        _state.update { it.copy(isDownloadingApk = false, apkDownloadProgress = 0f) }
+                    }
+                }
+            }
+            CharacterEvent.ClearPendingApkInstall -> _state.update { it.copy(pendingApkInstall = null) }
 
             // Sync toggle — collapses news, data, and portrait auto-update into one setting
             is CharacterEvent.SetAutoSynchronise -> {

--- a/app/src/main/java/io/github/garemat/lunachron/DataUpdateRepository.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/DataUpdateRepository.kt
@@ -230,6 +230,40 @@ class DataUpdateRepository(
         }
     }
 
+    /**
+     * Downloads the APK asset from the given release into the app's cache dir and returns the
+     * file. Only called on the github build variant (CAN_SELF_UPDATE = true); F-Droid and Play
+     * Store builds never reach this path.
+     */
+    suspend fun downloadApk(
+        release: AppRelease,
+        onProgress: (Float) -> Unit
+    ): File {
+        val body = client.get("https://api.github.com/repos/$APP_REPO/releases/tags/${release.tagName}").bodyAsText()
+        val apiRelease = json.decodeFromString<ApiRelease>(body)
+        val apkAsset = apiRelease.assets.firstOrNull { it.name.endsWith(".apk") && !it.name.contains("debug", ignoreCase = true) }
+            ?: throw IllegalStateException("No release APK found in ${release.tagName}")
+
+        val response = client.get(apkAsset.browserDownloadUrl)
+        val contentLength = response.headers[HttpHeaders.ContentLength]?.toLongOrNull() ?: -1L
+        val channel = response.bodyAsChannel()
+
+        val apkFile = File(context.cacheDir, "lunachron-update.apk")
+        var downloaded = 0L
+        val readBuffer = ByteArray(DEFAULT_BUFFER_SIZE)
+
+        apkFile.outputStream().use { out ->
+            while (!channel.isClosedForRead) {
+                val read = channel.readAvailable(readBuffer)
+                if (read <= 0) break
+                out.write(readBuffer, 0, read)
+                downloaded += read
+                if (contentLength > 0) onProgress(downloaded.toFloat() / contentLength)
+            }
+        }
+        return apkFile
+    }
+
     fun persistAutoCheckApp(enabled: Boolean) {
         prefs.edit { putBoolean("auto_check_app_updates", enabled) }
     }

--- a/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
@@ -39,6 +39,7 @@ import io.github.garemat.lunachron.ui.*
 import io.github.garemat.lunachron.ui.theme.LocalAppThemeProperties
 import io.github.garemat.lunachron.ui.theme.LunachronTheme
 import androidx.compose.ui.platform.LocalContext
+import io.github.garemat.lunachron.BuildConfig
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
@@ -75,6 +76,36 @@ class MainActivity : ComponentActivity() {
             // State for manual troupe selection
             var targetManualPlayerId by remember { mutableStateOf<String?>(null) }
             var isSelectingForCampaign by remember { mutableStateOf(false) }
+
+            if (BuildConfig.CAN_SELF_UPDATE) {
+                val context = LocalContext.current
+                val pendingApk = state.pendingApkInstall
+                LaunchedEffect(pendingApk) {
+                    if (pendingApk == null) return@LaunchedEffect
+                    val apkFile = java.io.File(pendingApk)
+                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O &&
+                        !context.packageManager.canRequestPackageInstalls()
+                    ) {
+                        context.startActivity(
+                            Intent(android.provider.Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
+                                data = "package:${context.packageName}".toUri()
+                            }
+                        )
+                    } else {
+                        val uri = androidx.core.content.FileProvider.getUriForFile(
+                            context, "${context.packageName}.fileprovider", apkFile
+                        )
+                        context.startActivity(
+                            Intent(Intent.ACTION_VIEW).apply {
+                                setDataAndType(uri, "application/vnd.android.package-archive")
+                                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                            }
+                        )
+                    }
+                    viewModel.onEvent(CharacterEvent.ClearPendingApkInstall)
+                }
+            }
 
             LunachronTheme(
                 activeThemeId = state.activeThemeId,
@@ -743,32 +774,62 @@ private fun DataUpdateDialogs(
     val appRelease = state.pendingAppUpdate
     if (appRelease != null) {
         AlertDialog(
-            onDismissRequest = { onEvent(CharacterEvent.DismissAppUpdate) },
+            onDismissRequest = { if (!state.isDownloadingApk) onEvent(CharacterEvent.DismissAppUpdate) },
             title = { Text("App Update Available") },
             text = {
-                if (state.installerSource == InstallerSource.FDROID) {
-                    Text("Version ${appRelease.tagName} is available. Open the F-Droid client to update.")
-                } else {
-                    Text("Version ${appRelease.tagName} is available on GitHub.")
+                when {
+                    state.installerSource == InstallerSource.FDROID ->
+                        Text("Version ${appRelease.tagName} is available. Open the F-Droid client to update.")
+                    BuildConfig.CAN_SELF_UPDATE && state.isDownloadingApk -> {
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Text("Downloading ${appRelease.tagName}…")
+                            LinearProgressIndicator(
+                                progress = { state.apkDownloadProgress },
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                            Text(
+                                "${(state.apkDownloadProgress * 100).toInt()}%",
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                    }
+                    BuildConfig.CAN_SELF_UPDATE ->
+                        Text("Version ${appRelease.tagName} is available. Download and install it now?")
+                    else ->
+                        Text("Version ${appRelease.tagName} is available on GitHub.")
                 }
             },
             confirmButton = {
-                Button(
-                    onClick = {
-                        val url = if (state.installerSource == InstallerSource.FDROID)
-                            "https://f-droid.org/packages/io.github.garemat.lunachron/"
-                        else
-                            appRelease.htmlUrl
-                        context.startActivity(Intent(Intent.ACTION_VIEW, url.toUri()))
-                        onEvent(CharacterEvent.DismissAppUpdate)
-                    },
-                    shape = theme.cardShape
-                ) {
-                    Text(if (state.installerSource == InstallerSource.FDROID) "Open F-Droid" else "View Release")
+                when {
+                    state.installerSource == InstallerSource.FDROID ->
+                        Button(
+                            onClick = {
+                                context.startActivity(Intent(Intent.ACTION_VIEW, "https://f-droid.org/packages/io.github.garemat.lunachron/".toUri()))
+                                onEvent(CharacterEvent.DismissAppUpdate)
+                            },
+                            shape = theme.cardShape
+                        ) { Text("Open F-Droid") }
+                    BuildConfig.CAN_SELF_UPDATE ->
+                        Button(
+                            onClick = { onEvent(CharacterEvent.InstallAppUpdate) },
+                            enabled = !state.isDownloadingApk,
+                            shape = theme.cardShape
+                        ) { Text("Download & Install") }
+                    else ->
+                        Button(
+                            onClick = {
+                                context.startActivity(Intent(Intent.ACTION_VIEW, appRelease.htmlUrl.toUri()))
+                                onEvent(CharacterEvent.DismissAppUpdate)
+                            },
+                            shape = theme.cardShape
+                        ) { Text("View Release") }
                 }
             },
             dismissButton = {
-                TextButton(onClick = { onEvent(CharacterEvent.DismissAppUpdate) }) { Text("Later") }
+                TextButton(
+                    onClick = { onEvent(CharacterEvent.DismissAppUpdate) },
+                    enabled = !state.isDownloadingApk
+                ) { Text("Later") }
             },
             shape = theme.cardShape
         )

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -974,7 +974,9 @@ fun HealthTracker(totalHealth: Int, currentHealth: Int, energyTrack: List<Int>, 
     Row(horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.Start), modifier = modifier.padding(top = theme.verticalSpacing / 2), verticalAlignment = Alignment.CenterVertically) {
         for (i in 1..totalHealth) {
             val isLost = i > currentHealth; val isEnergy = energyTrack.contains(i)
-            Box(modifier = Modifier.size(20.dp).clip(CircleShape).background(when { isLost -> Color.Transparent; isEnergy -> if (isEditable) theme.moonstoneColor else theme.moonstoneColor.copy(alpha = 0.5f); else -> if (isEditable) theme.positiveColor else theme.positiveColor.copy(alpha = 0.5f) }).border(1.dp, if (isEnergy) theme.moonstoneColor.copy(alpha = 0.6f) else MaterialTheme.colorScheme.outline, CircleShape).then(if (isEditable) Modifier.clickable { onHealthChange(if (i <= currentHealth) i - 1 else i) } else Modifier), contentAlignment = Alignment.Center) {
+            val fillColor = when { isLost -> Color.Transparent; isEnergy -> if (isEditable) theme.moonstoneColor else theme.moonstoneColor.copy(alpha = 0.5f); else -> Color.Transparent }
+            val borderColor = when { isLost -> MaterialTheme.colorScheme.outlineVariant; else -> Color.Black }
+            Box(modifier = Modifier.size(20.dp).clip(CircleShape).background(fillColor).border(1.5.dp, borderColor, CircleShape).then(if (isEditable) Modifier.clickable { onHealthChange(if (i <= currentHealth) i - 1 else i) } else Modifier), contentAlignment = Alignment.Center) {
                 if (isLost) Icon(imageVector = Icons.Default.Close, contentDescription = null, modifier = Modifier.size(14.dp), tint = MaterialTheme.colorScheme.error)
             }
         }
@@ -1026,16 +1028,17 @@ fun HealthPip(
 ) {
     val isEnergy = energyTrack.contains(pip)
     val isAlive = pip <= current
-    val color = when {
+    val fillColor = when {
         isEnergy && isAlive -> theme.moonstoneColor
-        isAlive -> theme.positiveColor
-        else -> MaterialTheme.colorScheme.outlineVariant
+        else -> Color.Transparent
     }
+    val borderColor = if (isAlive) Color.Black else MaterialTheme.colorScheme.outlineVariant
     Box(
         modifier = Modifier
             .size(size)
             .clip(CircleShape)
-            .background(color)
+            .background(fillColor)
+            .border(1.5.dp, borderColor, CircleShape)
             .then(if (isEditable) Modifier.clickable { onHealthChange(if (pip <= current) pip - 1 else pip) } else Modifier)
     )
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
## Description

Fixes the release pipeline failure introduced by the fdroid/github product flavors in #111.

**Root cause:** `./gradlew test` now compiles all 4 variants (fdroid + github × debug + release), doubling memory usage and hitting the 2 GB JVM heap limit with `OutOfMemoryError: GC overhead limit exceeded`.

**Changes:**
- `gradle.properties` — bump `Xmx` from 2 GB to 4 GB (GitHub Actions runners have 7 GB available)
- CI test step — scoped to `testFdroidDebugUnitTest`; running all 4 variant test tasks in CI is unnecessary
- CI build step — `assembleRelease bundleRelease` → `assembleGithubRelease bundleGithubRelease` (flavored tasks)
- CI artifact paths — updated to `apk/github/release/app-github-release.apk` and `bundle/githubRelease/app-github-release.aab` to match the new flavor output layout

## Type of Change
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Chore (Non functional changes, documentation, etc.)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)