### PR TITLE
chore: add AI smoke test agent script

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "enabledMcpjsonServers": ["android"]
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "android": {
+      "command": "android-mcp",
+      "args": []
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Publish fdroid flavor to Play Store, not github flavor
+- Publish fdroid flavor to Play Store instead of github (#126)
 
 
 ## [2.12.5] - 2026-04-21

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "io.github.garemat.lunachron"
         minSdk = 24
         targetSdk = 36
-        versionCode = 21206
-        versionName = "2.12.6"
+        versionCode = 21207
+        versionName = "2.12.7"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Run a Haiku-powered smoke test against the app on a connected emulator/device.
+# Usage: ./scripts/smoke-test.sh [device-serial]
+#
+# Requires:
+#   - android-mcp installed and on PATH  (pip install android-mcp)
+#   - claude CLI installed               (npm install -g @anthropic-ai/claude-code)
+#   - Android emulator or device running with the app installed
+set -euo pipefail
+
+PACKAGE="io.github.garemat.lunachron"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+DEVICE="${1:-}"
+ADB_TARGET=( adb )
+[[ -n "$DEVICE" ]] && ADB_TARGET=( adb -s "$DEVICE" )
+
+pass() { echo "  ✓ $*"; }
+fail() { echo "  ✗ $*" >&2; exit 1; }
+
+# --- Resolve latest version tag (needed by preflight) ---
+LATEST_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]' | head -1)
+if [[ -z "$LATEST_TAG" ]]; then
+  echo "Error: no version tags found in this repo." >&2
+  exit 1
+fi
+VERSION="${LATEST_TAG#v}"
+
+# ---------------------------------------------------------------------------
+# Preflight — deterministic checks before the agent runs
+# ---------------------------------------------------------------------------
+echo ""
+echo "Preflight checks..."
+
+# 1. ADB available
+command -v adb &>/dev/null || fail "adb not found on PATH"
+pass "adb found"
+
+# 2. Device visible
+DEVICE_STATE=$( "${ADB_TARGET[@]}" get-state 2>/dev/null || true )
+[[ "$DEVICE_STATE" == "device" ]] || fail "no device in 'device' state (got: '${DEVICE_STATE:-none}') — is the emulator running?"
+pass "device online"
+
+# 3. App installed
+"${ADB_TARGET[@]}" shell pm list packages 2>/dev/null | grep -q "^package:${PACKAGE}$" \
+  || fail "app not installed on device (${PACKAGE})"
+pass "app installed"
+
+# 4. App version matches latest tag
+INSTALLED_VERSION=$( "${ADB_TARGET[@]}" shell dumpsys package "$PACKAGE" 2>/dev/null \
+  | grep -m1 'versionName' | sed 's/.*versionName=//' | tr -d '[:space:]' )
+if [[ "$INSTALLED_VERSION" != "$VERSION" ]]; then
+  echo "  ⚠ version mismatch: installed=${INSTALLED_VERSION}, tag=${VERSION} (continuing anyway)"
+else
+  pass "version matches tag (${VERSION})"
+fi
+
+# 5. App launches without immediate crash — force-stop first for a clean slate
+"${ADB_TARGET[@]}" shell am force-stop "$PACKAGE" 2>/dev/null || true
+"${ADB_TARGET[@]}" shell monkey -p "$PACKAGE" -c android.intent.category.LAUNCHER 1 &>/dev/null \
+  || fail "app failed to launch via monkey"
+sleep 3
+# Check logcat for a fatal exception in the last 5 s of logs
+CRASH=$( "${ADB_TARGET[@]}" logcat -d -t 100 2>/dev/null \
+  | grep -E "AndroidRuntime.*FATAL EXCEPTION|Process: ${PACKAGE}.*has died" || true )
+[[ -z "$CRASH" ]] || fail "crash detected on launch:\n${CRASH}"
+pass "app launched without crash"
+
+echo ""
+
+# --- Extract changelog section for this version ---
+CHANGELOG_SECTION=$(awk "
+  /^## \[${VERSION}\]/ { found=1; next }
+  /^## \[/             { if (found) exit }
+  found                { print }
+" CHANGELOG.md | sed '/^[[:space:]]*$/d')
+
+if [[ -z "$CHANGELOG_SECTION" ]]; then
+  CHANGELOG_SECTION="(no changelog entry found for ${LATEST_TAG})"
+fi
+
+# --- Build device hint for the prompt ---
+if [[ -n "$DEVICE" ]]; then
+  DEVICE_HINT="Target device serial: ${DEVICE}. Pass this as the 'device' parameter to all MCP tool calls."
+else
+  DEVICE_HINT="Use the default connected device (omit the 'device' parameter from tool calls)."
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  LunaChron smoke test — ${LATEST_TAG}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "Changes in this release:"
+echo "$CHANGELOG_SECTION"
+echo ""
+echo "Preflight passed — handing off to agent..."
+echo ""
+
+PROMPT="You are a QA tester for the LunaChron Moonstone companion Android app \
+(package: io.github.garemat.lunachron).
+
+Version ${LATEST_TAG} was just published to the Play Store. Here is what changed in this release:
+
+${CHANGELOG_SECTION}
+
+${DEVICE_HINT}
+
+Your job: test the app on the emulator as a real user would. Focus on the features and fixes \
+listed above, but also do a quick sanity check of the core flows so we catch obvious regressions.
+
+Core flows to verify:
+- App launches without crashing
+- Home screen loads with news feed
+- Bottom nav tabs are accessible (Compendium, Play, Troupes, Campaigns)
+- At least one feature from the changelog above
+
+Use the Android MCP tools to interact with the device. Start by launching the app, then navigate \
+and interact naturally. Take screenshots to confirm state where useful.
+
+For each area you test, report:
+- What you tested
+- Whether it worked correctly
+- Any issues — crashes, slow loading (note if something took more than ~2 s), visual glitches, \
+  or unexpected behaviour
+
+Be concise and specific. Structure your final output as a short findings list. \
+If everything looks fine, say so."
+
+claude --model claude-haiku-4-5-20251001 --dangerously-skip-permissions -p "$PROMPT"


### PR DESCRIPTION
## Description

Adds a local smoke test script (`scripts/smoke-test.sh`) that can be run manually after publishing a release to the Play Store.

The script:
1. **Preflight checks** — deterministic ADB assertions before spending any tokens: `adb` on PATH, device online, app installed, version matches latest tag, clean launch with no crash in logcat
2. **Changelog context** — extracts the changelog section for the latest tag and passes it as context to the agent; if no entry exists there's nothing feature-specific to test and the agent falls back to core flow checks
3. **Haiku agent** — hands off to `claude-haiku-4-5-20251001` via the `android-mcp` MCP server, which can take screenshots, inspect the UI hierarchy, tap, swipe, and type; the agent navigates the app as a user would and returns a structured findings list

Also adds `.mcp.json` to register the `android-mcp` server for Claude Code sessions in this repo, and `.claude/settings.json` to enable it.

**Usage:**
```bash
./scripts/smoke-test.sh                  # default device
./scripts/smoke-test.sh emulator-5554    # specific device
```

**Requirements:** `android-mcp` (`pip install android-mcp`) and `claude` CLI on PATH, emulator running with app installed.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)