### PR TITLE
chore: add content descriptions to icon-only buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Extend troupe character search to include abilities
+- Extend troupe character search to include abilities (#128)
 
 
 ## [2.12.6] - 2026-04-21

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "io.github.garemat.lunachron"
         minSdk = 24
         targetSdk = 36
-        versionCode = 21300
-        versionName = "2.13.0"
+        versionCode = 21301
+        versionName = "2.13.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/AddEditTroupeScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/AddEditTroupeScreen.kt
@@ -238,7 +238,7 @@ fun AddEditTroupeScreen(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     modifier = Modifier.onGloballyPositioned { onTargetPositioned("ConfirmSelectionButton", it) }
                 ) {
-                    Icon(Icons.Default.Check, contentDescription = null)
+                    Icon(Icons.Default.Check, contentDescription = "Confirm selection")
                 }
             }
         }
@@ -590,7 +590,7 @@ private fun TroupeHeader(
             Text("Victory Points:", style = MaterialTheme.typography.labelMedium)
             Spacer(modifier = Modifier.width(8.dp))
             IconButton(onClick = { onVictoryPointsChange((victoryPoints - 1).coerceAtLeast(0)) }, modifier = Modifier.size(24.dp)) {
-                Icon(Icons.Default.Remove, contentDescription = null)
+                Icon(Icons.Default.Remove, contentDescription = "Decrease victory points")
             }
             Text(
                 text = victoryPoints.toString(),
@@ -599,7 +599,7 @@ private fun TroupeHeader(
                 modifier = Modifier.padding(horizontal = 8.dp)
             )
             IconButton(onClick = { onVictoryPointsChange(victoryPoints + 1) }, modifier = Modifier.size(24.dp)) {
-                Icon(Icons.Default.Add, contentDescription = null)
+                Icon(Icons.Default.Add, contentDescription = "Increase victory points")
             }
         }
 
@@ -1055,7 +1055,7 @@ private fun DashboardFabColumn(
                     MaterialTheme.colorScheme.surfaceVariant,
                 modifier = Modifier.onGloballyPositioned { onTargetPositioned("SaveButton", it) }
             ) {
-                Icon(Icons.Default.Check, contentDescription = null)
+                Icon(Icons.Default.Check, contentDescription = "Save troupe")
             }
         }
     }
@@ -1237,7 +1237,7 @@ private fun CampaignCardManagementSheet(
                 leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
                 trailingIcon = {
                     if (searchQuery.isNotEmpty()) IconButton(onClick = { searchQuery = "" }) {
-                        Icon(Icons.Default.Clear, contentDescription = null)
+                        Icon(Icons.Default.Clear, contentDescription = "Clear search")
                     }
                 },
                 singleLine = true,
@@ -1617,7 +1617,7 @@ private fun UpgradeManagementSheet(
                 leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
                 trailingIcon = {
                     if (searchQuery.isNotEmpty()) IconButton(onClick = { searchQuery = "" }) {
-                        Icon(Icons.Default.Clear, contentDescription = null)
+                        Icon(Icons.Default.Clear, contentDescription = "Clear search")
                     }
                 },
                 singleLine = true,

--- a/app/src/main/java/io/github/garemat/lunachron/ui/TroupeListScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/TroupeListScreen.kt
@@ -49,13 +49,13 @@ fun TroupeListScreen(
                 if (selectionMode) {
                     CenterAlignedTopAppBar(
                         title = { Text(if (isCampaignSelection) "Select Campaign Troupe" else "Select Tournament Troupe", style = theme.titleStyle) },
-                        navigationIcon = { IconButton(onClick = onNavigateBack) { Icon(Icons.Default.ArrowBack, contentDescription = null) } }
+                        navigationIcon = { IconButton(onClick = onNavigateBack) { Icon(Icons.Default.ArrowBack, contentDescription = "Back") } }
                     )
                 }
             },
             floatingActionButton = {
                 if (!selectionMode) {
-                    FloatingActionButton(onClick = onAddTroupe, modifier = Modifier.onGloballyPositioned { onTargetPositioned("AddTroupe", it) }) { Icon(Icons.Default.Add, contentDescription = null) }
+                    FloatingActionButton(onClick = onAddTroupe, modifier = Modifier.onGloballyPositioned { onTargetPositioned("AddTroupe", it) }) { Icon(Icons.Default.Add, contentDescription = "Add troupe") }
                 }
             }
         ) { padding ->
@@ -190,12 +190,12 @@ fun TroupeListItem(
                     }
                 }
                 if (selectionMode) {
-                    IconButton(onClick = onEdit, modifier = Modifier.size(36.dp)) { Icon(Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(20.dp)) }
+                    IconButton(onClick = onEdit, modifier = Modifier.size(36.dp)) { Icon(Icons.Default.Edit, contentDescription = "Edit troupe", modifier = Modifier.size(20.dp)) }
                 } else {
                     IconButton(onClick = onQr, modifier = Modifier.size(36.dp)) { Icon(Icons.Default.QrCode, contentDescription = "Show QR", modifier = Modifier.size(20.dp)) }
-                    IconButton(onClick = onShare, modifier = Modifier.size(36.dp).onGloballyPositioned { onPositioned("ShareTroupe", it) }) { Icon(Icons.Default.Share, contentDescription = null, modifier = Modifier.size(20.dp)) }
+                    IconButton(onClick = onShare, modifier = Modifier.size(36.dp).onGloballyPositioned { onPositioned("ShareTroupe", it) }) { Icon(Icons.Default.Share, contentDescription = "Share troupe", modifier = Modifier.size(20.dp)) }
                 }
-                if (showDelete) IconButton(onClick = onDelete, modifier = Modifier.size(36.dp).onGloballyPositioned { onPositioned("DeleteTroupe", it) }) { Icon(Icons.Default.Delete, contentDescription = null, modifier = Modifier.size(20.dp), tint = MaterialTheme.colorScheme.error) }
+                if (showDelete) IconButton(onClick = onDelete, modifier = Modifier.size(36.dp).onGloballyPositioned { onPositioned("DeleteTroupe", it) }) { Icon(Icons.Default.Delete, contentDescription = "Delete troupe", modifier = Modifier.size(20.dp), tint = MaterialTheme.colorScheme.error) }
             }
             if (!characters.isNullOrEmpty()) {
                 Spacer(modifier = Modifier.height(8.dp))

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -82,6 +82,15 @@ if [[ -z "$CHANGELOG_SECTION" ]]; then
   CHANGELOG_SECTION="(no changelog entry found for ${LATEST_TAG})"
 fi
 
+# --- Get files changed since previous tag ---
+PREV_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]' | sed -n '2p')
+if [[ -n "$PREV_TAG" ]]; then
+  CHANGED_FILES=$(git diff "${PREV_TAG}...${LATEST_TAG}" --name-only \
+    | grep -v '^CHANGELOG\|^data\.version\|^app/build\.gradle' || true)
+else
+  CHANGED_FILES=""
+fi
+
 # --- Build device hint for the prompt ---
 if [[ -n "$DEVICE" ]]; then
   DEVICE_HINT="Target device serial: ${DEVICE}. Pass this as the 'device' parameter to all MCP tool calls."
@@ -95,9 +104,24 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 echo ""
 echo "Changes in this release:"
 echo "$CHANGELOG_SECTION"
+if [[ -n "$CHANGED_FILES" ]]; then
+  echo ""
+  echo "Files changed:"
+  echo "$CHANGED_FILES"
+fi
 echo ""
 echo "Preflight passed — handing off to agent..."
 echo ""
+
+# Build changed files section for prompt
+if [[ -n "$CHANGED_FILES" ]]; then
+  FILES_CONTEXT="Files modified in this release (use these to infer which screens to focus on):
+${CHANGED_FILES}
+
+"
+else
+  FILES_CONTEXT=""
+fi
 
 PROMPT="You are a QA tester for the LunaChron Moonstone companion Android app \
 (package: io.github.garemat.lunachron).
@@ -106,7 +130,7 @@ Version ${LATEST_TAG} was just published to the Play Store. Here is what changed
 
 ${CHANGELOG_SECTION}
 
-${DEVICE_HINT}
+${FILES_CONTEXT}${DEVICE_HINT}
 
 Your job: test the app on the emulator as a real user would. Focus on the features and fixes \
 listed above, but also do a quick sanity check of the core flows so we catch obvious regressions.

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -49,14 +49,18 @@ pass "device online"
   || fail "app not installed on device (${PACKAGE})"
 pass "app installed"
 
-# 4. App version matches latest tag
-INSTALLED_VERSION=$( "${ADB_TARGET[@]}" shell dumpsys package "$PACKAGE" 2>/dev/null \
-  | grep -m1 'versionName' | sed 's/.*versionName=//' | tr -d '[:space:]' )
-if [[ "$INSTALLED_VERSION" != "$VERSION" ]]; then
-  echo "  ⚠ version mismatch: installed=${INSTALLED_VERSION}, tag=${VERSION} (continuing anyway)"
-else
-  pass "version matches tag (${VERSION})"
-fi
+# 4b. Download and install the release APK from GitHub
+APK_TMP=$(mktemp /tmp/lunachron-XXXXXX.apk)
+echo "  Downloading ${LATEST_TAG} APK..."
+gh release download "$LATEST_TAG" \
+  --repo Garemat/lunachron \
+  --pattern "app-github-release.apk" \
+  --output "$APK_TMP" 2>/dev/null \
+  || fail "could not download APK for ${LATEST_TAG} — is gh authenticated?"
+"${ADB_TARGET[@]}" install -r "$APK_TMP" &>/dev/null \
+  || fail "adb install failed"
+rm -f "$APK_TMP"
+pass "release APK installed (${LATEST_TAG})"
 
 # 5. App launches without immediate crash — force-stop first for a clean slate
 "${ADB_TARGET[@]}" shell am force-stop "$PACKAGE" 2>/dev/null || true
@@ -142,7 +146,8 @@ Core flows to verify:
 - At least one feature from the changelog above
 
 Use the Android MCP tools to interact with the device. Start by launching the app, then navigate \
-and interact naturally. Take screenshots to confirm state where useful.
+and interact naturally. Prefer get_ui_hierarchy over screenshot for navigation decisions — it is \
+faster and cheaper. Only use screenshot when verifying something visual (colours, layout, theme).
 
 For each area you test, report:
 - What you tested


### PR DESCRIPTION
## Description

Adds `contentDescription` to icon-only interactive buttons in `TroupeListScreen` and `AddEditTroupeScreen`. Previously these buttons had `contentDescription = null`, which meant the UIAutomator accessibility tree exposed them as unlabelled `Button ''` nodes — forcing the MCP smoke test agent to use coordinate-based tapping instead of the faster `tap_element()` by label.

**TroupeListScreen:**
- FAB → `"Add troupe"`
- Back arrow → `"Back"`
- Edit button → `"Edit troupe"`
- Share button → `"Share troupe"`
- Delete button → `"Delete troupe"`

**AddEditTroupeScreen:**
- Confirm selection → `"Confirm selection"`
- Save troupe → `"Save troupe"`
- VP stepper → `"Decrease/Increase victory points"`
- Search clear (both instances) → `"Clear search"`

Also improves accessibility for screen reader users — these buttons were previously completely invisible to TalkBack.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)