### PR TITLE
fix: resolve smoke test APK download and install issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.2] - 2026-04-22
+
+### Fixed
+
+- Resolve APK download and install issues in smoke test
+
+
 ## [2.13.0] - 2026-04-21
 
 ### Added

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "io.github.garemat.lunachron"
         minSdk = 24
         targetSdk = 36
-        versionCode = 21301
-        versionName = "2.13.1"
+        versionCode = 21302
+        versionName = "2.13.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -55,9 +55,11 @@ echo "  Downloading ${LATEST_TAG} APK..."
 gh release download "$LATEST_TAG" \
   --repo Garemat/lunachron \
   --pattern "app-github-release.apk" \
-  --output "$APK_TMP" 2>/dev/null \
+  --output "$APK_TMP" \
+  --clobber 2>/dev/null \
   || fail "could not download APK for ${LATEST_TAG} — is gh authenticated?"
-"${ADB_TARGET[@]}" install -r "$APK_TMP" &>/dev/null \
+"${ADB_TARGET[@]}" uninstall "$PACKAGE" &>/dev/null || true
+"${ADB_TARGET[@]}" install "$APK_TMP" &>/dev/null \
   || fail "adb install failed"
 rm -f "$APK_TMP"
 pass "release APK installed (${LATEST_TAG})"


### PR DESCRIPTION
## Description

Two small fixes to `scripts/smoke-test.sh` that were blocking the preflight APK install step:

- **`--clobber` on `gh release download`** — `mktemp` pre-creates the temp file; without this flag `gh` refuses to overwrite it and exits non-zero
- **Uninstall before install** — replaced `adb install -r` with an unconditional uninstall followed by a fresh install, to handle signature mismatches between any previously installed debug build and the signed release APK

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)