### PR TITLE
feat: add Obsidian dark theme with themeable health pip colour

### DIFF
--- a/app/src/main/assets/themes/obsidian.json
+++ b/app/src/main/assets/themes/obsidian.json
@@ -1,0 +1,80 @@
+{
+  "id": "obsidian",
+  "name": "Obsidian",
+  "fonts": {
+    "display": "default",
+    "body": "default",
+    "mono": "monospace"
+  },
+  "colorScheme": {
+    "primary":              "#C9A84C",
+    "onPrimary":            "#1A0F00",
+    "primaryContainer":     "#3D2E00",
+    "onPrimaryContainer":   "#F5D58C",
+    "secondary":            "#A88A35",
+    "onSecondary":          "#1A0F00",
+    "secondaryContainer":   "#2D2000",
+    "onSecondaryContainer": "#E8C56A",
+    "surface":              "#1A1A1A",
+    "onSurface":            "#E8E0D0",
+    "surfaceVariant":       "#252525",
+    "onSurfaceVariant":     "#B0A88A",
+    "background":           "#0A0A0A",
+    "onBackground":         "#E8E0D0",
+    "outline":              "#4A4030",
+    "error":                "#CF6679",
+    "onError":              "#1A000B",
+    "isDark":               true
+  },
+  "factionColors": {
+    "commonwealth": "#C9A84C",
+    "dominion":     "#4A8CC9",
+    "leshavult":    "#4AAF6A",
+    "shades":       "#888888"
+  },
+  "shapes": {
+    "cardCornerRadius": 8.0,
+    "navItemShape":     "circle",
+    "drawerShape":      "rounded"
+  },
+  "spacing": {
+    "compact":            8.0,
+    "cozy":               16.0,
+    "spacious":           24.0,
+    "cardPaddingCompact": 8.0,
+    "cardPaddingCozy":    12.0,
+    "cardPaddingSpacious": 16.0
+  },
+  "typography": {
+    "titleStyle":      { "base": "titleLarge",    "weight": "bold" },
+    "headerStyle":     { "base": "headlineMedium" },
+    "labelStyle":      { "base": "labelSmall",    "weight": "bold" },
+    "buttonTextStyle": { "base": "labelLarge",    "weight": "bold" }
+  },
+  "gameColors": {
+    "moonstone":         "#2196F3",
+    "positive":          "#4AAF6A",
+    "rankingGold":       "#C9A84C",
+    "rankingSilver":     "#A0A0A0",
+    "rankingBronze":     "#CD7F32",
+    "ready":             "#4AAF6A",
+    "scoreCircle":       "#4A8CC9",
+    "magicalDamage":     "#6EB5FF",
+    "followUpHighlight": "#C9A84C",
+    "arcaneGreen":       "#4AAF6A",
+    "arcaneBlue":        "#4A8CC9",
+    "arcanePurple":      "#C268A8",
+    "catastrophe":       "#FF4444",
+    "healthPip":         "#C9A84C"
+  },
+  "characterCard": {
+    "showBackgroundImageOverlay": false,
+    "showExpandedStatsHeader":    false,
+    "showCardDivider":            true,
+    "useDamageTypeIcons":         false
+  },
+  "showFactionBackgrounds": false,
+  "gameplayPreferences": {
+    "defaultTrackingMode": "LOW_DETAIL"
+  }
+}

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -975,7 +975,7 @@ fun HealthTracker(totalHealth: Int, currentHealth: Int, energyTrack: List<Int>, 
         for (i in 1..totalHealth) {
             val isLost = i > currentHealth; val isEnergy = energyTrack.contains(i)
             val fillColor = when { isLost -> Color.Transparent; isEnergy -> if (isEditable) theme.moonstoneColor else theme.moonstoneColor.copy(alpha = 0.5f); else -> Color.Transparent }
-            val borderColor = when { isLost -> MaterialTheme.colorScheme.outlineVariant; else -> Color.Black }
+            val borderColor = when { isLost -> MaterialTheme.colorScheme.outlineVariant; else -> theme.healthPipColor }
             Box(modifier = Modifier.size(20.dp).clip(CircleShape).background(fillColor).border(1.5.dp, borderColor, CircleShape).then(if (isEditable) Modifier.clickable { onHealthChange(if (i <= currentHealth) i - 1 else i) } else Modifier), contentAlignment = Alignment.Center) {
                 if (isLost) Icon(imageVector = Icons.Default.Close, contentDescription = null, modifier = Modifier.size(14.dp), tint = MaterialTheme.colorScheme.error)
             }
@@ -1032,7 +1032,7 @@ fun HealthPip(
         isEnergy && isAlive -> theme.moonstoneColor
         else -> Color.Transparent
     }
-    val borderColor = if (isAlive) Color.Black else MaterialTheme.colorScheme.outlineVariant
+    val borderColor = if (isAlive) theme.healthPipColor else MaterialTheme.colorScheme.outlineVariant
     Box(
         modifier = Modifier
             .size(size)

--- a/app/src/main/java/io/github/garemat/lunachron/ui/theme/ThemeDefinition.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/theme/ThemeDefinition.kt
@@ -144,6 +144,7 @@ data class GameColorDefinition(
     val arcaneBlue: String? = null,
     val arcanePurple: String? = null,
     val catastrophe: String? = null,
+    val healthPip: String? = null,
 )
 
 /** Preferred game tracking mode applied when the user switches to this theme. */

--- a/app/src/main/java/io/github/garemat/lunachron/ui/theme/ThemeProperties.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/theme/ThemeProperties.kt
@@ -51,6 +51,7 @@ data class AppThemeProperties(
     val arcaneBlueColor: Color = Color(0xFF1565C0),
     val arcanePurpleColor: Color = Color(0xFFC2185B),
     val catastropheColor: Color = Color.Red,
+    val healthPipColor: Color = Color.Black,
     // Faction identity colors
     val factionCommonwealth: Color = Color(0xFFFBC02D),
     val factionDominion: Color = Color(0xFF1976D2),

--- a/app/src/main/java/io/github/garemat/lunachron/ui/theme/ThemeRepository.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/theme/ThemeRepository.kt
@@ -312,6 +312,7 @@ private fun GameColorDefinition?.mergeOver(base: GameColorDefinition?) = GameCol
     arcaneBlue        = this?.arcaneBlue        ?: base?.arcaneBlue,
     arcanePurple      = this?.arcanePurple      ?: base?.arcanePurple,
     catastrophe       = this?.catastrophe       ?: base?.catastrophe,
+    healthPip         = this?.healthPip         ?: base?.healthPip,
 )
 
 private fun CharacterCardDefinition?.mergeOver(base: CharacterCardDefinition?) = CharacterCardDefinition(
@@ -389,6 +390,7 @@ fun ThemeRepository.buildAppThemeProperties(
         arcaneBlueColor        = gc.arcaneBlue?.toColor()        ?: Color(0xFF1565C0),
         arcanePurpleColor      = gc.arcanePurple?.toColor()      ?: Color(0xFFC2185B),
         catastropheColor       = gc.catastrophe?.toColor()       ?: Color.Red,
+        healthPipColor         = gc.healthPip?.toColor()         ?: Color.Black,
         factionCommonwealth    = fc.commonwealth?.toColor()      ?: Color(0xFFFBC02D),
         factionDominion        = fc.dominion?.toColor()          ?: Color(0xFF1976D2),
         factionLeshavult       = fc.leshavult?.toColor()         ?: Color(0xFF388E3C),


### PR DESCRIPTION
## Description
Adds a new built-in **Obsidian** theme — a professional dark mode with a true black background (`#0A0A0A`), dark card surfaces (`#1A1A1A`), and gold (`#C9A84C`) as the primary accent colour. Also introduces a `healthPipColor` theme property so themes can control the alive-pip outline colour independently; Obsidian uses gold outlines for visibility on the dark background.

Changes:
- `assets/themes/obsidian.json` — new built-in theme (auto-discovered by `ThemeRepository`)
- `ThemeDefinition.kt` — adds `healthPip` field to `GameColorDefinition`
- `ThemeProperties.kt` — adds `healthPipColor: Color` to `AppThemeProperties` (default `Color.Black`)
- `ThemeRepository.kt` — wires `healthPip` through merge and builder; defaults to `Color.Black`
- `CommonComponents.kt` — `HealthPip` and `HealthTracker` use `theme.healthPipColor` instead of hardcoded `Color.Black`

## Type of Change
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Chore (Non functional changes, documentation, etc.)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)