### PR TITLE
fix: target app-github-release.apk explicitly for self-update

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/DataUpdateRepository.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/DataUpdateRepository.kt
@@ -241,7 +241,7 @@ class DataUpdateRepository(
     ): File {
         val body = client.get("https://api.github.com/repos/$APP_REPO/releases/tags/${release.tagName}").bodyAsText()
         val apiRelease = json.decodeFromString<ApiRelease>(body)
-        val apkAsset = apiRelease.assets.firstOrNull { it.name.endsWith(".apk") && !it.name.contains("debug", ignoreCase = true) }
+        val apkAsset = apiRelease.assets.firstOrNull { it.name == "app-github-release.apk" }
             ?: throw IllegalStateException("No release APK found in ${release.tagName}")
 
         val response = client.get(apkAsset.browserDownloadUrl)


### PR DESCRIPTION
## Description
GitHub's release API returns assets in alphabetical order. After PR #146 changed the F-Droid release format from AAB to APK, both `app-fdroid-release.apk` and `app-github-release.apk` were present in releases. The previous broad filter (`endsWith(".apk") && !contains("debug")`) was picking `app-fdroid-release.apk` (alphabetically first), installing the F-Droid flavor on the device — which has `CAN_SELF_UPDATE = false` and falls back to showing a manual install link instead of installing automatically.

Fix uses an exact name match to always select the correct GitHub-flavor APK.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)