### PR TITLE
fix: write Play Store credentials to temp file for GPP

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,9 +78,12 @@ jobs:
         KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
       run: ./gradlew assembleGithubRelease bundleGithubRelease bundleFdroidRelease
 
+    - name: Write Play Store credentials to file
+      run: echo '${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}' > /tmp/play-service-account.json
+
     - name: Publish to Play Store internal track
       env:
-        PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+        PLAY_SERVICE_ACCOUNT_JSON: /tmp/play-service-account.json
       run: ./gradlew publishGithubReleaseBundle
 
     - name: Create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.4] - 2026-04-21
+
+### Fixed
+
+- Write Play Store credentials to temp file before passing to GPP
+
+
 ## [2.12.3] - 2026-04-21
 
 ### Added
@@ -56,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use --unreleased for release notes before tag is created (#122)
 
-- Move data.version pin to pre-merge, release workflow pushes tag only
+- Release workflow pushes tag only, no direct push to main (#123)
 
 
 ## [0.0.1] - 2026-02-10

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "io.github.garemat.lunachron"
         minSdk = 24
         targetSdk = 36
-        versionCode = 21203
-        versionName = "2.12.3"
+        versionCode = 21204
+        versionName = "2.12.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Description
GPP expects `PLAY_SERVICE_ACCOUNT_JSON` to be a **file path**, not the JSON content. Passing the raw JSON as an env var caused Gradle to use the entire JSON string as a file path, which exposed the private key in the error logs.

Fixes this by writing the secret to a temp file first, then passing the path to Gradle.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)