### PR TITLE
fix: publish fdroid flavor to Play Store instead of github

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
         KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
         KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
         KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
-      run: ./gradlew publishGithubReleaseBundle
+      run: ./gradlew publishFdroidReleaseBundle
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.6] - 2026-04-21
+
+### Fixed
+
+- Publish fdroid flavor to Play Store, not github flavor
+
+
 ## [2.12.5] - 2026-04-21
 
 ### Fixed
 
-- Pass keystore env vars to publishGithubReleaseBundle step
+- Fix Play Store credentials and signing for GPP publish (#125)
 
 
 ## [2.12.4] - 2026-04-21

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "io.github.garemat.lunachron"
         minSdk = 24
         targetSdk = 36
-        versionCode = 21205
-        versionName = "2.12.5"
+        versionCode = 21206
+        versionName = "2.12.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Description
The `github` flavor includes `REQUEST_INSTALL_PACKAGES` (for self-update via GitHub releases), which Play Store rejects. The `fdroid` flavor has `CAN_SELF_UPDATE = false` and no such permission — it's the correct flavor for Play Store distribution.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)