### PR TITLE
chore: also build fdroid AAB for Play Store uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
         KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
         KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
         KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
-      run: ./gradlew assembleGithubRelease bundleGithubRelease
+      run: ./gradlew assembleGithubRelease bundleGithubRelease bundleFdroidRelease
 
     - name: Create GitHub Release
       if: steps.bump_type.outputs.type != 'none'
@@ -117,6 +117,7 @@ jobs:
         files: |
           app/build/outputs/apk/github/release/app-github-release.apk
           app/build/outputs/bundle/githubRelease/app-github-release.aab
+          app/build/outputs/bundle/fdroidRelease/app-fdroid-release.aab
         name: Release ${{ steps.version.outputs.new_tag }}
         generate_release_notes: true
       env:


### PR DESCRIPTION
## Description

The `github` flavor AAB (already built in CI) includes `REQUEST_INSTALL_PACKAGES`, which is unnecessary for Play Store users and could add friction during Google Play review. This adds `bundleFdroidRelease` to the build step and uploads `app-fdroid-release.aab` as a release asset — that's the bundle to submit to the Play Console when we set up automated Play Store delivery.

No functional code changes; workflow only.

## Type of Change
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Chore (Non functional changes, documentation, etc.)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)