### PR TITLE
fix: patch bump for chore PRs and serialise concurrent releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ jobs:
   release:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    concurrency:
+      group: release
+      cancel-in-progress: false
     permissions:
       contents: write
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,12 @@ jobs:
       run: |
         BUMPED=$(git cliff --bumped-version 2>/dev/null || echo "")
         LATEST=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+        # If git-cliff found no releasable commits (e.g. chore-only PR), force a patch bump
         if [ -z "$BUMPED" ] || [ "$BUMPED" = "$LATEST" ]; then
-          echo "bump=false" >> $GITHUB_OUTPUT
-          exit 0
+          LATEST_VER="${LATEST#v}"
+          if [ -z "$LATEST_VER" ]; then LATEST_VER="0.0.0"; fi
+          IFS='.' read -r major minor patch <<< "$LATEST_VER"
+          BUMPED="v${major}.${minor}.$((patch+1))"
         fi
         NEW_TAG="$BUMPED"
         VERSION_NAME="${NEW_TAG#v}"


### PR DESCRIPTION
## Description
Two fixes to the release pipeline:

- Fall back to a patch bump when git-cliff finds no releasable commits (chore-only PRs), so every merged PR produces a release
- Add `concurrency: group: release` to the release job so rapid back-to-back merges queue rather than race, preventing duplicate tag conflicts

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)