### PR TITLE
fix: use --unreleased for release notes before tag is created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Extract release notes
       id: release_notes
       run: |
-        NOTES=$(git cliff --tag ${{ steps.version.outputs.new_tag }} --current --strip header)
+        NOTES=$(git cliff --unreleased --strip header)
         echo "notes<<EOF" >> $GITHUB_OUTPUT
         echo "$NOTES" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Obsidian dark theme with themeable health pip colour (#113)
 
-- Move version bump to pre-merge workflow, release pipeline tags only
+- Pre-merge version bump embedded in PR branch (#121)
 
 
 ### Fixed
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Patch bump for chore PRs and serialise concurrent releases (#117)
 
 - Correct version floor using absolute latest tag (#118)
+
+- Use --unreleased for release notes before tag exists
 
 
 ## [0.0.1] - 2026-02-10


### PR DESCRIPTION
## Description
`git cliff --current` fails with "No tag exists for the current commit" because the tag hasn't been created yet when release notes are extracted. Switch to `--unreleased` which returns the same commits without requiring the tag to exist first.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)