### PR TITLE
fix: produce F-Droid APK instead of AAB in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
         KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
         KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: ./gradlew assembleGithubRelease bundleGithubRelease bundleFdroidRelease
+      run: ./gradlew assembleGithubRelease bundleGithubRelease assembleFdroidRelease
 
     - name: Write Play Store credentials to file
       run: echo '${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}' > /tmp/play-service-account.json
@@ -104,7 +104,7 @@ jobs:
         files: |
           app/build/outputs/apk/github/release/app-github-release.apk
           app/build/outputs/bundle/githubRelease/app-github-release.aab
-          app/build/outputs/bundle/fdroidRelease/app-fdroid-release.aab
+          app/build/outputs/apk/fdroid/release/app-fdroid-release.apk
         name: Release ${{ steps.version.outputs.new_tag }}
         body: ${{ steps.release_notes.outputs.notes }}
       env:


### PR DESCRIPTION
## Description
Switch the F-Droid release build from `bundleFdroidRelease` (AAB) to `assembleFdroidRelease` (APK), and update the GitHub Release artifact path accordingly. F-Droid builds and distributes APKs directly — AABs are a Play Store format and are not accepted by F-Droid.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)