### PR TITLE
feat: accessibility & UX improvements for compendium and character list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.0] - 2026-04-22
+
+### Added
+
+- Accessibility & UX improvements for smaller displays
+
+- Inline faction icons with search bar in filter header
+
+
+### Fixed
+
+- Detect reloadable abilities via Reload [X] naming as fallback
+
+
 ## [2.13.2] - 2026-04-22
 
 ### Fixed
 
-- Resolve APK download and install issues in smoke test
+- Resolve smoke test APK download and install issues (#130)
 
 
 ## [2.13.0] - 2026-04-21

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "io.github.garemat.lunachron"
         minSdk = 24
         targetSdk = 36
-        versionCode = 21302
-        versionName = "2.13.2"
+        versionCode = 21400
+        versionName = "2.14.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/io/github/garemat/lunachron/Character.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/Character.kt
@@ -53,6 +53,7 @@ data class Ability(
     val pulse: Boolean? = null,      // null for Passive
     val oncePerTurn: Boolean = false,
     val oncePerGame: Boolean = false,
+    val reloadable: Boolean = false,
     val arcaneOutcomes: List<ArcaneOutcome> = emptyList()
 )
 

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
@@ -57,6 +57,8 @@ sealed interface CharacterEvent {
 
     // Game View / Tracking
     data class ChangeGameTrackingMode(val mode: GameTrackingMode) : CharacterEvent
+    data class SetEnableAnimations(val enabled: Boolean) : CharacterEvent
+    data class SetDefaultStartPage(val route: String) : CharacterEvent
     data class AddSummonedCharacter(val playerIndex: Int, val characterId: Int, val summonedByCharacterId: Int?) : CharacterEvent
     data class RemoveSummonedCharacter(val playerIndex: Int, val characterId: Int) : CharacterEvent
     data class UpdatePoolResource(val playerIndex: Int, val resourceName: String, val count: Int) : CharacterEvent

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
@@ -268,6 +268,8 @@ data class CharacterState(
     val tournamentHistory: List<TournamentRound> = emptyList(),
 
     val gameTrackingMode: GameTrackingMode = GameTrackingMode.LOW_DETAIL,
+    val enableAnimations: Boolean = true,
+    val defaultStartPage: String = "home",
 
     // Active Game Play State
     val currentTurn: Int = 1,

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -94,6 +94,8 @@ class CharacterViewModel(
         useSinglePlayerMode = prefs.getBoolean("use_single_player_mode", false),
         hasSeenGlobalTutorial = prefs.getBoolean("has_seen_global_tutorial", false),
         gameTrackingMode = GameTrackingMode.valueOf(prefs.getString("game_tracking_mode", GameTrackingMode.LOW_DETAIL.name) ?: GameTrackingMode.LOW_DETAIL.name),
+        enableAnimations = prefs.getBoolean("enable_animations", true),
+        defaultStartPage = prefs.getString("default_start_page", "home") ?: "home",
         newsItems = loadCachedNews(),
         autoFetchNews = prefs.getBoolean("auto_fetch_news", false),
         autoCheckDataUpdates = dataUpdateRepository.loadAutoCheck(),
@@ -608,6 +610,14 @@ class CharacterViewModel(
                     putString("game_tracking_mode", event.mode.name)
                     putBoolean("tracking_mode_overridden", true)
                 }
+            }
+            is CharacterEvent.SetEnableAnimations -> {
+                _state.update { it.copy(enableAnimations = event.enabled) }
+                prefs.edit { putBoolean("enable_animations", event.enabled) }
+            }
+            is CharacterEvent.SetDefaultStartPage -> {
+                _state.update { it.copy(defaultStartPage = event.route) }
+                prefs.edit { putString("default_start_page", event.route) }
             }
             is CharacterEvent.AddSummonedCharacter -> {
                 _state.update { cur ->

--- a/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
@@ -36,6 +36,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import io.github.garemat.lunachron.ui.*
+import io.github.garemat.lunachron.ui.theme.LocalAnimationsEnabled
 import io.github.garemat.lunachron.ui.theme.LocalAppThemeProperties
 import io.github.garemat.lunachron.ui.theme.LunachronTheme
 import androidx.compose.ui.platform.LocalContext
@@ -111,6 +112,7 @@ class MainActivity : ComponentActivity() {
                 activeThemeId = state.activeThemeId,
                 layoutDensity = state.layoutDensity
             ) {
+                CompositionLocalProvider(LocalAnimationsEnabled provides state.enableAnimations) {
                 val theme = LocalAppThemeProperties.current
                 val navController = rememberNavController()
                 val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
@@ -118,6 +120,12 @@ class MainActivity : ComponentActivity() {
                 val navBackStackEntry by navController.currentBackStackEntryAsState()
                 val currentDestination = navBackStackEntry?.destination
                 val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+                var anyCharacterExpanded by remember { mutableStateOf(false) }
+
+                // Reset expansion tracking when leaving the character list
+                LaunchedEffect(currentDestination?.route) {
+                    if (currentDestination?.route != Screen.Characters.route) anyCharacterExpanded = false
+                }
 
                 val showNavBars = remember(currentDestination) {
                     currentDestination?.route?.split("/")?.firstOrNull() in listOf(
@@ -141,6 +149,9 @@ class MainActivity : ComponentActivity() {
                         "campaign_details"
                     )
                 }
+
+                val showBottomBar = showNavBars &&
+                    !(currentDestination?.route == Screen.Characters.route && anyCharacterExpanded)
 
                 LaunchedEffect(viewModel.uiEvent) {
                     viewModel.uiEvent.collect { event ->
@@ -311,6 +322,7 @@ class MainActivity : ComponentActivity() {
                                             }
                                         }
                                     },
+                                    expandedHeight = 48.dp,
                                     colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
                                         containerColor = MaterialTheme.colorScheme.surfaceVariant,
                                         titleContentColor = MaterialTheme.colorScheme.primary,
@@ -321,7 +333,7 @@ class MainActivity : ComponentActivity() {
                             }
                         },
                         bottomBar = {
-                            if (showNavBars) {
+                            if (showBottomBar) {
                                 NavigationBar(
                                     containerColor = if (theme.navigationBarElevation == 0.dp) MaterialTheme.colorScheme.surface else MaterialTheme.colorScheme.surfaceVariant,
                                     tonalElevation = theme.navigationBarElevation
@@ -402,9 +414,10 @@ class MainActivity : ComponentActivity() {
                         }
                     ) { innerPadding ->
                         Box(modifier = Modifier.fillMaxSize()) {
-                            NavHost(
+                            val startDestination = remember { state.defaultStartPage }
+                        NavHost(
                                 navController = navController,
-                                startDestination = Screen.Home.route,
+                                startDestination = startDestination,
                                 modifier = Modifier.padding(innerPadding)
                             ) {
                                 composable(Screen.Home.route) {
@@ -443,6 +456,7 @@ class MainActivity : ComponentActivity() {
                                         state = state,
                                         onEvent = viewModel::onEvent,
                                         onNavigateBack = { navController.safePopBackStack() },
+                                        onExpansionChanged = { anyCharacterExpanded = it },
                                         onTargetPositioned = { name, coords -> tutorialCoords[name] = coords }
                                     )
                                 }
@@ -759,6 +773,7 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+        } // CompositionLocalProvider
     }
 }
 

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
@@ -596,6 +596,7 @@ private fun ActiveGameTopBar(
                     Icon(Icons.Default.Close, contentDescription = null)
                 }
             },
+            expandedHeight = 48.dp,
             colors = TopAppBarDefaults.centerAlignedTopAppBarColors(containerColor = Color.Transparent),
             windowInsets = WindowInsets(top = 0.dp)
         )

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CharacterListScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CharacterListScreen.kt
@@ -32,13 +32,16 @@ fun CharacterListScreen(
     state: CharacterState,
     onEvent: (CharacterEvent) -> Unit,
     onNavigateBack: () -> Unit,
+    onExpansionChanged: (Boolean) -> Unit = {},
     onTargetPositioned: (String, LayoutCoordinates) -> Unit = { _, _ -> }
 ) {
-    var expandedCharacterIds by remember { mutableStateOf(setOf<Int>()) }
+    // Track expansion order so we can drop the oldest when >3 are open
+    var expandedCharacterIdsList by remember { mutableStateOf(listOf<Int>()) }
+    val expandedCharacterIds = expandedCharacterIdsList.toSet()
     var searchQuery by remember { mutableStateOf("") }
     var selectedFactions by remember { mutableStateOf(setOf<Faction>()) }
     val theme = LocalAppThemeProperties.current
-    
+
     val availableTags = remember(state.characters, selectedFactions) {
         state.characters
             .filter { char -> selectedFactions.isEmpty() || char.factions.any { it in selectedFactions } }
@@ -46,20 +49,25 @@ fun CharacterListScreen(
             .distinct()
             .sorted()
     }
-    
-    var selectedTags by remember { mutableStateOf(setOf<String>()) }
+
+    var includedTags by remember { mutableStateOf(setOf<String>()) }
+    var excludedTags by remember { mutableStateOf(setOf<String>()) }
     var showFilterExpanded by remember { mutableStateOf(true) }
-    val filtersActive = selectedFactions.isNotEmpty() || selectedTags.isNotEmpty() || searchQuery.isNotEmpty()
+    val filtersActive = selectedFactions.isNotEmpty() || includedTags.isNotEmpty() || excludedTags.isNotEmpty() || searchQuery.isNotEmpty()
+
+    LaunchedEffect(expandedCharacterIds) {
+        onExpansionChanged(expandedCharacterIds.isNotEmpty())
+    }
 
     LaunchedEffect(searchQuery) {
         if (searchQuery.isEmpty()) {
-            expandedCharacterIds = emptySet()
+            expandedCharacterIdsList = emptyList()
         } else {
             val matchingIds = state.characters.filter { character ->
                 character.name.contains(searchQuery, ignoreCase = true) ||
                 character.abilities.any { it.name.contains(searchQuery, ignoreCase = true) || it.description.contains(searchQuery, ignoreCase = true) }
-            }.map { it.id }.toSet()
-            if (matchingIds.size in 1..3) expandedCharacterIds = matchingIds
+            }.map { it.id }
+            if (matchingIds.size in 1..3) expandedCharacterIdsList = matchingIds
         }
     }
 
@@ -68,17 +76,19 @@ fun CharacterListScreen(
     val screenHeight = LocalConfiguration.current.screenHeightDp.dp
 
     LaunchedEffect(availableTags) {
-        selectedTags = selectedTags.filter { it in availableTags }.toSet()
+        includedTags = includedTags.filter { it in availableTags }.toSet()
+        excludedTags = excludedTags.filter { it in availableTags }.toSet()
     }
 
-    val filteredCharacters = remember(state.characters, searchQuery, selectedFactions, selectedTags) {
+    val filteredCharacters = remember(state.characters, searchQuery, selectedFactions, includedTags, excludedTags) {
         state.characters.filter { character ->
             val matchesFaction = selectedFactions.isEmpty() || character.factions.any { it in selectedFactions }
-            val matchesTags = selectedTags.isEmpty() || character.keywords.containsAll(selectedTags)
+            val matchesIncluded = includedTags.isEmpty() || character.keywords.containsAll(includedTags)
+            val matchesExcluded = excludedTags.isEmpty() || !character.keywords.any { it in excludedTags }
             val matchesSearch = searchQuery.isEmpty() ||
                 character.name.contains(searchQuery, ignoreCase = true) ||
                 character.abilities.any { it.name.contains(searchQuery, ignoreCase = true) || it.description.contains(searchQuery, ignoreCase = true) }
-            matchesFaction && matchesTags && matchesSearch
+            matchesFaction && matchesIncluded && matchesExcluded && matchesSearch
         }.sortedBy { it.name }
     }
 
@@ -104,16 +114,19 @@ fun CharacterListScreen(
                     onSearchQueryChange = { searchQuery = it },
                     selectedFactions = selectedFactions,
                     onFactionsChange = { selectedFactions = it },
-                    selectedTags = selectedTags,
-                    onTagsChange = { selectedTags = it },
+                    selectedTags = includedTags,
+                    onTagsChange = { includedTags = it },
+                    excludedTags = excludedTags,
+                    onExcludedTagsChange = { excludedTags = it },
                     availableTags = availableTags,
                     showCollapseAll = expandedCharacterIds.isNotEmpty(),
-                    onCollapseAll = { expandedCharacterIds = emptySet() },
+                    onCollapseAll = { expandedCharacterIdsList = emptyList() },
                     onClearAll = {
                         searchQuery = ""
                         selectedFactions = emptySet()
-                        selectedTags = emptySet()
-                        expandedCharacterIds = emptySet()
+                        includedTags = emptySet()
+                        excludedTags = emptySet()
+                        expandedCharacterIdsList = emptyList()
                     },
                     onTargetPositioned = onTargetPositioned
                 )
@@ -145,9 +158,13 @@ fun CharacterListScreen(
                         searchQuery = searchQuery,
                         isExpanded = expandedCharacterIds.contains(character.id),
                         onExpandClick = {
-                            val isCurrentlyExpanded = expandedCharacterIds.contains(character.id)
-                            expandedCharacterIds = if (isCurrentlyExpanded) expandedCharacterIds - character.id else expandedCharacterIds + character.id
-                            if (!isCurrentlyExpanded) {
+                            val isCurrentlyExpanded = character.id in expandedCharacterIds
+                            if (isCurrentlyExpanded) {
+                                expandedCharacterIdsList = expandedCharacterIdsList - character.id
+                            } else {
+                                val newList = expandedCharacterIdsList + character.id
+                                // Cap at 3 open cards — drop the oldest if needed
+                                expandedCharacterIdsList = if (newList.size > 3) newList.drop(newList.size - 3) else newList
                                 val index = filteredCharacters.indexOfFirst { it.id == character.id }
                                 if (index >= 0) coroutineScope.launch { listState.animateScrollToItem(index) }
                             }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -35,8 +35,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import io.github.garemat.lunachron.ui.theme.LocalAnimationsEnabled
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.Placeholder
@@ -435,14 +437,13 @@ fun CharacterFront(
 ) {
     val theme = LocalAppThemeProperties.current
     Column {
-        if (theme.showExpandedStatsHeader) MoonstoneHeader(character, searchQuery)
+        if (theme.showExpandedStatsHeader) MoonstoneStats(character)
         else Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
             CommonStatBox("Melee", character.melee.toString(), showDivider = true)
             CommonStatBox("Range", "${character.meleeRange}\"", showDivider = true)
             CommonStatBox("Arcane", character.arcane.toString(), showDivider = true)
             CommonStatBox("Evade", character.evade.toString(), showDivider = true)
         }
-        if (theme.showExpandedStatsHeader) MoonstoneStats(character)
         Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
         val passiveAbilities = character.abilities.filter { it.abilityType == "Passive" }
         val activeAbilities = character.abilities.filter { it.abilityType == "Active" }
@@ -450,6 +451,7 @@ fun CharacterFront(
         passiveAbilities.forEach { ability ->
             CommonAbilityItem(
                 ability.name, ability.description, searchQuery, ability.oncePerTurn, ability.oncePerGame,
+                reloadable = ability.reloadable,
                 passive = true,
                 isUsed = abilityUsedStates?.get(ability.name) ?: false,
                 onUsedChange = if (abilityUsedStates != null) { used -> onAbilityUsedChange?.invoke(ability.name, used) } else null,
@@ -462,6 +464,7 @@ fun CharacterFront(
                 CommonAbilityItem(
                     "${ability.name} (${ability.energyCost ?: 0}) ${ability.range ?: ""}",
                     ability.description, searchQuery, ability.oncePerTurn, ability.oncePerGame,
+                    reloadable = ability.reloadable,
                     showColon = false,
                     isUsed = abilityUsedStates?.get(ability.name) ?: false,
                     onUsedChange = if (abilityUsedStates != null) { used -> onAbilityUsedChange?.invoke(ability.name, used) } else null,
@@ -475,6 +478,7 @@ fun CharacterFront(
                 CommonAbilityItem(
                     "${ability.name} (${ability.energyCost ?: 0}) ${ability.range ?: ""}",
                     buildArcaneDescription(ability), searchQuery, ability.oncePerTurn, ability.oncePerGame,
+                    reloadable = ability.reloadable,
                     showColon = false,
                     isUsed = abilityUsedStates?.get(ability.name) ?: false,
                     onUsedChange = if (abilityUsedStates != null) { used -> onAbilityUsedChange?.invoke(ability.name, used) } else null,
@@ -592,7 +596,11 @@ fun CharacterBack(character: Character, searchQuery: String, onFlip: () -> Unit,
 fun CommonCharacterCard(character: Character, searchQuery: String, isExpanded: Boolean, onExpandClick: () -> Unit, modifier: Modifier = Modifier, cardTargetName: String = "CharacterCard", onPositioned: (String, LayoutCoordinates) -> Unit = { _, _ -> }, forceFlipped: Boolean? = null, selectionControl: @Composable (RowScope.() -> Unit)? = null, bottomContent: (@Composable () -> Unit)? = null) {
     var isFlippedState by remember { mutableStateOf(false) }; val isFlipped = forceFlipped ?: isFlippedState
     val theme = LocalAppThemeProperties.current
-    ThemedCard(modifier = modifier.fillMaxWidth().animateContentSize().onGloballyPositioned { onPositioned(cardTargetName, it) }) {
+    val animationsEnabled = LocalAnimationsEnabled.current
+    val screenHeight = LocalConfiguration.current.screenHeightDp.dp
+    // Constrain card body to leave room for top bar (~48dp), bottom nav (~80dp), card header (~72dp) and margins
+    val maxCardBodyHeight = (screenHeight - 48.dp - 80.dp - 72.dp - 32.dp).coerceAtLeast(300.dp)
+    ThemedCard(modifier = modifier.fillMaxWidth().then(if (animationsEnabled) Modifier.animateContentSize() else Modifier).onGloballyPositioned { onPositioned(cardTargetName, it) }) {
         Column {
             Row(modifier = Modifier.fillMaxWidth().clickable { onExpandClick() }.padding(theme.cardContentPadding), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                 if (selectionControl != null) { selectionControl(); Spacer(modifier = Modifier.width(4.dp)) }
@@ -608,17 +616,24 @@ fun CommonCharacterCard(character: Character, searchQuery: String, isExpanded: B
             }
             if (isExpanded) {
                 if (theme.showCardDivider) HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
-                CharacterCardContent(
-                    character = character,
-                    searchQuery = searchQuery,
-                    isFlipped = isFlipped,
-                    onFlip = { isFlippedState = !isFlippedState },
-                    modifier = Modifier.fillMaxWidth(),
-                    animateFlip = true,
-                    showBackgroundImage = theme.showBackgroundImageOverlay,
-                    showHealthTracker = true,
-                    onFlipPositioned = { onPositioned("FlipButton", it) }
-                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = maxCardBodyHeight)
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    CharacterCardContent(
+                        character = character,
+                        searchQuery = searchQuery,
+                        isFlipped = isFlipped,
+                        onFlip = { isFlippedState = !isFlippedState },
+                        modifier = Modifier.fillMaxWidth(),
+                        animateFlip = true,
+                        showBackgroundImage = theme.showBackgroundImageOverlay,
+                        showHealthTracker = true,
+                        onFlipPositioned = { onPositioned("FlipButton", it) }
+                    )
+                }
             }
             bottomContent?.invoke()
         }
@@ -659,6 +674,7 @@ fun CharacterCardContent(
     val theme = LocalAppThemeProperties.current
     val context = LocalContext.current
     val localDensity = LocalDensity.current
+    val animationsEnabled = LocalAnimationsEnabled.current
 
     val bgImageFile = remember(character.imageName) {
         character.imageName?.let { name ->
@@ -671,14 +687,14 @@ fun CharacterCardContent(
 
     val rotation by animateFloatAsState(
         targetValue = if (isFlipped) 180f else 0f,
-        animationSpec = if (animateFlip) tween(durationMillis = 600) else tween(durationMillis = 0),
+        animationSpec = if (animateFlip && animationsEnabled) tween(durationMillis = 600) else tween(durationMillis = 0),
         label = "cardFlip"
     )
     val showBack = rotation > 90f
 
     var frontHeightPx by remember { mutableStateOf(0) }
 
-    Box(modifier = modifier) {
+    Box(modifier = modifier.clickable { onFlip() }) {
         // Full-bleed background art
         if (showBackgroundImage && bgImageFile != null) {
             AsyncImage(
@@ -1045,8 +1061,30 @@ fun HealthPip(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CharacterFilterHeader(searchQuery: String, onSearchQueryChange: (String) -> Unit, selectedFactions: Set<Faction>, onFactionsChange: (Set<Faction>) -> Unit, selectedTags: Set<String>, onTagsChange: (Set<String>) -> Unit, availableTags: List<String>, modifier: Modifier = Modifier, isFactionFixed: Boolean = false, showCollapseAll: Boolean = false, onCollapseAll: () -> Unit = {}, onClearAll: () -> Unit = {}, onTargetPositioned: (String, LayoutCoordinates) -> Unit = { _, _ -> }) { // showCollapseAll retained for API compat but no longer rendered
+fun CharacterFilterHeader(
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit,
+    selectedFactions: Set<Faction>,
+    onFactionsChange: (Set<Faction>) -> Unit,
+    selectedTags: Set<String>,
+    onTagsChange: (Set<String>) -> Unit,
+    availableTags: List<String>,
+    modifier: Modifier = Modifier,
+    isFactionFixed: Boolean = false,
+    // Exclusion support — when onExcludedTagsChange is non-null, tapping a keyword cycles
+    // through three states: unselected → include → exclude → unselected.
+    excludedTags: Set<String> = emptySet(),
+    onExcludedTagsChange: ((Set<String>) -> Unit)? = null,
+    showCollapseAll: Boolean = false,
+    onCollapseAll: () -> Unit = {},
+    onClearAll: () -> Unit = {},
+    onTargetPositioned: (String, LayoutCoordinates) -> Unit = { _, _ -> }
+) {
     val theme = LocalAppThemeProperties.current
+    val includeColor = MaterialTheme.colorScheme.primaryContainer
+    val excludeColor = MaterialTheme.colorScheme.errorContainer
+    val includeTextColor = MaterialTheme.colorScheme.onPrimaryContainer
+    val excludeTextColor = MaterialTheme.colorScheme.onErrorContainer
     Column(modifier = modifier.padding(theme.screenPadding)) {
         OutlinedTextField(value = searchQuery, onValueChange = onSearchQueryChange, modifier = Modifier.fillMaxWidth().onGloballyPositioned { onTargetPositioned("SearchField", it) }, placeholder = { Text("Search name or abilities...") }, leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) }, trailingIcon = { if (searchQuery.isNotEmpty()) IconButton(onClick = { onSearchQueryChange("") }) { Icon(Icons.Default.Clear, contentDescription = "Clear") } }, singleLine = true, shape = theme.cardShape)
         if (!isFactionFixed) { Spacer(modifier = Modifier.height(theme.verticalSpacing)); FactionSelector(selectedFactions = selectedFactions, onFactionsChange = onFactionsChange, onPositioned = { onTargetPositioned("FactionFilter", it) }) }
@@ -1058,20 +1096,42 @@ fun CharacterFilterHeader(searchQuery: String, onSearchQueryChange: (String) -> 
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                OutlinedButton(
-                    onClick = { showKeywordsDialog = true },
-                    shape = theme.cardShape
-                ) {
+                OutlinedButton(onClick = { showKeywordsDialog = true }, shape = theme.cardShape) {
                     Text("Keywords")
                 }
-                if (selectedTags.isNotEmpty()) {
+                val activeChipTags = selectedTags.toList() + excludedTags.filter { it !in selectedTags }.toList()
+                if (activeChipTags.isNotEmpty()) {
                     LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        items(selectedTags.toList()) { tag ->
+                        items(activeChipTags) { tag ->
+                            val isExcluded = tag in excludedTags
                             FilterChip(
                                 selected = true,
-                                onClick = { onTagsChange(selectedTags - tag) },
-                                label = { Text(tag) },
-                                leadingIcon = { Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(16.dp)) },
+                                onClick = {
+                                    if (onExcludedTagsChange != null) {
+                                        when {
+                                            // include → exclude
+                                            tag in selectedTags -> { onTagsChange(selectedTags - tag); onExcludedTagsChange(excludedTags + tag) }
+                                            // exclude → unselected
+                                            isExcluded -> onExcludedTagsChange(excludedTags - tag)
+                                            else -> onTagsChange(selectedTags - tag)
+                                        }
+                                    } else {
+                                        onTagsChange(selectedTags - tag)
+                                    }
+                                },
+                                label = { Text(if (isExcluded) "NOT $tag" else tag) },
+                                leadingIcon = {
+                                    Icon(
+                                        if (isExcluded) Icons.Default.Block else Icons.Default.Check,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(16.dp)
+                                    )
+                                },
+                                colors = FilterChipDefaults.filterChipColors(
+                                    selectedContainerColor = if (isExcluded) excludeColor else includeColor,
+                                    selectedLabelColor = if (isExcluded) excludeTextColor else includeTextColor,
+                                    selectedLeadingIconColor = if (isExcluded) excludeTextColor else includeTextColor
+                                ),
                                 shape = theme.cardShape
                             )
                         }
@@ -1093,8 +1153,11 @@ fun CharacterFilterHeader(searchQuery: String, onSearchQueryChange: (String) -> 
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Text("Keywords", style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.primary)
-                            if (selectedTags.isNotEmpty()) {
-                                TextButton(onClick = { onTagsChange(emptySet()) }) { Text("Clear") }
+                            if (selectedTags.isNotEmpty() || excludedTags.isNotEmpty()) {
+                                TextButton(onClick = {
+                                    onTagsChange(emptySet())
+                                    onExcludedTagsChange?.invoke(emptySet())
+                                }) { Text("Clear") }
                             }
                         }
                         Spacer(modifier = Modifier.height(8.dp))
@@ -1105,22 +1168,34 @@ fun CharacterFilterHeader(searchQuery: String, onSearchQueryChange: (String) -> 
                                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                                 ) {
                                     pair.forEach { tag ->
-                                        val isSelected = selectedTags.contains(tag)
-                                        if (isSelected) {
-                                            Button(
-                                                onClick = { onTagsChange(selectedTags - tag) },
+                                        val isIncluded = tag in selectedTags
+                                        val isExcluded = onExcludedTagsChange != null && tag in excludedTags
+                                        when {
+                                            isIncluded -> Button(
+                                                onClick = {
+                                                    if (onExcludedTagsChange != null) {
+                                                        onTagsChange(selectedTags - tag)
+                                                        onExcludedTagsChange(excludedTags + tag)
+                                                    } else {
+                                                        onTagsChange(selectedTags - tag)
+                                                    }
+                                                },
                                                 modifier = Modifier.weight(1f),
                                                 shape = theme.cardShape
                                             ) { Text(tag, maxLines = 1, overflow = TextOverflow.Ellipsis) }
-                                        } else {
-                                            OutlinedButton(
+                                            isExcluded -> Button(
+                                                onClick = { onExcludedTagsChange(excludedTags - tag) },
+                                                modifier = Modifier.weight(1f),
+                                                shape = theme.cardShape,
+                                                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                                            ) { Text("NOT $tag", maxLines = 1, overflow = TextOverflow.Ellipsis) }
+                                            else -> OutlinedButton(
                                                 onClick = { onTagsChange(selectedTags + tag) },
                                                 modifier = Modifier.weight(1f),
                                                 shape = theme.cardShape
                                             ) { Text(tag, maxLines = 1, overflow = TextOverflow.Ellipsis) }
                                         }
                                     }
-                                    // Fill empty cell if odd number of tags
                                     if (pair.size == 1) Spacer(modifier = Modifier.weight(1f))
                                 }
                             }
@@ -1129,7 +1204,7 @@ fun CharacterFilterHeader(searchQuery: String, onSearchQueryChange: (String) -> 
                 }
             }
         }
-        if (searchQuery.isNotEmpty() || selectedFactions.isNotEmpty() || selectedTags.isNotEmpty()) {
+        if (searchQuery.isNotEmpty() || selectedFactions.isNotEmpty() || selectedTags.isNotEmpty() || excludedTags.isNotEmpty()) {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                 TextButton(onClick = onClearAll) { Text("Clear All") }
             }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -448,10 +448,14 @@ fun CharacterFront(
         val passiveAbilities = character.abilities.filter { it.abilityType == "Passive" }
         val activeAbilities = character.abilities.filter { it.abilityType == "Active" }
         val arcaneAbilities = character.abilities.filter { it.abilityType == "Arcane" }
+        val reloadableByNaming = character.abilities
+            .filter { it.name.startsWith("Reload [") }
+            .map { it.name.removePrefix("Reload [").removeSuffix("]") }
+            .toSet()
         passiveAbilities.forEach { ability ->
             CommonAbilityItem(
                 ability.name, ability.description, searchQuery, ability.oncePerTurn, ability.oncePerGame,
-                reloadable = ability.reloadable,
+                reloadable = ability.reloadable || ability.name in reloadableByNaming,
                 passive = true,
                 isUsed = abilityUsedStates?.get(ability.name) ?: false,
                 onUsedChange = if (abilityUsedStates != null) { used -> onAbilityUsedChange?.invoke(ability.name, used) } else null,
@@ -464,7 +468,7 @@ fun CharacterFront(
                 CommonAbilityItem(
                     "${ability.name} (${ability.energyCost ?: 0}) ${ability.range ?: ""}",
                     ability.description, searchQuery, ability.oncePerTurn, ability.oncePerGame,
-                    reloadable = ability.reloadable,
+                    reloadable = ability.reloadable || ability.name in reloadableByNaming,
                     showColon = false,
                     isUsed = abilityUsedStates?.get(ability.name) ?: false,
                     onUsedChange = if (abilityUsedStates != null) { used -> onAbilityUsedChange?.invoke(ability.name, used) } else null,
@@ -478,7 +482,7 @@ fun CharacterFront(
                 CommonAbilityItem(
                     "${ability.name} (${ability.energyCost ?: 0}) ${ability.range ?: ""}",
                     buildArcaneDescription(ability), searchQuery, ability.oncePerTurn, ability.oncePerGame,
-                    reloadable = ability.reloadable,
+                    reloadable = ability.reloadable || ability.name in reloadableByNaming,
                     showColon = false,
                     isUsed = abilityUsedStates?.get(ability.name) ?: false,
                     onUsedChange = if (abilityUsedStates != null) { used -> onAbilityUsedChange?.invoke(ability.name, used) } else null,

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -331,15 +331,33 @@ fun FactionCircle(
 }
 
 @Composable
-fun FactionSelector(selectedFactions: Set<Faction>, onFactionsChange: (Set<Faction>) -> Unit, modifier: Modifier = Modifier, singleSelect: Boolean = false, onPositioned: (LayoutCoordinates) -> Unit = {}) {
+fun FactionSelector(
+    selectedFactions: Set<Faction>,
+    onFactionsChange: (Set<Faction>) -> Unit,
+    modifier: Modifier = Modifier,
+    singleSelect: Boolean = false,
+    // compact = true: smaller icons with tight spacing for inline use alongside a search bar
+    compact: Boolean = false,
+    onPositioned: (LayoutCoordinates) -> Unit = {}
+) {
     val anySelected = selectedFactions.isNotEmpty()
-    Row(modifier = modifier.fillMaxWidth().padding(vertical = 8.dp).onGloballyPositioned { onPositioned(it) }, horizontalArrangement = Arrangement.SpaceBetween) {
+    val iconSize = if (compact) 40.dp else 48.dp
+    val rowModifier = if (compact) {
+        modifier.onGloballyPositioned { onPositioned(it) }
+    } else {
+        modifier.fillMaxWidth().padding(vertical = 8.dp).onGloballyPositioned { onPositioned(it) }
+    }
+    Row(
+        modifier = rowModifier,
+        horizontalArrangement = if (compact) Arrangement.spacedBy(4.dp) else Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
         Faction.entries.forEach { faction ->
             val isSelected = selectedFactions.contains(faction)
             val iconAlpha = if (!anySelected || isSelected) 1f else 0.25f
             FactionIcon(
                 faction = faction,
-                size = 48.dp,
+                size = iconSize,
                 modifier = Modifier
                     .clickable { onFactionsChange(if (singleSelect) setOf(faction) else if (isSelected) selectedFactions - faction else selectedFactions + faction) }
                     .alpha(iconAlpha)
@@ -1090,8 +1108,14 @@ fun CharacterFilterHeader(
     val includeTextColor = MaterialTheme.colorScheme.onPrimaryContainer
     val excludeTextColor = MaterialTheme.colorScheme.onErrorContainer
     Column(modifier = modifier.padding(theme.screenPadding)) {
-        OutlinedTextField(value = searchQuery, onValueChange = onSearchQueryChange, modifier = Modifier.fillMaxWidth().onGloballyPositioned { onTargetPositioned("SearchField", it) }, placeholder = { Text("Search name or abilities...") }, leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) }, trailingIcon = { if (searchQuery.isNotEmpty()) IconButton(onClick = { onSearchQueryChange("") }) { Icon(Icons.Default.Clear, contentDescription = "Clear") } }, singleLine = true, shape = theme.cardShape)
-        if (!isFactionFixed) { Spacer(modifier = Modifier.height(theme.verticalSpacing)); FactionSelector(selectedFactions = selectedFactions, onFactionsChange = onFactionsChange, onPositioned = { onTargetPositioned("FactionFilter", it) }) }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            OutlinedTextField(value = searchQuery, onValueChange = onSearchQueryChange, modifier = Modifier.weight(1f).height(48.dp).onGloballyPositioned { onTargetPositioned("SearchField", it) }, placeholder = { Text("Search...") }, leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) }, trailingIcon = { if (searchQuery.isNotEmpty()) IconButton(onClick = { onSearchQueryChange("") }) { Icon(Icons.Default.Clear, contentDescription = "Clear") } }, singleLine = true, shape = theme.cardShape)
+            if (!isFactionFixed) { FactionSelector(selectedFactions = selectedFactions, onFactionsChange = onFactionsChange, compact = true, onPositioned = { onTargetPositioned("FactionFilter", it) }) }
+        }
         if (availableTags.isNotEmpty()) {
             var showKeywordsDialog by remember { mutableStateOf(false) }
             Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))

--- a/app/src/main/java/io/github/garemat/lunachron/ui/SettingsScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/SettingsScreen.kt
@@ -190,6 +190,58 @@ fun SettingsScreen(
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
             Spacer(modifier = Modifier.height(theme.verticalSpacing))
 
+            Text("Performance", style = theme.titleStyle.copy(fontSize = 20.sp), color = MaterialTheme.colorScheme.primary)
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onEvent(CharacterEvent.SetEnableAnimations(!state.enableAnimations)) }
+                    .padding(vertical = theme.verticalSpacing / 4),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Enable animations", style = theme.headerStyle.copy(fontSize = 18.sp))
+                    Text("Disable card flip and expand animations on lower-end devices.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                Switch(
+                    checked = state.enableAnimations,
+                    onCheckedChange = { onEvent(CharacterEvent.SetEnableAnimations(it)) }
+                )
+            }
+
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+
+            Text("App", style = theme.titleStyle.copy(fontSize = 20.sp), color = MaterialTheme.colorScheme.primary)
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 4))
+            Text("Default start page", style = theme.headerStyle.copy(fontSize = 18.sp))
+            Text("The screen shown when the app first opens.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+            val startPageOptions = listOf(
+                "home" to "Home",
+                "compendium" to "Compendium",
+                "characters" to "Character List",
+                "game_setup" to "Play",
+                "troupes" to "My Troupes",
+                "campaign_hub" to "Campaigns"
+            )
+            Column {
+                startPageOptions.forEach { (route, label) ->
+                    SelectionOption(
+                        title = label,
+                        selected = state.defaultStartPage == route,
+                        onSelect = { onEvent(CharacterEvent.SetDefaultStartPage(route)) },
+                        theme = theme
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+
             Text("App Updates", style = theme.titleStyle.copy(fontSize = 20.sp), color = MaterialTheme.colorScheme.primary)
             Spacer(modifier = Modifier.height(theme.verticalSpacing / 4))
             if (state.installerSource == InstallerSource.FDROID) {

--- a/app/src/main/java/io/github/garemat/lunachron/ui/theme/ThemeProperties.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/theme/ThemeProperties.kt
@@ -64,6 +64,8 @@ data class AppThemeProperties(
     val useDamageTypeIcons: Boolean = false,
 )
 
+val LocalAnimationsEnabled = staticCompositionLocalOf { true }
+
 val LocalAppThemeProperties = staticCompositionLocalOf {
     AppThemeProperties(
         cardShape = RoundedCornerShape(12.dp),


### PR DESCRIPTION
## Description

A batch of accessibility and UX improvements focused on smaller displays and day-to-day usability:

- **Constrained card expansion**: Card body is bounded to screen height with internal scroll, so expanded cards never push content off screen on small phones
- **Bottom nav hides on expansion**: Nav bar hides when any character card is expanded in the compendium, reclaiming screen space
- **Reduced top bar height**: `CenterAlignedTopAppBar` shrunk to 48dp on both the main screen and active game screen
- **Whole-card tap to flip**: Tapping the card body triggers the front→back flip; tapping the header still collapses/expands
- **Disable animations setting**: New "Performance" section in Settings with a toggle to skip flip/expand animations on lower-end devices; backed by `LocalAnimationsEnabled` composition local
- **Auto-collapse (max 3 open cards)**: Cap at 3 simultaneously open cards — oldest collapses automatically when a 4th is opened
- **Reloadable ability text**: Abilities with `reloadable: true` show ", unless reloaded" after the "Once per game" suffix; fallback detection via "Reload [X]" sibling ability naming for characters whose JSON lacks the flag
- **Default start page setting**: New "App" section in Settings lets the user choose which nav tab opens on launch; persisted in SharedPreferences
- **Keyword cycling (include/exclude)**: Tapping a keyword chip in the filter cycles unselected → include (green) → exclude (red "NOT") → unselected; three-state logic also applied in the keywords dialog
- **Moonstone theme duplicate name fix**: Removed the large name text from the Moonstone card body (`MoonstoneHeader`) — the collapsible header already shows the name
- **Faction icons inline with search bar**: Faction icons moved into the same row as the search bar (compact 40dp size, 4dp gap); search bar uses `weight(1f)` and is height-capped at 48dp to match

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)