### PR TITLE
fix: correct version floor using absolute latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,13 @@ jobs:
           IFS='.' read -r major minor patch <<< "$LATEST_VER"
           BUMPED="v${major}.${minor}.$((patch+1))"
         fi
+        # If the computed tag already exists (e.g. race between concurrent releases),
+        # keep incrementing patch until we find a free tag
+        while git tag | grep -qx "$BUMPED"; do
+          VER="${BUMPED#v}"
+          IFS='.' read -r major minor patch <<< "$VER"
+          BUMPED="v${major}.${minor}.$((patch+1))"
+        done
         NEW_TAG="$BUMPED"
         VERSION_NAME="${NEW_TAG#v}"
         IFS='.' read -r major minor patch <<< "$VERSION_NAME"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,17 +26,25 @@ jobs:
     - name: Determine next version from conventional commits
       id: version
       run: |
+        # Use absolute latest tag (sort-based, not ancestry-based) so orphaned
+        # release commits from the old workflow are still recognised as the floor
+        LATEST=$(git tag --sort=-v:refname | grep '^v' | head -1)
+        if [ -z "$LATEST" ]; then LATEST="v0.0.0"; fi
+
         BUMPED=$(git cliff --bumped-version 2>/dev/null || echo "")
-        LATEST=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-        # If git-cliff found no releasable commits (e.g. chore-only PR), force a patch bump
-        if [ -z "$BUMPED" ] || [ "$BUMPED" = "$LATEST" ]; then
+
+        # Helper: returns 0 if $1 >= $2 by semver
+        version_gte() { [ "$(printf '%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ]; }
+
+        # If git-cliff produced nothing, or its result is <= the actual latest tag
+        # (because it was working from a stale reachable tag), bump patch from LATEST
+        if [ -z "$BUMPED" ] || ! version_gte "$BUMPED" "$LATEST" || [ "$BUMPED" = "$LATEST" ]; then
           LATEST_VER="${LATEST#v}"
-          if [ -z "$LATEST_VER" ]; then LATEST_VER="0.0.0"; fi
           IFS='.' read -r major minor patch <<< "$LATEST_VER"
           BUMPED="v${major}.${minor}.$((patch+1))"
         fi
-        # If the computed tag already exists (e.g. race between concurrent releases),
-        # keep incrementing patch until we find a free tag
+
+        # Keep incrementing patch until we find a tag that doesn't already exist
         while git tag | grep -qx "$BUMPED"; do
           VER="${BUMPED#v}"
           IFS='.' read -r major minor patch <<< "$VER"


### PR DESCRIPTION
## Description
Fixes incorrect version computation caused by orphaned release commits from the old workflow (which pushed tags but never pushed release commits back to main). `git describe` only walks commit ancestry so was finding `v2.2.7` instead of `v2.12.0`, causing git-cliff to compute `v2.3.0`.

- Use `git tag --sort=-v:refname` to find the absolute latest tag regardless of commit reachability
- If git-cliff computes a version at or below the actual latest tag, fall back to a patch bump from the real latest
- Keep the existing while-loop guard to skip any tags that already exist

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)