### PR TITLE
feat: upload versionCode.txt as release asset for F-Droid

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,13 @@ jobs:
         KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
       run: ./gradlew publishFdroidReleaseBundle
 
+    - name: Generate versionCode.txt
+      run: |
+        VERSION="${{ steps.version.outputs.new_tag }}"
+        VERSION="${VERSION#v}"
+        IFS='.' read -r major minor patch <<< "$VERSION"
+        echo "$((major * 10000 + minor * 100 + patch))" > versionCode.txt
+
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
@@ -105,6 +112,7 @@ jobs:
           app/build/outputs/apk/github/release/app-github-release.apk
           app/build/outputs/bundle/githubRelease/app-github-release.aab
           app/build/outputs/apk/fdroid/release/app-fdroid-release.apk
+          versionCode.txt
         name: Release ${{ steps.version.outputs.new_tag }}
         body: ${{ steps.release_notes.outputs.notes }}
       env:


### PR DESCRIPTION
## Description
Adds a `versionCode.txt` file as a release asset on every GitHub release. The file contains the integer Android versionCode (computed as `major * 10000 + minor * 100 + patch`), giving F-Droid's `fdroid checkupdates` a reliable static source for the correct versionCode without requiring static analysis of the dynamic `gitVersionCode()` function in `build.gradle.kts`.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)