### PR TITLE
fix: scale character card content to fit instead of scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.16.1] - 2026-05-06
+
+### Fixed
+
+- Scale character card content to fit instead of scrolling
+
+- Suppress background portrait art when card content is scaled down
+
+
 ## [2.16.0] - 2026-05-06
 
 ### Added

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -626,7 +626,7 @@ fun CharacterBack(character: Character, searchQuery: String, onFlip: () -> Unit,
  * If the natural content height fits, no scaling is applied. Clips overflow.
  */
 @Composable
-private fun ScaleToFit(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+private fun ScaleToFit(modifier: Modifier = Modifier, content: @Composable (isScaled: Boolean) -> Unit) {
     BoxWithConstraints(modifier = modifier.clipToBounds()) {
         val availableHeightPx = constraints.maxHeight
         var contentHeightPx by remember { mutableStateOf(availableHeightPx) }
@@ -640,7 +640,7 @@ private fun ScaleToFit(modifier: Modifier = Modifier, content: @Composable () ->
                 .graphicsLayer(scaleX = scale, scaleY = scale, transformOrigin = TransformOrigin(0f, 0f))
                 .onSizeChanged { size -> if (size.height != contentHeightPx) contentHeightPx = size.height }
         ) {
-            content()
+            content(scale < 1f)
         }
     }
 }
@@ -669,7 +669,7 @@ fun CommonCharacterCard(character: Character, searchQuery: String, isExpanded: B
             }
             if (isExpanded) {
                 if (theme.showCardDivider) HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
-                ScaleToFit(modifier = Modifier.fillMaxWidth().heightIn(max = maxCardBodyHeight)) {
+                ScaleToFit(modifier = Modifier.fillMaxWidth().heightIn(max = maxCardBodyHeight)) { isScaled ->
                     CharacterCardContent(
                         character = character,
                         searchQuery = searchQuery,
@@ -677,7 +677,7 @@ fun CommonCharacterCard(character: Character, searchQuery: String, isExpanded: B
                         onFlip = { isFlippedState = !isFlippedState },
                         modifier = Modifier.fillMaxWidth(),
                         animateFlip = true,
-                        showBackgroundImage = theme.showBackgroundImageOverlay,
+                        showBackgroundImage = !isScaled && theme.showBackgroundImageOverlay,
                         showHealthTracker = true,
                         onFlipPositioned = { onPositioned("FlipButton", it) }
                     )
@@ -778,7 +778,7 @@ fun CharacterCardContent(
                         .then(if (pinnedFooter) Modifier.fillMaxSize() else Modifier.onSizeChanged { sz -> frontHeightPx = sz.height })
                 ) {
                     if (pinnedFooter) {
-                        ScaleToFit(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                        ScaleToFit(modifier = Modifier.weight(1f).fillMaxWidth()) { _ ->
                             CharacterFront(
                                 character = character,
                                 searchQuery = searchQuery,
@@ -849,7 +849,7 @@ fun CharacterCardContent(
                         verticalArrangement = if (pinnedFooter) Arrangement.Top else Arrangement.SpaceBetween
                     ) {
                         if (pinnedFooter) {
-                            ScaleToFit(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                            ScaleToFit(modifier = Modifier.weight(1f).fillMaxWidth()) { _ ->
                                 CharacterBack(
                                     character = character,
                                     searchQuery = searchQuery,

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
@@ -619,6 +621,30 @@ fun CharacterBack(character: Character, searchQuery: String, onFlip: () -> Unit,
     }
 }
 
+/**
+ * Renders [content] scaled down (from the top-left) to fit within the available height.
+ * If the natural content height fits, no scaling is applied. Clips overflow.
+ */
+@Composable
+private fun ScaleToFit(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    BoxWithConstraints(modifier = modifier.clipToBounds()) {
+        val availableHeightPx = constraints.maxHeight
+        var contentHeightPx by remember { mutableStateOf(availableHeightPx) }
+        val scale = if (availableHeightPx > 0 && contentHeightPx > availableHeightPx) {
+            availableHeightPx.toFloat() / contentHeightPx.toFloat()
+        } else 1f
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight(align = Alignment.Top, unbounded = true)
+                .graphicsLayer(scaleX = scale, scaleY = scale, transformOrigin = TransformOrigin(0f, 0f))
+                .onSizeChanged { size -> if (size.height != contentHeightPx) contentHeightPx = size.height }
+        ) {
+            content()
+        }
+    }
+}
+
 @Composable
 fun CommonCharacterCard(character: Character, searchQuery: String, isExpanded: Boolean, onExpandClick: () -> Unit, modifier: Modifier = Modifier, cardTargetName: String = "CharacterCard", onPositioned: (String, LayoutCoordinates) -> Unit = { _, _ -> }, forceFlipped: Boolean? = null, selectionControl: @Composable (RowScope.() -> Unit)? = null, bottomContent: (@Composable () -> Unit)? = null) {
     var isFlippedState by remember { mutableStateOf(false) }; val isFlipped = forceFlipped ?: isFlippedState
@@ -643,12 +669,7 @@ fun CommonCharacterCard(character: Character, searchQuery: String, isExpanded: B
             }
             if (isExpanded) {
                 if (theme.showCardDivider) HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = maxCardBodyHeight)
-                        .verticalScroll(rememberScrollState())
-                ) {
+                ScaleToFit(modifier = Modifier.fillMaxWidth().heightIn(max = maxCardBodyHeight)) {
                     CharacterCardContent(
                         character = character,
                         searchQuery = searchQuery,
@@ -750,28 +771,38 @@ fun CharacterCardContent(
         Box(modifier = flipModifier) {
             if (!showBack) {
                 // Front face.
-                // pinnedFooter = true  → content scrolls, footer anchored to bottom (modal)
+                // pinnedFooter = true  → content scales to fit, footer anchored to bottom (modal)
                 // pinnedFooter = false → card auto-sizes; track height so back face never shrinks
                 Column(
                     modifier = Modifier.fillMaxWidth()
                         .then(if (pinnedFooter) Modifier.fillMaxSize() else Modifier.onSizeChanged { sz -> frontHeightPx = sz.height })
                 ) {
-                    Column(
-                        modifier = if (pinnedFooter)
-                            Modifier.weight(1f).verticalScroll(rememberScrollState())
-                        else
-                            Modifier.fillMaxWidth()
-                    ) {
-                        CharacterFront(
-                            character = character,
-                            searchQuery = searchQuery,
-                            onFlip = onFlip,
-                            onFlipPositioned = onFlipPositioned,
-                            showHealthTracker = showHealthTracker,
-                            showSignatureLink = false,
-                            abilityUsedStates = abilityUsedStates,
-                            onAbilityUsedChange = onAbilityUsedChange
-                        )
+                    if (pinnedFooter) {
+                        ScaleToFit(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                            CharacterFront(
+                                character = character,
+                                searchQuery = searchQuery,
+                                onFlip = onFlip,
+                                onFlipPositioned = onFlipPositioned,
+                                showHealthTracker = showHealthTracker,
+                                showSignatureLink = false,
+                                abilityUsedStates = abilityUsedStates,
+                                onAbilityUsedChange = onAbilityUsedChange
+                            )
+                        }
+                    } else {
+                        Column(modifier = Modifier.fillMaxWidth()) {
+                            CharacterFront(
+                                character = character,
+                                searchQuery = searchQuery,
+                                onFlip = onFlip,
+                                onFlipPositioned = onFlipPositioned,
+                                showHealthTracker = showHealthTracker,
+                                showSignatureLink = false,
+                                abilityUsedStates = abilityUsedStates,
+                                onAbilityUsedChange = onAbilityUsedChange
+                            )
+                        }
                     }
                     // Signature-move link — pinned at the visual bottom in both modes
                     character.signatureMove?.let { sigMove ->
@@ -817,19 +848,26 @@ fun CharacterCardContent(
                             Modifier.fillMaxWidth().heightIn(min = with(localDensity) { frontHeightPx.toDp() }),
                         verticalArrangement = if (pinnedFooter) Arrangement.Top else Arrangement.SpaceBetween
                     ) {
-                        Column(
-                            modifier = if (pinnedFooter)
-                                Modifier.weight(1f).verticalScroll(rememberScrollState())
-                            else
-                                Modifier.fillMaxWidth()
-                        ) {
-                            CharacterBack(
-                                character = character,
-                                searchQuery = searchQuery,
-                                onFlip = onFlip,
-                                onFlipPositioned = onFlipPositioned,
-                                showBackLink = false
-                            )
+                        if (pinnedFooter) {
+                            ScaleToFit(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                                CharacterBack(
+                                    character = character,
+                                    searchQuery = searchQuery,
+                                    onFlip = onFlip,
+                                    onFlipPositioned = onFlipPositioned,
+                                    showBackLink = false
+                                )
+                            }
+                        } else {
+                            Column(modifier = Modifier.fillMaxWidth()) {
+                                CharacterBack(
+                                    character = character,
+                                    searchQuery = searchQuery,
+                                    onFlip = onFlip,
+                                    onFlipPositioned = onFlipPositioned,
+                                    showBackLink = false
+                                )
+                            }
                         }
                         // Back-to-stats link — wrapped in Column so SpaceBetween treats it as
                         // one unit and places it at the visual bottom of the card


### PR DESCRIPTION
## Description

Character cards in both the in-game modal and the compendium expanded view were allowing internal vertical scrolling when content exceeded the available height. This meant health pips, base size, and lower abilities were hidden on first open — requiring a scroll to see the full card.

This PR replaces both `verticalScroll` wrappers with a new `ScaleToFit` composable that:
- Uses `BoxWithConstraints` to know the available height
- Measures the natural content height via `onSizeChanged`
- Applies a proportional `graphicsLayer` scale-down (anchored top-left) when content would overflow
- Clips overflow so nothing bleeds outside the card bounds
- Is a no-op (scale = 1.0) when content already fits

Affected locations:
- `CommonCharacterCard` (compendium expanded card) — replaces `heightIn(max=...) + verticalScroll`
- `CharacterCardContent` front face with `pinnedFooter = true` (game modal) — replaces `weight(1f) + verticalScroll`
- `CharacterCardContent` back face with `pinnedFooter = true` (game modal) — same

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)