### PR TITLE
fix: fix Play Store credentials and signing for GPP publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,10 @@ jobs:
     - name: Publish to Play Store internal track
       env:
         PLAY_SERVICE_ACCOUNT_JSON: /tmp/play-service-account.json
+        KEYSTORE_PATH: release.keystore
+        KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+        KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+        KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
       run: ./gradlew publishGithubReleaseBundle
 
     - name: Create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.5] - 2026-04-21
+
+### Fixed
+
+- Pass keystore env vars to publishGithubReleaseBundle step
+
+
 ## [2.12.4] - 2026-04-21
 
 ### Fixed
 
-- Write Play Store credentials to temp file before passing to GPP
+- Write Play Store credentials to temp file for GPP (#124)
 
 
 ## [2.12.3] - 2026-04-21

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "io.github.garemat.lunachron"
         minSdk = 24
         targetSdk = 36
-        versionCode = 21204
-        versionName = "2.12.4"
+        versionCode = 21205
+        versionName = "2.12.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Description
Two fixes for the `publishGithubReleaseBundle` step:

- GPP expects `PLAY_SERVICE_ACCOUNT_JSON` to be a file path, not JSON content — write the secret to a temp file and pass the path instead
- `publishGithubReleaseBundle` re-triggers the bundle build as a dependency, so keystore env vars must be present in the publish step too, otherwise the bundle is built unsigned and Play Store rejects it with 403

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)