### PR TITLE
feat: dual-faction diagonal icon split with soft blend

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/ui/CampaignCardListScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CampaignCardListScreen.kt
@@ -30,6 +30,8 @@ fun CampaignCardListScreen(
     val theme = LocalAppThemeProperties.current
     
     var showFilterBar by remember { mutableStateOf(true) }
+    val listState = rememberLazyListState()
+    LaunchedEffect(searchQuery) { listState.scrollToItem(0) }
 
     val filteredCards = remember(state.campaignCards, searchQuery, selectedFactions) {
         state.campaignCards.filter { card ->
@@ -75,7 +77,7 @@ fun CampaignCardListScreen(
                 modifier = Modifier.fillMaxSize(),
                 verticalArrangement = Arrangement.spacedBy(theme.verticalSpacing / 2),
                 contentPadding = PaddingValues(top = theme.verticalSpacing / 2, bottom = 100.dp, start = theme.screenPadding, end = theme.screenPadding),
-                state = rememberLazyListState()
+                state = listState
             ) {
                 if (filteredCards.isEmpty()) {
                     item {

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CharacterListScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CharacterListScreen.kt
@@ -60,7 +60,11 @@ fun CharacterListScreen(
         onExpansionChanged(expandedCharacterIds.isNotEmpty())
     }
 
+    val listState = rememberLazyListState()
+    val coroutineScope = rememberCoroutineScope()
+
     LaunchedEffect(searchQuery) {
+        listState.scrollToItem(0)
         if (searchQuery.isEmpty()) {
             expandedCharacterIdsList = emptyList()
         } else {
@@ -71,9 +75,6 @@ fun CharacterListScreen(
             if (matchingIds.size in 1..3) expandedCharacterIdsList = matchingIds
         }
     }
-
-    val listState = rememberLazyListState()
-    val coroutineScope = rememberCoroutineScope()
     val screenHeight = LocalConfiguration.current.screenHeightDp.dp
 
     LaunchedEffect(availableTags) {

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -29,9 +29,14 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.LayoutCoordinates
@@ -290,22 +295,54 @@ fun FactionIcon(faction: Faction, size: Dp = 40.dp, modifier: Modifier = Modifie
     }
 }
 
+// Diagonal split shapes: line from bottom-left (0,h) to top-right (w,0).
+private object DiagonalTopLeftShape : Shape {
+    override fun createOutline(size: Size, layoutDirection: LayoutDirection, density: Density) =
+        Outline.Generic(Path().apply {
+            moveTo(0f, 0f)
+            lineTo(size.width, 0f)
+            lineTo(0f, size.height)
+            close()
+        })
+}
+
+private object DiagonalBottomRightShape : Shape {
+    override fun createOutline(size: Size, layoutDirection: LayoutDirection, density: Density) =
+        Outline.Generic(Path().apply {
+            moveTo(size.width, size.height)
+            lineTo(size.width, 0f)
+            lineTo(0f, size.height)
+            close()
+        })
+}
+
 /**
- * Displays one or two faction symbols blended together, matching the official dual-faction
- * card art. Both icons are centered in the [size] footprint with a small diagonal drift so
- * the primary sits slightly lower-left and the secondary upper-right. The secondary is
- * rendered with [BlendMode.Multiply] so its dark symbol elements show through the lighter
- * areas of the primary, approximating the translucent overlap in the physical card art.
- * For single-faction characters, delegates to [FactionIcon].
- */
-/**
- * Displays the primary faction symbol for a character. Multi-faction blending is
- * deferred to a later patch — for now only factions[0] is shown via [FactionIcon].
+ * Single-faction: renders [FactionIcon]. Dual-faction: diagonal split (bottom-left to
+ * top-right) with the primary faction in the top-left half and secondary in the bottom-right.
  */
 @Composable
 fun MultiFactionIcon(factions: List<Faction>, size: Dp = 40.dp, modifier: Modifier = Modifier) {
     if (factions.isEmpty()) return
-    FactionIcon(faction = factions[0], size = size, modifier = modifier)
+    if (factions.size == 1) {
+        FactionIcon(faction = factions[0], size = size, modifier = modifier)
+        return
+    }
+    val primary = factions[0]
+    val secondary = factions[1]
+    Box(modifier = modifier.size(size)) {
+        Box(
+            modifier = Modifier.size(size).clip(DiagonalTopLeftShape),
+            contentAlignment = Alignment.Center
+        ) {
+            FactionSymbol(faction = primary, modifier = Modifier.size(size * factionVisualScale(primary)))
+        }
+        Box(
+            modifier = Modifier.size(size).clip(DiagonalBottomRightShape),
+            contentAlignment = Alignment.Center
+        ) {
+            FactionSymbol(faction = secondary, modifier = Modifier.size(size * factionVisualScale(secondary)))
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -29,15 +29,15 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Outline
-import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.draw.drawWithContent
+import kotlin.math.sqrt
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -295,32 +295,14 @@ fun FactionIcon(faction: Faction, size: Dp = 40.dp, modifier: Modifier = Modifie
     }
 }
 
-// Diagonal split shapes. The icon is half-clipped by the card edge (right 50% overflows),
-// so the dividing line is anchored at (0, h*2/3) → (w, 0) to give a 50/50 visible split.
-private object DiagonalTopLeftShape : Shape {
-    override fun createOutline(size: Size, layoutDirection: LayoutDirection, density: Density) =
-        Outline.Generic(Path().apply {
-            moveTo(0f, 0f)
-            lineTo(size.width, 0f)
-            lineTo(0f, size.height * 2f / 3f)
-            close()
-        })
-}
-
-private object DiagonalBottomRightShape : Shape {
-    override fun createOutline(size: Size, layoutDirection: LayoutDirection, density: Density) =
-        Outline.Generic(Path().apply {
-            moveTo(0f, size.height * 2f / 3f)
-            lineTo(size.width, 0f)
-            lineTo(size.width, size.height)
-            lineTo(0f, size.height)
-            close()
-        })
-}
-
 /**
- * Single-faction: renders [FactionIcon]. Dual-faction: diagonal split (bottom-left to
- * top-right) with the primary faction in the top-left half and secondary in the bottom-right.
+ * Single-faction: renders [FactionIcon]. Dual-faction: diagonal split using gradient alpha
+ * masks (BlendMode.DstIn). The gradient runs perpendicular to the diagonal so its 50/50
+ * midpoint lands exactly on the split line. A ~15% blend strip softens the edge so spiky
+ * elements (antlers, sun rays) don't produce a harsh hard cut.
+ *
+ * The icon is half-clipped by the card edge (offset x = size/2), so the diagonal anchors
+ * at (0, h×2/3)→(w, 0) to give equal visible area for each faction.
  */
 @Composable
 fun MultiFactionIcon(factions: List<Faction>, size: Dp = 40.dp, modifier: Modifier = Modifier) {
@@ -331,15 +313,71 @@ fun MultiFactionIcon(factions: List<Faction>, size: Dp = 40.dp, modifier: Modifi
     }
     val primary = factions[0]
     val secondary = factions[1]
+
     Box(modifier = modifier.size(size)) {
+        // Primary: top-left half fading toward diagonal
         Box(
-            modifier = Modifier.size(size).clip(DiagonalTopLeftShape),
+            modifier = Modifier
+                .size(size)
+                .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+                .drawWithContent {
+                    drawContent()
+                    // 'this.size' is DrawScope.size (pixels), not the outer Dp parameter.
+                    val w = this.size.width
+                    val h = this.size.height
+                    val anchored = h * 2f / 3f
+                    val diagLen = sqrt(w * w + anchored * anchored)
+                    val perpX = anchored / diagLen
+                    val perpY = w / diagLen
+                    val cx = w / 2f; val cy = h / 3f
+                    val blendFrac = (w * 0.15f) / (2f * diagLen)
+                    drawRect(
+                        brush = Brush.linearGradient(
+                            colorStops = arrayOf<Pair<Float, Color>>(
+                                Pair(0f, Color.Black),
+                                Pair(0.5f - blendFrac, Color.Black),
+                                Pair(0.5f + blendFrac, Color.Transparent),
+                                Pair(1f, Color.Transparent)
+                            ),
+                            start = Offset(cx - perpX * diagLen, cy - perpY * diagLen),
+                            end   = Offset(cx + perpX * diagLen, cy + perpY * diagLen)
+                        ),
+                        blendMode = BlendMode.DstIn
+                    )
+                },
             contentAlignment = Alignment.Center
         ) {
             FactionSymbol(faction = primary, modifier = Modifier.size(size * factionVisualScale(primary)))
         }
+        // Secondary: bottom-right half fading toward diagonal
         Box(
-            modifier = Modifier.size(size).clip(DiagonalBottomRightShape),
+            modifier = Modifier
+                .size(size)
+                .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+                .drawWithContent {
+                    drawContent()
+                    val w = this.size.width
+                    val h = this.size.height
+                    val anchored = h * 2f / 3f
+                    val diagLen = sqrt(w * w + anchored * anchored)
+                    val perpX = anchored / diagLen
+                    val perpY = w / diagLen
+                    val cx = w / 2f; val cy = h / 3f
+                    val blendFrac = (w * 0.15f) / (2f * diagLen)
+                    drawRect(
+                        brush = Brush.linearGradient(
+                            colorStops = arrayOf<Pair<Float, Color>>(
+                                Pair(0f, Color.Transparent),
+                                Pair(0.5f - blendFrac, Color.Transparent),
+                                Pair(0.5f + blendFrac, Color.Black),
+                                Pair(1f, Color.Black)
+                            ),
+                            start = Offset(cx - perpX * diagLen, cy - perpY * diagLen),
+                            end   = Offset(cx + perpX * diagLen, cy + perpY * diagLen)
+                        ),
+                        blendMode = BlendMode.DstIn
+                    )
+                },
             contentAlignment = Alignment.Center
         ) {
             FactionSymbol(faction = secondary, modifier = Modifier.size(size * factionVisualScale(secondary)))

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -295,13 +295,14 @@ fun FactionIcon(faction: Faction, size: Dp = 40.dp, modifier: Modifier = Modifie
     }
 }
 
-// Diagonal split shapes: line from bottom-left (0,h) to top-right (w,0).
+// Diagonal split shapes. The icon is half-clipped by the card edge (right 50% overflows),
+// so the dividing line is anchored at (0, h*2/3) → (w, 0) to give a 50/50 visible split.
 private object DiagonalTopLeftShape : Shape {
     override fun createOutline(size: Size, layoutDirection: LayoutDirection, density: Density) =
         Outline.Generic(Path().apply {
             moveTo(0f, 0f)
             lineTo(size.width, 0f)
-            lineTo(0f, size.height)
+            lineTo(0f, size.height * 2f / 3f)
             close()
         })
 }
@@ -309,8 +310,9 @@ private object DiagonalTopLeftShape : Shape {
 private object DiagonalBottomRightShape : Shape {
     override fun createOutline(size: Size, layoutDirection: LayoutDirection, density: Density) =
         Outline.Generic(Path().apply {
-            moveTo(size.width, size.height)
+            moveTo(0f, size.height * 2f / 3f)
             lineTo(size.width, 0f)
+            lineTo(size.width, size.height)
             lineTo(0f, size.height)
             close()
         })

--- a/app/src/main/java/io/github/garemat/lunachron/ui/UpgradeListScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/UpgradeListScreen.kt
@@ -38,6 +38,8 @@ fun UpgradeListScreen(
     }
     
     var showFilterBar by remember { mutableStateOf(true) }
+    val listState = rememberLazyListState()
+    LaunchedEffect(searchQuery) { listState.scrollToItem(0) }
 
     val filteredUpgrades = remember(state.upgradeCards, searchQuery, selectedFactions, selectedTags) {
         state.upgradeCards.filter { card ->
@@ -85,7 +87,7 @@ fun UpgradeListScreen(
                 modifier = Modifier.fillMaxSize(),
                 verticalArrangement = Arrangement.spacedBy(theme.verticalSpacing / 2),
                 contentPadding = PaddingValues(top = theme.verticalSpacing / 2, bottom = 100.dp, start = theme.screenPadding, end = theme.screenPadding),
-                state = rememberLazyListState()
+                state = listState
             ) {
                 if (filteredUpgrades.isEmpty()) {
                     item {


### PR DESCRIPTION
## Description

Implements the long-deferred dual-faction icon display for characters belonging to two factions. `MultiFactionIcon` previously only showed `factions[0]`; it now renders a diagonal split showing both.

**Dual-faction icon (`CommonComponents.kt`):**
- Diagonal split from bottom-left to top-right, with primary faction in the top-left half and secondary in the bottom-right
- Uses `BlendMode.DstIn` gradient alpha masks (offscreen compositing) instead of hard Shape clips — the gradient direction is computed perpendicular to the split line so the 50/50 midpoint aligns exactly with the diagonal
- The diagonal is anchored at `(0, h×⅔)→(w, 0)` so the visible portion (icon is half-clipped by the card edge) is evenly split between both factions
- A ~15% blend strip softens the boundary so spiky elements (antlers, sun rays) fade out rather than hard-cutting into the other faction's half
- Single-faction characters are unchanged

**Compendium scroll reset (CharacterListScreen, UpgradeListScreen, CampaignCardListScreen):**
- All three list screens now scroll back to the top whenever the search query changes
- CharacterListScreen already had a `LaunchedEffect(searchQuery)` but was missing the `scrollToItem(0)` call, and `listState` was declared after the effect (fixed ordering)
- Upgrade and campaign card screens had their list state created inline with no named reference; extracted to a named variable and added matching effects

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)