### PR TITLE
chore: conventional commits, git-cliff changelog, and GPP Play Store publishing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,10 @@
 ## Description
 <!-- Provide a brief description of the changes -->
-
-## Type of Change
-- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] ✨ New feature (non-breaking change which adds functionality)
-- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-- [ ] 🧹 Chore (Non functional changes, documentation, etc.)
+<!-- Version bump is derived automatically from conventional commit messages:
+     feat: → minor bump | fix: → patch bump | feat!:/BREAKING CHANGE: → major bump -->
 
 ## Checklist
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
 - [ ] I have added tests that prove my fix is effective or that my feature works (N/A for now)
 - [ ] New and existing unit tests pass locally with my changes (N/A for now)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,70 +17,66 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Determine Version Bump
-      id: bump_type
-      env:
-        BODY: ${{ github.event.pull_request.body }}
+    - name: Install git-cliff
+      uses: kenji-miyake/setup-git-cliff@v2
+
+    - name: Determine next version from conventional commits
+      id: version
       run: |
-        if [[ "$BODY" == *"[x] 💥 Breaking change"* ]]; then
-          echo "type=major" >> $GITHUB_OUTPUT
-        elif [[ "$BODY" == *"[x] ✨ New feature"* ]]; then
-          echo "type=minor" >> $GITHUB_OUTPUT
-        elif [[ "$BODY" == *"[x] 🐛 Bug fix"* ]]; then
-          echo "type=patch" >> $GITHUB_OUTPUT
-        else
-          echo "type=none" >> $GITHUB_OUTPUT
+        BUMPED=$(git cliff --bumped-version 2>/dev/null || echo "")
+        LATEST=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+        if [ -z "$BUMPED" ] || [ "$BUMPED" = "$LATEST" ]; then
+          echo "bump=false" >> $GITHUB_OUTPUT
+          exit 0
         fi
+        NEW_TAG="$BUMPED"
+        VERSION_NAME="${NEW_TAG#v}"
+        IFS='.' read -r major minor patch <<< "$VERSION_NAME"
+        VERSION_CODE=$(( major * 10000 + minor * 100 + patch ))
+        echo "bump=true" >> $GITHUB_OUTPUT
+        echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
+        echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
+        echo "version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
 
     - name: Pin latest lunachron-data release
-      if: steps.bump_type.outputs.type != 'none'
-      id: pin_data
+      if: steps.version.outputs.bump == 'true'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         DATA_TAG=$(gh api repos/garemat/lunachron-data/releases/latest --jq '.tag_name')
-        echo "data_tag=$DATA_TAG" >> $GITHUB_OUTPUT
         echo "$DATA_TAG" > data.version
-        echo "Pinned data release: $DATA_TAG"
 
-    - name: Compute next version and write to build.gradle.kts
-      if: steps.bump_type.outputs.type != 'none'
-      id: version
+    - name: Write version to build.gradle.kts
+      if: steps.version.outputs.bump == 'true'
       run: |
-        LATEST_TAG=$(git tag --sort=-v:refname | grep '^v' | head -1)
-        LATEST="${LATEST_TAG#v}"
-        if [ -z "$LATEST" ]; then LATEST="0.0.0"; fi
-        IFS='.' read -r major minor patch <<< "$LATEST"
-        major=${major:-0}; minor=${minor:-0}; patch=${patch:-0}
-        case "${{ steps.bump_type.outputs.type }}" in
-          major) major=$((major+1)); minor=0; patch=0 ;;
-          minor) minor=$((minor+1)); patch=0 ;;
-          patch) patch=$((patch+1)) ;;
-        esac
-        VERSION_NAME="${major}.${minor}.${patch}"
-        VERSION_CODE=$(( major * 10000 + minor * 100 + patch ))
-        NEW_TAG="v${VERSION_NAME}"
-        echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
-        echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
-        echo "version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
-        # Write hardcoded values into build.gradle.kts so F-Droid can read them
-        # directly from the tagged commit without needing env var injection.
-        sed -i "s/        versionCode = .*/        versionCode = $VERSION_CODE/" app/build.gradle.kts
-        sed -i "s/        versionName = .*/        versionName = \"$VERSION_NAME\"/" app/build.gradle.kts
-        echo "Version: $VERSION_NAME ($VERSION_CODE), tag: $NEW_TAG"
+        sed -i "s/        versionCode = .*/        versionCode = ${{ steps.version.outputs.version_code }}/" app/build.gradle.kts
+        sed -i "s/        versionName = .*/        versionName = \"${{ steps.version.outputs.version_name }}\"/" app/build.gradle.kts
+
+    - name: Generate changelog
+      if: steps.version.outputs.bump == 'true'
+      run: git cliff --tag ${{ steps.version.outputs.new_tag }} -o CHANGELOG.md
 
     - name: Create release commit and tag
-      if: steps.bump_type.outputs.type != 'none'
+      if: steps.version.outputs.bump == 'true'
       run: |
         git config user.name  "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add app/build.gradle.kts data.version
+        git add app/build.gradle.kts data.version CHANGELOG.md
         git diff --staged --quiet || git commit -m "chore: release ${{ steps.version.outputs.new_tag }} [skip ci]"
         git tag ${{ steps.version.outputs.new_tag }}
-        git push origin ${{ steps.version.outputs.new_tag }}
+        git push origin HEAD:main ${{ steps.version.outputs.new_tag }}
 
-    - name: set up JDK 17
-      if: steps.bump_type.outputs.type != 'none'
+    - name: Extract release notes for this version
+      if: steps.version.outputs.bump == 'true'
+      id: release_notes
+      run: |
+        NOTES=$(git cliff --tag ${{ steps.version.outputs.new_tag }} --current --strip header)
+        echo "notes<<EOF" >> $GITHUB_OUTPUT
+        echo "$NOTES" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+
+    - name: Set up JDK 17
+      if: steps.version.outputs.bump == 'true'
       uses: actions/setup-java@v5
       with:
         java-version: '17'
@@ -88,20 +84,19 @@ jobs:
         cache: gradle
 
     - name: Grant execute permission for gradlew
-      if: steps.bump_type.outputs.type != 'none'
+      if: steps.version.outputs.bump == 'true'
       run: chmod +x gradlew
 
     - name: Run tests
-      if: steps.bump_type.outputs.type != 'none'
+      if: steps.version.outputs.bump == 'true'
       run: ./gradlew testFdroidDebugUnitTest
 
     - name: Decode Keystore
-      if: steps.bump_type.outputs.type != 'none'
-      run: |
-        echo "${{ secrets.RELEASE_KEYSTORE }}" | base64 --decode > app/release.keystore
+      if: steps.version.outputs.bump == 'true'
+      run: echo "${{ secrets.RELEASE_KEYSTORE }}" | base64 --decode > app/release.keystore
 
     - name: Build Release APK and AAB
-      if: steps.bump_type.outputs.type != 'none'
+      if: steps.version.outputs.bump == 'true'
       env:
         KEYSTORE_PATH: release.keystore
         KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
@@ -109,8 +104,14 @@ jobs:
         KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
       run: ./gradlew assembleGithubRelease bundleGithubRelease bundleFdroidRelease
 
+    - name: Publish to Play Store internal track
+      if: steps.version.outputs.bump == 'true'
+      env:
+        PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+      run: ./gradlew publishGithubReleaseBundle
+
     - name: Create GitHub Release
-      if: steps.bump_type.outputs.type != 'none'
+      if: steps.version.outputs.bump == 'true'
       uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ steps.version.outputs.new_tag }}
@@ -119,6 +120,6 @@ jobs:
           app/build/outputs/bundle/githubRelease/app-github-release.aab
           app/build/outputs/bundle/fdroidRelease/app-fdroid-release.aab
         name: Release ${{ steps.version.outputs.new_tag }}
-        generate_release_notes: true
+        body: ${{ steps.release_notes.outputs.notes }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,11 +28,6 @@ jobs:
         run: |
           echo "Validating PR description..."
 
-          if ! echo "$PR_BODY" | grep -qEi "(- \[x\] (🐛 Bug fix|✨ New feature|💥 Breaking change|🧹 Chore))"; then
-            echo "::error::Validation Failed: Please select at least one 'Type of Change' in your PR description."
-            exit 1
-          fi
-
           if echo "$PR_BODY" | sed -n '/## Checklist/,$p' | grep -q "\[ \]"; then
             echo "::error::Validation Failed: Please ensure all items in the 'Checklist' are completed and checked."
             exit 1

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.gradle.play.publisher)
 }
 
 android {
@@ -89,6 +90,17 @@ android {
             jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
         }
     }
+}
+
+// Gradle Play Publisher — uploads the github flavor AAB to Play Store.
+// Requires PLAY_SERVICE_ACCOUNT_JSON env var (path to service account JSON) in CI.
+// Locally, place the file at app/play-service-account.json (gitignored).
+play {
+    serviceAccountCredentials.set(
+        file(System.getenv("PLAY_SERVICE_ACCOUNT_JSON") ?: "play-service-account.json")
+    )
+    track.set("internal")
+    defaultToAppBundles.set(true)
 }
 
 ksp {

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,42 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+"""
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }}\
+{% if commit.breaking %} (**BREAKING**){% endif %}
+{% endfor %}
+{% endfor %}\n
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+commit_parsers = [
+  { message = "^feat", group = "Added" },
+  { message = "^fix", group = "Fixed" },
+  { message = "^perf", group = "Changed" },
+  { message = "^refactor", group = "Changed" },
+  { message = "^docs", skip = true },
+  { message = "^style", skip = true },
+  { message = "^test", skip = true },
+  { message = "^chore|^ci|^build", skip = true },
+]
+filter_commits = true
+tag_pattern = "v[0-9]*"
+sort_commits = "oldest"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+gradlePlayPublisher = "3.12.1"
 agp = "8.13.2"
 coreKtx = "1.18.0"
 junit = "4.13.2"
@@ -56,6 +57,7 @@ coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coi
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
+gradle-play-publisher = { id = "com.github.triplet.play", version.ref = "gradlePlayPublisher" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
## Description
Replaces the manual PR-body checkbox version bump system with a fully automated release pipeline:

- **Conventional commits** enforced via a global `~/.git-hooks/commit-msg` hook; version bump type (`feat` → minor, `fix` → patch, `feat!` → major) is now derived automatically from commit messages
- **git-cliff** generates `CHANGELOG.md` automatically on each release using `cliff.toml`
- **Gradle Play Publisher** (`com.github.triplet.play:3.12.1`) added to upload the `github` flavor AAB to the Play Store internal track on every release; requires `PLAY_SERVICE_ACCOUNT_JSON` GitHub secret
- PR template updated to remove Type of Change checkboxes (no longer needed)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)