### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,11 @@ name: Automated Release
 on:
   push:
     branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   release:
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    if: "github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     concurrency:
       group: release


### PR DESCRIPTION
## Description

Adds `workflow_dispatch` to `release.yml` so the release can be manually triggered when the automatic `push: main` event is suppressed.

The push event can be silently skipped when a squash-merged PR body contains a skip-ci marker from an intermediate commit (as happened with PR #139). Without `workflow_dispatch`, there's no way to recover without making a dummy commit. The `if` guard is updated to always pass for manual dispatches while keeping the skip-ci check for push events.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)