### PR TITLE
feat: pre-merge version bump embedded in PR branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,75 +20,35 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install git-cliff
-      uses: kenji-miyake/setup-git-cliff@v2
-
-    - name: Determine next version from conventional commits
+    - name: Read version from build.gradle.kts
       id: version
       run: |
-        # Use absolute latest tag (sort-based, not ancestry-based) so orphaned
-        # release commits from the old workflow are still recognised as the floor
-        LATEST=$(git tag --sort=-v:refname | grep '^v' | head -1)
-        if [ -z "$LATEST" ]; then LATEST="v0.0.0"; fi
-
-        BUMPED=$(git cliff --bumped-version 2>/dev/null || echo "")
-
-        # Helper: returns 0 if $1 >= $2 by semver
-        version_gte() { [ "$(printf '%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ]; }
-
-        # If git-cliff produced nothing, or its result is <= the actual latest tag
-        # (because it was working from a stale reachable tag), bump patch from LATEST
-        if [ -z "$BUMPED" ] || ! version_gte "$BUMPED" "$LATEST" || [ "$BUMPED" = "$LATEST" ]; then
-          LATEST_VER="${LATEST#v}"
-          IFS='.' read -r major minor patch <<< "$LATEST_VER"
-          BUMPED="v${major}.${minor}.$((patch+1))"
-        fi
-
-        # Keep incrementing patch until we find a tag that doesn't already exist
-        while git tag | grep -qx "$BUMPED"; do
-          VER="${BUMPED#v}"
-          IFS='.' read -r major minor patch <<< "$VER"
-          BUMPED="v${major}.${minor}.$((patch+1))"
-        done
-        NEW_TAG="$BUMPED"
-        VERSION_NAME="${NEW_TAG#v}"
+        VERSION_NAME=$(grep '^\s*versionName' app/build.gradle.kts | sed 's/.*"\(.*\)".*/\1/')
         IFS='.' read -r major minor patch <<< "$VERSION_NAME"
         VERSION_CODE=$(( major * 10000 + minor * 100 + patch ))
-        echo "bump=true" >> $GITHUB_OUTPUT
+        NEW_TAG="v${VERSION_NAME}"
+        # Safety: if tag already exists, increment patch
+        while git tag | grep -qx "$NEW_TAG"; do
+          patch=$((patch+1))
+          VERSION_NAME="${major}.${minor}.${patch}"
+          VERSION_CODE=$(( major * 10000 + minor * 100 + patch ))
+          NEW_TAG="v${VERSION_NAME}"
+        done
         echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
         echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
         echo "version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
 
     - name: Pin latest lunachron-data release
-      if: steps.version.outputs.bump == 'true'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         DATA_TAG=$(gh api repos/garemat/lunachron-data/releases/latest --jq '.tag_name')
         echo "$DATA_TAG" > data.version
 
-    - name: Write version to build.gradle.kts
-      if: steps.version.outputs.bump == 'true'
-      run: |
-        sed -i "s/        versionCode = .*/        versionCode = ${{ steps.version.outputs.version_code }}/" app/build.gradle.kts
-        sed -i "s/        versionName = .*/        versionName = \"${{ steps.version.outputs.version_name }}\"/" app/build.gradle.kts
+    - name: Install git-cliff
+      uses: kenji-miyake/setup-git-cliff@v2
 
-    - name: Generate changelog
-      if: steps.version.outputs.bump == 'true'
-      run: git cliff --tag ${{ steps.version.outputs.new_tag }} -o CHANGELOG.md
-
-    - name: Create release commit and tag
-      if: steps.version.outputs.bump == 'true'
-      run: |
-        git config user.name  "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add app/build.gradle.kts data.version CHANGELOG.md
-        git diff --staged --quiet || git commit -m "chore: release ${{ steps.version.outputs.new_tag }} [skip ci]"
-        git tag ${{ steps.version.outputs.new_tag }}
-        git push origin HEAD:main ${{ steps.version.outputs.new_tag }}
-
-    - name: Extract release notes for this version
-      if: steps.version.outputs.bump == 'true'
+    - name: Extract release notes
       id: release_notes
       run: |
         NOTES=$(git cliff --tag ${{ steps.version.outputs.new_tag }} --current --strip header)
@@ -96,8 +56,16 @@ jobs:
         echo "$NOTES" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
 
+    - name: Tag release
+      run: |
+        git config user.name  "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add data.version
+        git diff --staged --quiet || git commit -m "chore: pin data for ${{ steps.version.outputs.new_tag }} [skip ci]"
+        git tag ${{ steps.version.outputs.new_tag }}
+        git push origin HEAD:main ${{ steps.version.outputs.new_tag }}
+
     - name: Set up JDK 17
-      if: steps.version.outputs.bump == 'true'
       uses: actions/setup-java@v5
       with:
         java-version: '17'
@@ -105,19 +73,15 @@ jobs:
         cache: gradle
 
     - name: Grant execute permission for gradlew
-      if: steps.version.outputs.bump == 'true'
       run: chmod +x gradlew
 
     - name: Run tests
-      if: steps.version.outputs.bump == 'true'
       run: ./gradlew testFdroidDebugUnitTest
 
     - name: Decode Keystore
-      if: steps.version.outputs.bump == 'true'
       run: echo "${{ secrets.RELEASE_KEYSTORE }}" | base64 --decode > app/release.keystore
 
     - name: Build Release APK and AAB
-      if: steps.version.outputs.bump == 'true'
       env:
         KEYSTORE_PATH: release.keystore
         KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
@@ -126,13 +90,11 @@ jobs:
       run: ./gradlew assembleGithubRelease bundleGithubRelease bundleFdroidRelease
 
     - name: Publish to Play Store internal track
-      if: steps.version.outputs.bump == 'true'
       env:
         PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
       run: ./gradlew publishGithubReleaseBundle
 
     - name: Create GitHub Release
-      if: steps.version.outputs.bump == 'true'
       uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ steps.version.outputs.new_tag }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,84 @@
+name: Version Bump
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    types: [ "opened", "synchronize", "reopened", "ready_for_review" ]
+
+jobs:
+  bump:
+    # Skip if the last commit was already made by this workflow (avoid infinite loop)
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.head_ref }}
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Skip if last commit is from bot
+      id: check
+      run: |
+        LAST_AUTHOR=$(git log -1 --format='%ae')
+        if [[ "$LAST_AUTHOR" == *"github-actions"* ]]; then
+          echo "skip=true" >> $GITHUB_OUTPUT
+        else
+          echo "skip=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Install git-cliff
+      if: steps.check.outputs.skip != 'true'
+      uses: kenji-miyake/setup-git-cliff@v2
+
+    - name: Compute next version
+      if: steps.check.outputs.skip != 'true'
+      id: version
+      run: |
+        LATEST=$(git tag --sort=-v:refname | grep '^v' | head -1)
+        if [ -z "$LATEST" ]; then LATEST="v0.0.0"; fi
+
+        BUMPED=$(git cliff --bumped-version 2>/dev/null || echo "")
+
+        version_gte() { [ "$(printf '%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ]; }
+
+        if [ -z "$BUMPED" ] || ! version_gte "$BUMPED" "$LATEST" || [ "$BUMPED" = "$LATEST" ]; then
+          LATEST_VER="${LATEST#v}"
+          IFS='.' read -r major minor patch <<< "$LATEST_VER"
+          BUMPED="v${major}.${minor}.$((patch+1))"
+        fi
+
+        while git tag | grep -qx "$BUMPED"; do
+          VER="${BUMPED#v}"
+          IFS='.' read -r major minor patch <<< "$VER"
+          BUMPED="v${major}.${minor}.$((patch+1))"
+        done
+
+        VERSION_NAME="${BUMPED#v}"
+        IFS='.' read -r major minor patch <<< "$VERSION_NAME"
+        VERSION_CODE=$(( major * 10000 + minor * 100 + patch ))
+        echo "new_tag=$BUMPED" >> $GITHUB_OUTPUT
+        echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
+        echo "version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
+
+    - name: Update versionName and versionCode
+      if: steps.check.outputs.skip != 'true'
+      run: |
+        sed -i "s/        versionCode = .*/        versionCode = ${{ steps.version.outputs.version_code }}/" app/build.gradle.kts
+        sed -i "s/        versionName = .*/        versionName = \"${{ steps.version.outputs.version_name }}\"/" app/build.gradle.kts
+
+    - name: Generate changelog
+      if: steps.check.outputs.skip != 'true'
+      run: git cliff --tag ${{ steps.version.outputs.new_tag }} -o CHANGELOG.md
+
+    - name: Commit version bump
+      if: steps.check.outputs.skip != 'true'
+      run: |
+        git config user.name  "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add app/build.gradle.kts CHANGELOG.md
+        git diff --staged --quiet || git commit -m "chore: bump version to ${{ steps.version.outputs.new_tag }}"
+        git push origin HEAD:${{ github.head_ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,104 +5,55 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.12.2] - 2026-04-21
 
 ### Added
-- Themes can now specify preferred game layout and tracking modes; switching themes applies the theme's preference unless you've already customised those settings under that theme.
-- Favourite troupes: tap the star on any troupe card to mark it as a favourite. Favourites appear in a Quick Start bar at the top of the Home screen for one-tap game launch.
-- Quick Start bar auto-hides when scrolling through the news feed and reappears when you scroll back to the top.
-- New local game setup flow: Player Count → Troupe Selection → Ready to Play. Troupe selection uses a bottom sheet with character portrait previews. Troupes with more characters than the game size allows show an inline character picker for trimming the roster.
 
-### Changed
-- Game setup entry point redesigned: "Local Game" is the primary hero card; multiplayer and tournament modes are secondary.
-- Removed "Skip Game Mode Selection" and "Only track 1 player" settings — the new setup flow handles this inline.
-- Multiplayer and tournament mode buttons now show an "upcoming update" notice instead of launching the (work-in-progress) flow.
+- JSON-driven theme system with font and inheritance support (#76)
 
-## [2.2.7] - 2026-03-19
+- Google Play prep — privacy policy, name fix, installer detection, theme gameplay prefs (#79)
 
-### Added
-- Fastlane `icon.png` for F-Droid store listing metadata
+- Troupe editor UX polish — header, cards, strip (#89)
+
+- Campaign overhaul — machinations, VP tracking, MP distribution, round rankings (#91)
+
+- Compendium UI overhaul — filter, fast-scroll, card polish, faction icons (#99)
+
+- Settings UI improvements (#101)
+
+- Local game setup flow, favourite troupes, and home Quick Start (#105)
+
+- LunaChron online campaign API integration (#109)
+
+- Health pip outline style and in-app APK updates for GitHub builds (#111)
+
+- Add Obsidian dark theme with themeable health pip colour (#113)
+
+- Move version bump to pre-merge workflow, release pipeline tags only
+
 
 ### Fixed
-- Replaced ML Kit barcode scanning with ZXing (Apache-2.0) for F-Droid compatibility
-- `signingConfig` now uses `findByName` so F-Droid builds survive the stripped signing block
-- `versionCode`/`versionName` now derived from git tags for reproducible F-Droid builds
-- PNG crunching disabled for reproducible builds
-- Force-pinned vulnerable transitive dependency versions via resolution strategy
-- Resolved all lint warnings
 
-## [2.2.2] - 2026-03-16
+- Use findByName for signingConfig to survive F-Droid build (#69)
 
-### Fixed
-- Release pipeline no longer fails when `data.version` is unchanged between releases
+- Replace ML Kit barcode scanning with ZXing (#70)
 
-## [2.2.1] - 2026-03-16
+- Disable tutorial and local tournament flows (#93)
 
-### Changed
-- Dependabot auto-updates enabled for Gradle and GitHub Actions dependencies
-- Updated Compose BOM from 2024.10.01 to 2024.12.01
-- Updated various GitHub Actions (upload-artifact, setup-java, checkout, cache)
+- Privacy-first defaults, app icon, and startup network tests (#97)
 
-## [2.2.0] - 2026-03-15
+- Update CI workflow ref from deleted branch to main (#100)
 
-### Changed
-- Split Room database into `GameDatabase` (destructive migration OK — game data is reseedable) and `UserDatabase` (explicit migrations required — preserves troupes, campaigns, results)
+- CI, compile, and cold-start fixes for campaign API integration (#110)
 
-## [2.1.0] - 2026-03-15
+- CI OOM and artifact paths after fdroid/github flavor split (#112)
 
-### Fixed
-- Bundled assets patch for compendium data loading
+- Remove stale Type of Change validation and bump patch for chore PRs (#116)
 
-## [2.0.0] - 2026-03-09
+- Patch bump for chore PRs and serialise concurrent releases (#117)
 
-### Added
-- Data update system: app checks for new compendium releases from `garemat/lunachron-data` on GitHub and downloads updated JSON assets and portrait images
-- `DataUpdateRepository` with `PROMPT`/`ENABLED`/`DISABLED` image download preference
-- Consolidated asset files (`compendium.json`, `upgrades.json`, `campaign.json`) replace per-file subdirectories
+- Correct version floor using absolute latest tag (#118)
 
-### Changed
-- `CharacterData` reads from `filesDir/data/` first, falling back to bundled assets (enables live updates without reinstall)
 
-## [1.1.0] - 2026-03-08
+## [0.0.1] - 2026-02-10
 
-### Added
-- Active game screen redesign with two layout modes: `COMPACT_GRID` (2-column grid) and `DETAILED_LIST` (full card)
-- `GameTrackingMode`: `LOW_DETAIL` (health pips only) and `FULL_TRACKING` (energy, moonstones, ability markers)
-- `HealthPipsChunked` canonical health display (groups of 5, new row after 10)
-- `SummonerIndicator` shared composable for both layout modes
-
-## [1.0.0] - 2026-03-07
-
-### Added
-- Campaign management: `CampaignManagement`, `CampaignDetails`, `AddEditCampaign`, `EditCampaign` screens
-- `CampaignCard` and `UpgradeCard` compendium entries
-- Share codes for all compendium items (5-char format: `[type][faction][id0][id1][id2]`)
-- Troupe share strings (base64-encoded faction + character/upgrade codes)
-
-## [0.2.0] - 2026-02-25
-
-### Added
-- Usability improvements across compendium, troupe, and game setup flows
-
-## [0.1.0] - 2026-02-10
-
-### Added
-- Initial public release
-- Character compendium with four factions (Commonwealth, Dominion, Leshavult, Shades)
-- Troupe builder with faction filtering
-- Local multiplayer via Android NSD (mDNS) + TCP sockets; Wi-Fi Direct support
-- Local tournament bracket management
-- Two app themes: Default and Moonstone
-- Three layout densities: Compact, Cozy, Spacious
-
-[Unreleased]: https://github.com/Garemat/lunachron/compare/v2.2.7...HEAD
-[2.2.7]: https://github.com/Garemat/lunachron/compare/v2.2.2...v2.2.7
-[2.2.2]: https://github.com/Garemat/lunachron/compare/v2.2.1...v2.2.2
-[2.2.1]: https://github.com/Garemat/lunachron/compare/v2.2.0...v2.2.1
-[2.2.0]: https://github.com/Garemat/lunachron/compare/v2.1.0...v2.2.0
-[2.1.0]: https://github.com/Garemat/lunachron/compare/v2.0.0...v2.1.0
-[2.0.0]: https://github.com/Garemat/lunachron/compare/v1.1.0...v2.0.0
-[1.1.0]: https://github.com/Garemat/lunachron/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/Garemat/lunachron/compare/v0.2.0...v1.0.0
-[0.2.0]: https://github.com/Garemat/lunachron/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/Garemat/lunachron/releases/tag/v0.1.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "io.github.garemat.lunachron"
         minSdk = 24
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0.0"
+        versionCode = 21202
+        versionName = "2.12.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Description
Moves version computation out of the release pipeline and into a pre-merge workflow that commits directly to the PR branch. The release pipeline now just reads `versionName` from `build.gradle.kts` and creates the tag — no push to main required.

**`version-bump.yml`** (new) — triggers on PR open/update:
- Computes next version using the same git-cliff + absolute-latest-tag logic
- Updates `versionName`/`versionCode` in `build.gradle.kts` and regenerates `CHANGELOG.md`
- Commits back to the PR branch
- Skips if the last commit was already from the bot (loop prevention)
- Skips for Dependabot PRs

**`release.yml`** (simplified) — triggers on PR merge:
- Reads `versionName` directly from `build.gradle.kts` (already set by pre-merge workflow)
- Pins `data.version`, creates tag, builds, publishes to Play Store and GitHub Releases
- Only needs to push the tag + data pin commit — no version bump commit to main

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)