### PR TITLE
feat: compendium card popup mode, keywords in modals, settings improvements

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
@@ -62,6 +62,9 @@ sealed interface CharacterEvent {
     data class ChangeGameTrackingMode(val mode: GameTrackingMode) : CharacterEvent
     data class SetEnableAnimations(val enabled: Boolean) : CharacterEvent
     data class SetDefaultStartPage(val route: String) : CharacterEvent
+    data class SetCardDisplayMode(val mode: CardDisplayMode) : CharacterEvent
+    data class SetSkipCompendiumLanding(val skip: Boolean) : CharacterEvent
+    data class SetHideCampaignTab(val hide: Boolean) : CharacterEvent
     data class AddSummonedCharacter(val playerIndex: Int, val characterId: Int, val summonedByCharacterId: Int?) : CharacterEvent
     data class RemoveSummonedCharacter(val playerIndex: Int, val characterId: Int) : CharacterEvent
     data class UpdatePoolResource(val playerIndex: Int, val resourceName: String, val count: Int) : CharacterEvent

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
@@ -14,6 +14,8 @@ enum class LayoutDensity {
 @Serializable
 enum class GameTrackingMode { LOW_DETAIL, FULL_TRACKING }
 
+enum class CardDisplayMode { AUTO, POPUP, COLLAPSIBLE }
+
 
 @Serializable
 enum class ImageDownloadPreference { PROMPT, ENABLED, DISABLED }
@@ -273,6 +275,9 @@ data class CharacterState(
     val gameTrackingMode: GameTrackingMode = GameTrackingMode.LOW_DETAIL,
     val enableAnimations: Boolean = true,
     val defaultStartPage: String = "home",
+    val cardDisplayMode: CardDisplayMode = CardDisplayMode.AUTO,
+    val skipCompendiumLanding: Boolean = false,
+    val hideCampaignTab: Boolean = false,
 
     // Active Game Play State
     val currentTurn: Int = 1,

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -96,6 +96,9 @@ class CharacterViewModel(
         gameTrackingMode = GameTrackingMode.valueOf(prefs.getString("game_tracking_mode", GameTrackingMode.LOW_DETAIL.name) ?: GameTrackingMode.LOW_DETAIL.name),
         enableAnimations = prefs.getBoolean("enable_animations", true),
         defaultStartPage = prefs.getString("default_start_page", "home") ?: "home",
+        cardDisplayMode = CardDisplayMode.valueOf(prefs.getString("card_display_mode", CardDisplayMode.AUTO.name) ?: CardDisplayMode.AUTO.name),
+        skipCompendiumLanding = prefs.getBoolean("skip_compendium_landing", false),
+        hideCampaignTab = prefs.getBoolean("hide_campaign_tab", false),
         newsItems = loadCachedNews(),
         autoFetchNews = prefs.getBoolean("auto_fetch_news", false),
         autoCheckDataUpdates = dataUpdateRepository.loadAutoCheck(),
@@ -650,6 +653,18 @@ class CharacterViewModel(
             is CharacterEvent.SetDefaultStartPage -> {
                 _state.update { it.copy(defaultStartPage = event.route) }
                 prefs.edit { putString("default_start_page", event.route) }
+            }
+            is CharacterEvent.SetCardDisplayMode -> {
+                _state.update { it.copy(cardDisplayMode = event.mode) }
+                prefs.edit { putString("card_display_mode", event.mode.name) }
+            }
+            is CharacterEvent.SetSkipCompendiumLanding -> {
+                _state.update { it.copy(skipCompendiumLanding = event.skip) }
+                prefs.edit { putBoolean("skip_compendium_landing", event.skip) }
+            }
+            is CharacterEvent.SetHideCampaignTab -> {
+                _state.update { it.copy(hideCampaignTab = event.hide) }
+                prefs.edit { putBoolean("hide_campaign_tab", event.hide) }
             }
             is CharacterEvent.AddSummonedCharacter -> {
                 _state.update { cur ->

--- a/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
@@ -464,7 +464,12 @@ class MainActivity : ComponentActivity() {
                         }
                     ) { innerPadding ->
                         Box(modifier = Modifier.fillMaxSize()) {
-                            val startDestination = remember { state.defaultStartPage }
+                            val startDestination = remember {
+                                if (state.defaultStartPage == Screen.Compendium.route && state.skipCompendiumLanding)
+                                    Screen.Characters.route
+                                else
+                                    state.defaultStartPage
+                            }
                         NavHost(
                                 navController = navController,
                                 startDestination = startDestination,

--- a/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
@@ -380,13 +380,14 @@ class MainActivity : ComponentActivity() {
                                 ) {
                                     val playRoute = if (state.useLocalModeByDefault && state.useSinglePlayerMode)
                                         Screen.SoloTroupeSelect.route else Screen.GameSetup.route
-                                    val items = listOf(
-                                        BottomNavItem("Home", Screen.Home.route, Icons.Default.Home),
-                                        BottomNavItem("Compendium", Screen.Compendium.route, Icons.Default.MenuBook),
-                                        BottomNavItem("Play", playRoute, Icons.Default.PlayArrow),
-                                        BottomNavItem("Troupes", Screen.Troupes.route, Icons.Default.Groups),
-                                        BottomNavItem("Campaigns", Screen.CampaignHub.route, Icons.Default.HistoryEdu)
-                                    )
+                                    val compendiumRoute = if (state.skipCompendiumLanding) Screen.Characters.route else Screen.Compendium.route
+                                    val items = buildList {
+                                        add(BottomNavItem("Home", Screen.Home.route, Icons.Default.Home))
+                                        add(BottomNavItem("Compendium", compendiumRoute, Icons.Default.MenuBook))
+                                        add(BottomNavItem("Play", playRoute, Icons.Default.PlayArrow))
+                                        add(BottomNavItem("Troupes", Screen.Troupes.route, Icons.Default.Groups))
+                                        if (!state.hideCampaignTab) add(BottomNavItem("Campaigns", Screen.CampaignHub.route, Icons.Default.HistoryEdu))
+                                    }
                                     items.forEach { item ->
                                         val isPlayButton = item.label == "Play"
                                         val isSelected = if (isPlayButton) {

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
@@ -1021,6 +1021,44 @@ private fun GameCharacterCardModal(
                         HorizontalDivider()
                     }
 
+                    // Character name + keywords header
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = theme.screenPadding, vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(32.dp)
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.surfaceVariant)
+                        ) {
+                            CharacterPortrait(character = character, size = 32.dp)
+                        }
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = character.name,
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.primary,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            if (character.keywords.isNotEmpty()) {
+                                Text(
+                                    text = character.keywords.joinToString(", "),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    fontStyle = FontStyle.Italic,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 1
+                                )
+                            }
+                        }
+                    }
+                    HorizontalDivider()
+
                     // Flip-animated card content (fills remaining space, pinned footer)
                     CharacterCardContent(
                         character = character,
@@ -1054,14 +1092,17 @@ private fun GameCharacterCardModal(
                     }
                 }
 
-                // Floating close button — overlays top-right corner
-                Box(modifier = Modifier.align(Alignment.TopEnd).zIndex(10f)) {
-                    IconButton(onClick = onDismiss) {
-                        Icon(Icons.Default.Close, contentDescription = "Close")
-                    }
-                }
             }
         }
+
+        Text(
+            text = "Tap outside to close",
+            style = MaterialTheme.typography.labelSmall,
+            color = Color.White.copy(alpha = 0.5f),
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 12.dp)
+        )
     }
 }
 

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
@@ -1071,7 +1071,8 @@ private fun GameCharacterCardModal(
                         showHealthTracker = true,
                         abilityUsedStates = if (isFullTracking && isEditable) playState.usedAbilities else null,
                         onAbilityUsedChange = if (isFullTracking && isEditable) onAbilityToggle else null,
-                        pinnedFooter = true
+                        pinnedFooter = true,
+                        scrollable = true
                     )
 
                     // Transform button

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CharacterListScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CharacterListScreen.kt
@@ -157,6 +157,7 @@ fun CharacterListScreen(
                         character = character,
                         searchQuery = searchQuery,
                         isExpanded = expandedCharacterIds.contains(character.id),
+                        cardDisplayMode = state.cardDisplayMode,
                         onExpandClick = {
                             val isCurrentlyExpanded = character.id in expandedCharacterIds
                             if (isCurrentlyExpanded) {

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -440,7 +440,7 @@ fun CommonAbilityItem(name: String, description: String, searchQuery: String = "
                     if (oncePerTurn) withStyle(style = SpanStyle(fontStyle = FontStyle.Italic, fontWeight = FontWeight.Normal)) { append(" - Once per turn") }
                     if (oncePerGame) withStyle(style = SpanStyle(fontStyle = FontStyle.Italic, fontWeight = FontWeight.Normal)) { append(if (reloadable) " - Once per game, unless reloaded" else " - Once per game") }
                 }
-                Text(text = title, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
+                Text(text = title, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 if (oncePerGame && onUsedChange != null) {
                     Box(modifier = Modifier.padding(start = 8.dp).size(16.dp).clip(CircleShape).background(if (isUsed) MaterialTheme.colorScheme.onSurfaceVariant else Color.Transparent).border(1.2.dp, if (isEditable) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline, CircleShape).then(if (isEditable) Modifier.clickable { onUsedChange(!isUsed) } else Modifier), contentAlignment = Alignment.Center) {
                         if (isUsed) Icon(imageVector = Icons.Default.Close, contentDescription = null, modifier = Modifier.size(10.dp), tint = Color.White)
@@ -655,7 +655,7 @@ fun CommonCharacterCard(character: Character, searchQuery: String, isExpanded: B
     val animationsEnabled = LocalAnimationsEnabled.current
     val configuration = LocalConfiguration.current
     val density = LocalDensity.current
-    val showAsPopup = configuration.screenWidthDp < 360 || density.fontScale > 1.3f
+    val showAsPopup = configuration.screenWidthDp < 420 || density.fontScale > 1.15f
     var showPopup by remember { mutableStateOf(false) }
     val screenHeight = configuration.screenHeightDp.dp
     // Constrain card body to leave room for top bar (~48dp), bottom nav (~80dp), card header (~72dp) and margins
@@ -785,7 +785,8 @@ private fun CompendiumCharacterPopup(
                         animateFlip = true,
                         showBackgroundImage = theme.showBackgroundImageOverlay,
                         showHealthTracker = true,
-                        pinnedFooter = true
+                        pinnedFooter = true,
+                        scrollable = true
                     )
                 }
             }
@@ -811,12 +812,12 @@ private fun CompendiumCharacterPopup(
  * @param showBackgroundImage  If true and the character has a portrait image, renders it as a
  *                     translucent background behind the card content.
  * @param showHealthTracker  Passed through to [CharacterFront] — shows health pips on the card.
- * @param pinnedFooter Controls whether the card content area is scrollable. Both `true` and `false`
- *                     render the Signature-Move / ← Character stats link as a pinned footer row
- *                     separated by a [HorizontalDivider]. When `true`, the content area gets a
- *                     `verticalScroll` wrapper and fills the available height — use this for
- *                     fixed-height containers (game modal). When `false` (default), the card
- *                     auto-sizes to its content — use this inside a [LazyColumn] (compendium).
+ * @param pinnedFooter When `true`, fills the available height with a pinned signature-move footer
+ *                     at the bottom. Use with `scrollable = true` for modal contexts. When `false`
+ *                     (default), the card auto-sizes to its content — use inside a [LazyColumn].
+ * @param scrollable   Only meaningful when [pinnedFooter] is `true`. When `true`, the content area
+ *                     scrolls vertically (full-size text, user scrolls). When `false` (default),
+ *                     [ScaleToFit] shrinks the text to fit the fixed container height.
  */
 @Composable
 fun CharacterCardContent(
@@ -831,6 +832,7 @@ fun CharacterCardContent(
     abilityUsedStates: Map<String, Boolean>? = null,
     onAbilityUsedChange: ((String, Boolean) -> Unit)? = null,
     pinnedFooter: Boolean = false,
+    scrollable: Boolean = false,
     onFlipPositioned: (LayoutCoordinates) -> Unit = {}
 ) {
     val theme = LocalAppThemeProperties.current
@@ -885,24 +887,39 @@ fun CharacterCardContent(
         Box(modifier = flipModifier) {
             if (!showBack) {
                 // Front face.
-                // pinnedFooter = true  → content scales to fit, footer anchored to bottom (modal)
+                // pinnedFooter = true  → fixed height with pinned footer; content scrolls (scrollable=true) or scales
                 // pinnedFooter = false → card auto-sizes; track height so back face never shrinks
                 Column(
                     modifier = Modifier.fillMaxWidth()
                         .then(if (pinnedFooter) Modifier.fillMaxSize() else Modifier.onSizeChanged { sz -> frontHeightPx = sz.height })
                 ) {
                     if (pinnedFooter) {
-                        ScaleToFit(modifier = Modifier.weight(1f).fillMaxWidth()) { _ ->
-                            CharacterFront(
-                                character = character,
-                                searchQuery = searchQuery,
-                                onFlip = onFlip,
-                                onFlipPositioned = onFlipPositioned,
-                                showHealthTracker = showHealthTracker,
-                                showSignatureLink = false,
-                                abilityUsedStates = abilityUsedStates,
-                                onAbilityUsedChange = onAbilityUsedChange
-                            )
+                        if (scrollable) {
+                            Column(modifier = Modifier.weight(1f).fillMaxWidth().verticalScroll(rememberScrollState())) {
+                                CharacterFront(
+                                    character = character,
+                                    searchQuery = searchQuery,
+                                    onFlip = onFlip,
+                                    onFlipPositioned = onFlipPositioned,
+                                    showHealthTracker = showHealthTracker,
+                                    showSignatureLink = false,
+                                    abilityUsedStates = abilityUsedStates,
+                                    onAbilityUsedChange = onAbilityUsedChange
+                                )
+                            }
+                        } else {
+                            ScaleToFit(modifier = Modifier.weight(1f).fillMaxWidth()) { _ ->
+                                CharacterFront(
+                                    character = character,
+                                    searchQuery = searchQuery,
+                                    onFlip = onFlip,
+                                    onFlipPositioned = onFlipPositioned,
+                                    showHealthTracker = showHealthTracker,
+                                    showSignatureLink = false,
+                                    abilityUsedStates = abilityUsedStates,
+                                    onAbilityUsedChange = onAbilityUsedChange
+                                )
+                            }
                         }
                     } else {
                         Column(modifier = Modifier.fillMaxWidth()) {
@@ -963,14 +980,26 @@ fun CharacterCardContent(
                         verticalArrangement = if (pinnedFooter) Arrangement.Top else Arrangement.SpaceBetween
                     ) {
                         if (pinnedFooter) {
-                            ScaleToFit(modifier = Modifier.weight(1f).fillMaxWidth()) { _ ->
-                                CharacterBack(
-                                    character = character,
-                                    searchQuery = searchQuery,
-                                    onFlip = onFlip,
-                                    onFlipPositioned = onFlipPositioned,
-                                    showBackLink = false
-                                )
+                            if (scrollable) {
+                                Column(modifier = Modifier.weight(1f).fillMaxWidth().verticalScroll(rememberScrollState())) {
+                                    CharacterBack(
+                                        character = character,
+                                        searchQuery = searchQuery,
+                                        onFlip = onFlip,
+                                        onFlipPositioned = onFlipPositioned,
+                                        showBackLink = false
+                                    )
+                                }
+                            } else {
+                                ScaleToFit(modifier = Modifier.weight(1f).fillMaxWidth()) { _ ->
+                                    CharacterBack(
+                                        character = character,
+                                        searchQuery = searchQuery,
+                                        onFlip = onFlip,
+                                        onFlipPositioned = onFlipPositioned,
+                                        showBackLink = false
+                                    )
+                                }
                             }
                         } else {
                             Column(modifier = Modifier.fillMaxWidth()) {

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -56,6 +56,9 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.zIndex
 import coil.compose.AsyncImage
 import io.github.garemat.lunachron.*
 import io.github.garemat.lunachron.R
@@ -529,7 +532,7 @@ fun CharacterFront(
             }
         }
         if (showHealthTracker) {
-            HealthTracker(character.health, character.health, character.energyTrack, {}, isEditable = false)
+            HealthPipsChunked(character.health, character.health, character.energyTrack, compact = false, isEditable = false, onHealthChange = {})
         }
         Text(text = "Base: ${character.baseSize}", style = MaterialTheme.typography.labelSmall, modifier = Modifier.fillMaxWidth(), textAlign = TextAlign.End)
     }
@@ -650,12 +653,25 @@ fun CommonCharacterCard(character: Character, searchQuery: String, isExpanded: B
     var isFlippedState by remember { mutableStateOf(false) }; val isFlipped = forceFlipped ?: isFlippedState
     val theme = LocalAppThemeProperties.current
     val animationsEnabled = LocalAnimationsEnabled.current
-    val screenHeight = LocalConfiguration.current.screenHeightDp.dp
+    val configuration = LocalConfiguration.current
+    val density = LocalDensity.current
+    val showAsPopup = configuration.screenWidthDp < 360 || density.fontScale > 1.3f
+    var showPopup by remember { mutableStateOf(false) }
+    val screenHeight = configuration.screenHeightDp.dp
     // Constrain card body to leave room for top bar (~48dp), bottom nav (~80dp), card header (~72dp) and margins
     val maxCardBodyHeight = (screenHeight - 48.dp - 80.dp - 72.dp - 32.dp).coerceAtLeast(300.dp)
+
+    if (showPopup) {
+        CompendiumCharacterPopup(
+            character = character,
+            searchQuery = searchQuery,
+            onDismiss = { showPopup = false }
+        )
+    }
+
     ThemedCard(modifier = modifier.fillMaxWidth().then(if (animationsEnabled) Modifier.animateContentSize() else Modifier).onGloballyPositioned { onPositioned(cardTargetName, it) }) {
         Column {
-            Row(modifier = Modifier.fillMaxWidth().clickable { onExpandClick() }.padding(theme.cardContentPadding), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+            Row(modifier = Modifier.fillMaxWidth().clickable { if (showAsPopup) showPopup = true else onExpandClick() }.padding(theme.cardContentPadding), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                 if (selectionControl != null) { selectionControl(); Spacer(modifier = Modifier.width(4.dp)) }
                 Box(modifier = Modifier.size(if (selectionControl != null) 40.dp else 56.dp).clip(CircleShape).background(MaterialTheme.colorScheme.surfaceVariant), contentAlignment = Alignment.Center) {
                     CharacterPortrait(character = character, size = if (selectionControl != null) 40.dp else 56.dp)
@@ -665,9 +681,15 @@ fun CommonCharacterCard(character: Character, searchQuery: String, isExpanded: B
                     Text(text = highlightText(character.name, searchQuery), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.primary, maxLines = 1, overflow = TextOverflow.Ellipsis)
                     Text(text = character.keywords.joinToString(", "), style = MaterialTheme.typography.bodySmall, fontStyle = FontStyle.Italic, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 2)
                 }
-                Icon(imageVector = if (isExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown, contentDescription = null, modifier = Modifier.padding(start = 8.dp))
+                Icon(
+                    imageVector = if (showAsPopup) Icons.Default.OpenInFull
+                                  else if (isExpanded) Icons.Default.KeyboardArrowUp
+                                  else Icons.Default.KeyboardArrowDown,
+                    contentDescription = null,
+                    modifier = Modifier.padding(start = 8.dp)
+                )
             }
-            if (isExpanded) {
+            if (isExpanded && !showAsPopup) {
                 if (theme.showCardDivider) HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
                 ScaleToFit(modifier = Modifier.fillMaxWidth().heightIn(max = maxCardBodyHeight)) { isScaled ->
                     CharacterCardContent(
@@ -684,6 +706,98 @@ fun CommonCharacterCard(character: Character, searchQuery: String, isExpanded: B
                 }
             }
             bottomContent?.invoke()
+        }
+    }
+}
+
+@Composable
+private fun CompendiumCharacterPopup(
+    character: Character,
+    searchQuery: String,
+    onDismiss: () -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    var isFlipped by remember { mutableStateOf(false) }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.72f))
+                    .clickable { onDismiss() }
+            )
+
+            ThemedCard(
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .fillMaxWidth(0.94f)
+                    .fillMaxHeight(0.88f)
+                    .clickable {}
+            ) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = theme.screenPadding, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(40.dp)
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.surfaceVariant)
+                        ) {
+                            CharacterPortrait(character = character, size = 40.dp)
+                        }
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = highlightText(character.name, searchQuery),
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.primary,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            if (character.keywords.isNotEmpty()) {
+                                Text(
+                                    text = character.keywords.joinToString(", "),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    fontStyle = FontStyle.Italic,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 2
+                                )
+                            }
+                        }
+                    }
+                    HorizontalDivider()
+
+                    CharacterCardContent(
+                        character = character,
+                        searchQuery = searchQuery,
+                        isFlipped = isFlipped,
+                        onFlip = { isFlipped = !isFlipped },
+                        modifier = Modifier.weight(1f).fillMaxWidth(),
+                        animateFlip = true,
+                        showBackgroundImage = theme.showBackgroundImageOverlay,
+                        showHealthTracker = true,
+                        pinnedFooter = true
+                    )
+                }
+            }
+
+            Text(
+                text = "Tap outside to close",
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White.copy(alpha = 0.5f),
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 12.dp)
+            )
         }
     }
 }
@@ -811,7 +925,7 @@ fun CharacterCardContent(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clickable { onFlip() }
-                                .padding(vertical = 8.dp, horizontal = 16.dp),
+                                .padding(vertical = 4.dp, horizontal = 16.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Text(
@@ -822,12 +936,12 @@ fun CharacterCardContent(
                                     }
                                     append(".")
                                 },
-                                style = MaterialTheme.typography.bodyMedium,
+                                style = MaterialTheme.typography.labelMedium,
                                 fontStyle = FontStyle.Italic,
                                 modifier = Modifier.weight(1f),
                                 color = MaterialTheme.colorScheme.secondary
                             )
-                            Icon(imageVector = Icons.Default.KeyboardArrowRight, contentDescription = "View signature move", modifier = Modifier.size(16.dp), tint = MaterialTheme.colorScheme.secondary)
+                            Icon(imageVector = Icons.Default.KeyboardArrowRight, contentDescription = "View signature move", modifier = Modifier.size(14.dp), tint = MaterialTheme.colorScheme.secondary)
                         }
                     }
                 }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -660,7 +660,7 @@ fun CommonCharacterCard(character: Character, searchQuery: String, isExpanded: B
         else -> when (cardDisplayMode) {
             CardDisplayMode.POPUP -> true
             CardDisplayMode.COLLAPSIBLE -> false
-            CardDisplayMode.AUTO -> configuration.screenWidthDp < 420 || density.fontScale > 1.15f
+            CardDisplayMode.AUTO -> LocalContext.current.resources.displayMetrics.densityDpi < 350 || density.fontScale > 1.15f
         }
     }
     var showPopup by remember { mutableStateOf(false) }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -437,8 +437,8 @@ fun CommonAbilityItem(name: String, description: String, searchQuery: String = "
                         appendWithHighlight(name, searchQuery)
                         if (showColon) append(": ")
                     }
-                    if (oncePerTurn) withStyle(style = SpanStyle(fontStyle = FontStyle.Italic, fontWeight = FontWeight.Normal)) { append(" - Once per turn") }
-                    if (oncePerGame) withStyle(style = SpanStyle(fontStyle = FontStyle.Italic, fontWeight = FontWeight.Normal)) { append(if (reloadable) " - Once per game, unless reloaded" else " - Once per game") }
+                    if (oncePerTurn) withStyle(style = SpanStyle(fontStyle = FontStyle.Italic, fontWeight = FontWeight.Normal, fontSize = 11.sp)) { append(" - Once per turn") }
+                    if (oncePerGame) withStyle(style = SpanStyle(fontStyle = FontStyle.Italic, fontWeight = FontWeight.Normal, fontSize = 11.sp)) { append(if (reloadable) " - Once per game, unless reloaded" else " - Once per game") }
                 }
                 Text(text = title, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 if (oncePerGame && onUsedChange != null) {
@@ -649,13 +649,20 @@ private fun ScaleToFit(modifier: Modifier = Modifier, content: @Composable (isSc
 }
 
 @Composable
-fun CommonCharacterCard(character: Character, searchQuery: String, isExpanded: Boolean, onExpandClick: () -> Unit, modifier: Modifier = Modifier, cardTargetName: String = "CharacterCard", onPositioned: (String, LayoutCoordinates) -> Unit = { _, _ -> }, forceFlipped: Boolean? = null, selectionControl: @Composable (RowScope.() -> Unit)? = null, bottomContent: (@Composable () -> Unit)? = null) {
+fun CommonCharacterCard(character: Character, searchQuery: String, isExpanded: Boolean, onExpandClick: () -> Unit, modifier: Modifier = Modifier, cardTargetName: String = "CharacterCard", onPositioned: (String, LayoutCoordinates) -> Unit = { _, _ -> }, forceFlipped: Boolean? = null, selectionControl: @Composable (RowScope.() -> Unit)? = null, bottomContent: (@Composable () -> Unit)? = null, cardDisplayMode: CardDisplayMode = CardDisplayMode.AUTO) {
     var isFlippedState by remember { mutableStateOf(false) }; val isFlipped = forceFlipped ?: isFlippedState
     val theme = LocalAppThemeProperties.current
     val animationsEnabled = LocalAnimationsEnabled.current
     val configuration = LocalConfiguration.current
     val density = LocalDensity.current
-    val showAsPopup = configuration.screenWidthDp < 420 || density.fontScale > 1.15f
+    val showAsPopup = when {
+        selectionControl != null -> false
+        else -> when (cardDisplayMode) {
+            CardDisplayMode.POPUP -> true
+            CardDisplayMode.COLLAPSIBLE -> false
+            CardDisplayMode.AUTO -> configuration.screenWidthDp < 420 || density.fontScale > 1.15f
+        }
+    }
     var showPopup by remember { mutableStateOf(false) }
     val screenHeight = configuration.screenHeightDp.dp
     // Constrain card body to leave room for top bar (~48dp), bottom nav (~80dp), card header (~72dp) and margins

--- a/app/src/main/java/io/github/garemat/lunachron/ui/SettingsScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/SettingsScreen.kt
@@ -19,6 +19,7 @@ import io.github.garemat.lunachron.CharacterEvent
 import io.github.garemat.lunachron.ui.theme.ThemeRepository
 import io.github.garemat.lunachron.BuildConfig
 import io.github.garemat.lunachron.CharacterState
+import io.github.garemat.lunachron.CardDisplayMode
 import io.github.garemat.lunachron.GameTrackingMode
 import io.github.garemat.lunachron.ImageDownloadPreference
 import io.github.garemat.lunachron.InstallerSource
@@ -237,6 +238,74 @@ fun SettingsScreen(
                         theme = theme
                     )
                 }
+            }
+
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+
+            Text("Compendium", style = theme.titleStyle.copy(fontSize = 20.sp), color = MaterialTheme.colorScheme.primary)
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 4))
+            Text("Character card style", style = theme.headerStyle.copy(fontSize = 18.sp))
+            Text("How character cards appear in the compendium list.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+            Column {
+                SelectionOption(
+                    title = "Automatic",
+                    subtitle = "Pop-out on small screens or large text, collapsible otherwise.",
+                    selected = state.cardDisplayMode == CardDisplayMode.AUTO,
+                    onSelect = { onEvent(CharacterEvent.SetCardDisplayMode(CardDisplayMode.AUTO)) },
+                    theme = theme
+                )
+                SelectionOption(
+                    title = "Pop-out",
+                    subtitle = "Tapping a card always opens it in a full-screen popup.",
+                    selected = state.cardDisplayMode == CardDisplayMode.POPUP,
+                    onSelect = { onEvent(CharacterEvent.SetCardDisplayMode(CardDisplayMode.POPUP)) },
+                    theme = theme
+                )
+                SelectionOption(
+                    title = "Collapsible",
+                    subtitle = "Tapping a card always expands it inline in the list.",
+                    selected = state.cardDisplayMode == CardDisplayMode.COLLAPSIBLE,
+                    onSelect = { onEvent(CharacterEvent.SetCardDisplayMode(CardDisplayMode.COLLAPSIBLE)) },
+                    theme = theme
+                )
+            }
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onEvent(CharacterEvent.SetSkipCompendiumLanding(!state.skipCompendiumLanding)) }
+                    .padding(vertical = theme.verticalSpacing / 4),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Skip compendium landing", style = theme.headerStyle.copy(fontSize = 18.sp))
+                    Text("Go straight to the character list when opening the Compendium tab.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                Switch(
+                    checked = state.skipCompendiumLanding,
+                    onCheckedChange = { onEvent(CharacterEvent.SetSkipCompendiumLanding(it)) }
+                )
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onEvent(CharacterEvent.SetHideCampaignTab(!state.hideCampaignTab)) }
+                    .padding(vertical = theme.verticalSpacing / 4),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Hide Campaigns tab", style = theme.headerStyle.copy(fontSize = 18.sp))
+                    Text("Remove the Campaigns tab from the bottom navigation bar.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                Switch(
+                    checked = state.hideCampaignTab,
+                    onCheckedChange = { onEvent(CharacterEvent.SetHideCampaignTab(it)) }
+                )
             }
 
             Spacer(modifier = Modifier.height(theme.verticalSpacing))


### PR DESCRIPTION
## Description

Improves the compendium and in-game character card experience, particularly for small screens and accessibility font sizes, and adds several quality-of-life settings.

**Character card popup mode**
- `CommonCharacterCard` can now show as a full-screen `Dialog` popup instead of expanding inline. Auto mode triggers when `densityDpi < 350` (low-DPI/older devices) or system font scale > 1.15×. Can be overridden per-user in Settings.
- `CompendiumCharacterPopup` — new private composable mirroring `GameCharacterCardModal`; shows name + keyword tags header, full-size scrollable card content (no `ScaleToFit` shrinking), and a "Tap outside to close" scrim hint.
- Selection-mode cards (troupe editor etc.) always stay collapsible regardless of the setting.

**Keywords in modal cards**
- Both `GameCharacterCardModal` and `CompendiumCharacterPopup` now show a name + keyword tags header row (portrait, bold name, italic keywords) above the flip-animated card content.
- Removes the floating X close button from `GameCharacterCardModal`; replaced by a "Tap outside to close" hint in the scrim below the card.

**Scrollable modal content**
- Added `scrollable: Boolean = false` parameter to `CharacterCardContent`. When `pinnedFooter = true && scrollable = true`, content uses `verticalScroll` instead of `ScaleToFit` — text stays full-size and users scroll rather than seeing shrunk text. Both modals pass `scrollable = true`.

**Health pips**
- `CharacterFront` now uses `HealthPipsChunked` (groups of 5 with `|` separator) instead of `HealthTracker`, consistent with the active game screen.

**Ability title**
- Ability title row uses `maxLines = 1, overflow = Ellipsis` — "Once per game, unless reloaded" no longer wraps to a second line.
- The italic "Once per turn / Once per game" suffix is rendered at 11sp to help fit on one line alongside the ability name.

**Signature move footer**
- Compressed: padding 8dp → 4dp, `bodyMedium` → `labelMedium`, icon 16dp → 14dp.

**Settings → Compendium (new section)**
- **Character card style** — `AUTO` / `POPUP` / `COLLAPSIBLE` selector (3-way `SelectionOption`); persisted in SharedPreferences.
- **Skip compendium landing** — Compendium tab navigates directly to the character list, bypassing the hub page. Also respected at app cold-start when the default start page is set to Compendium.
- **Hide Campaigns tab** — removes Campaigns from the bottom nav for players not using the campaign system.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)