### PR TITLE
fix: card label formatting and tutorial flow improvements

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
@@ -818,7 +818,7 @@ class MainActivity : ComponentActivity() {
                         onAdvance = { viewModel.onEvent(CharacterEvent.AdvanceTutorial) },
                         onSkip = { viewModel.onEvent(CharacterEvent.SkipTutorial) },
                         onStepChanged = { newStep ->
-                            if (newStep == 5) scope.launch { drawerState.close() }
+                            if (newStep == 6) scope.launch { drawerState.close() }
                         },
                         drawerState = drawerState
                     )

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -180,8 +180,13 @@ fun AnnotatedString.Builder.appendWithHighlight(text: String, searchQuery: Strin
 
 fun buildArcaneDescription(ability: Ability): String {
     val outcomeLines = ability.arcaneOutcomes.joinToString("\n") { outcome ->
-        val cardLabel = outcome.validCards.joinToString(" or ") { card ->
+        val cards = outcome.validCards.map { card ->
             if (card.colour == "Catastrophe") "Catastrophe" else "[${card.colour.first()}]${card.value}"
+        }
+        val cardLabel = when (cards.size) {
+            0 -> ""
+            1 -> cards[0]
+            else -> cards.dropLast(1).joinToString(",") + " or " + cards.last()
         }
         "$cardLabel: ${outcome.text}"
     }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/TutorialState.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/TutorialState.kt
@@ -47,32 +47,39 @@ private const val EXAMPLE_TROUPE_CODE = "RXhhbXBsZSBUcm91cGV8QTBBQUFBQkFBQUFDQUF
 
 val appTutorialSteps: List<TutorialStep> = listOf(
 
-    // 0 — Welcome
+    // 0 — Welcome (shown on Home so portrait downloads can complete before the user reaches the Compendium)
     TutorialStep(
         message = "Welcome to Lunachron! Let's take a quick tour of the key features — it'll only take a minute.",
         advance = AdvanceCondition.Manual,
         buttonLabel = "Let's go!",
-        requiredRoute = Screen.Characters.route
+        requiredRoute = Screen.Home.route
     ),
 
-    // 1 — Character Compendium
+    // 1 — Navigate to Compendium (stepping stone; skips the landing page and goes straight to the character list)
+    TutorialStep(
+        targetTag = "CompendiumNav",
+        message = "Tap the Compendium tab to explore every character available in Moonstone.",
+        advance = AdvanceCondition.OnNavigation(Screen.Characters.route)
+    ),
+
+    // 2 — Character Compendium
     TutorialStep(
         targetTag = "CharacterList",
         message = "This is the Character Compendium — a full reference of every character available in Moonstone.",
         advance = AdvanceCondition.Manual
     ),
 
-    // 2 — Filter button (the search panel is open by default on this screen)
+    // 3 — Filter button (the search panel is open by default on this screen)
     TutorialStep(
         targetTag = "FilterButtonOpen",
         message = "Tap the filter button to hide the search panel — you can reopen it anytime to filter by name, faction, or keywords.",
         advance = AdvanceCondition.OnSpotlightTap
     ),
 
-    // 3 — Menu / drawer button
+    // 4 — Menu / drawer button
     // Uses OnStateChange("drawer_opened") rather than OnSpotlightTap so the tutorial waits for
     // the drawer to actually finish opening before advancing — that way the user sees its contents
-    // before step 4 explains them.
+    // before step 5 explains them.
     TutorialStep(
         targetTag = "MenuButton",
         message = "The menu button opens the side drawer. Tap it to take a look.",
@@ -80,7 +87,7 @@ val appTutorialSteps: List<TutorialStep> = listOf(
         requiredRoute = Screen.Compendium.route
     ),
 
-    // 4 — Drawer contents (arrowless — drawer is open from step 3)
+    // 5 — Drawer contents (arrowless — drawer is open from step 4)
     TutorialStep(
         message = "From here you can access the Rules reference, your Stats, and Settings. " +
                 "In Settings you can change your default start page — handy if you prefer to open straight to the Compendium.",
@@ -88,14 +95,14 @@ val appTutorialSteps: List<TutorialStep> = listOf(
         buttonLabel = "Got it"
     ),
 
-    // 5 — Troupes tab  (onStepChanged(5) in MainActivity closes the drawer)
+    // 6 — Troupes tab  (onStepChanged(6) in MainActivity closes the drawer)
     TutorialStep(
         targetTag = "TroupesNav",
         message = "Next, let's head to My Troupes to build your roster.",
         advance = AdvanceCondition.OnNavigation(Screen.Troupes.route)
     ),
 
-    // 6 — Add / Import FAB  (importPrefill carried here so screen sees it even if state lags)
+    // 7 — Add / Import FAB  (importPrefill carried here so screen sees it even if state lags)
     TutorialStep(
         targetTag = "AddTroupe",
         message = "Tap + to create or import a troupe. We've queued up an example troupe — the Import tab will be ready for you on the next screen!",
@@ -103,7 +110,7 @@ val appTutorialSteps: List<TutorialStep> = listOf(
         importPrefill = EXAMPLE_TROUPE_CODE
     ),
 
-    // 7 — Import button inside AddEditTroupeScreen (Import tab pre-filled)
+    // 8 — Import button inside AddEditTroupeScreen (Import tab pre-filled)
     TutorialStep(
         targetTag = "ImportButton",
         message = "The example share code is already filled in — tap Import to add it to your collection.",
@@ -111,7 +118,7 @@ val appTutorialSteps: List<TutorialStep> = listOf(
         importPrefill = EXAMPLE_TROUPE_CODE
     ),
 
-    // 8 — Tap troupe card to open the editor
+    // 9 — Tap troupe card to open the editor
     TutorialStep(
         targetTag = "TroupeCard0",
         message = "Tap a troupe card to open it in the editor.",
@@ -119,7 +126,7 @@ val appTutorialSteps: List<TutorialStep> = listOf(
         requiredRoute = Screen.Troupes.route
     ),
 
-    // 9 — Inside the editor: troupe types — advance when user navigates back to Troupes
+    // 10 — Inside the editor: troupe types — advance when user navigates back to Troupes
     TutorialStep(
         message = "Inside the editor you can switch between Normal and Campaign troupe types — " +
                 "Campaign troupes track upgrade cards and victory points. " +
@@ -127,21 +134,21 @@ val appTutorialSteps: List<TutorialStep> = listOf(
         advance = AdvanceCondition.OnNavigation(Screen.Troupes.route),
     ),
 
-    // 10 — Back on Troupes: share codes and QR (no requiredRoute — user navigated here naturally)
+    // 11 — Back on Troupes: share codes and QR (no requiredRoute — user navigated here naturally)
     TutorialStep(
         targetTag = "TroupeCard0",
         message = "You can also tap the QR icon or share button on a troupe card to swap rosters with opponents — handy for quickly loading someone else's troupe.",
         advance = AdvanceCondition.Manual,
     ),
 
-    // 11 — Favourite star
+    // 12 — Favourite star
     TutorialStep(
         targetTag = "FavouriteStar0",
         message = "Star a troupe as a favourite for quick access from the home screen.",
         advance = AdvanceCondition.OnStateChange("troupe_favourited")
     ),
 
-    // 12 — Quick Start on Home
+    // 13 — Quick Start on Home
     TutorialStep(
         targetTag = "QuickStartSection",
         message = "Favourited troupes appear here in Quick Start — tap one to launch a game immediately without any setup.",
@@ -149,7 +156,7 @@ val appTutorialSteps: List<TutorialStep> = listOf(
         requiredRoute = Screen.Home.route
     ),
 
-    // 13 — Play tab
+    // 14 — Play tab
     TutorialStep(
         targetTag = "PlayNav",
         message = "The Play tab is where you set up local games. Select your player count, pick your troupes, and go! " +
@@ -158,7 +165,7 @@ val appTutorialSteps: List<TutorialStep> = listOf(
         advance = AdvanceCondition.OnNavigation(Screen.GameSetup.route)
     ),
 
-    // 14 — Campaigns tab
+    // 15 — Campaigns tab
     TutorialStep(
         targetTag = "CampaignsNav",
         message = "The Campaigns tab is home to the Wizard Chamberlain — your campaign organiser. " +
@@ -166,7 +173,7 @@ val appTutorialSteps: List<TutorialStep> = listOf(
         advance = AdvanceCondition.OnNavigation(Screen.CampaignHub.route)
     ),
 
-    // 15 — Cleanup (arrowless — example troupe position in list is unpredictable after re-runs)
+    // 16 — Cleanup (arrowless — example troupe position in list is unpredictable after re-runs)
     TutorialStep(
         message = "That's everything! If you'd like to remove the example troupe, tap its delete button (🗑) on the troupe card. Otherwise, feel free to keep it.",
         advance = AdvanceCondition.Manual,


### PR DESCRIPTION
## Description

Two small fixes:

**Card label formatting** — arcane outcome valid-card labels now use commas between all options except the last, which keeps the "or" conjunction (e.g. `[G]2,[B]2 or [P]2` instead of `[G]2 or [B]2 or [P]2`).

**Tutorial flow** — step 0 now lands on the Home screen instead of jumping straight to the Compendium character list. This gives portrait image downloads time to complete before the user reaches the Compendium. A new step 1 spotlights the Compendium nav button so the user taps into the character list themselves, making the transition feel natural. All subsequent step indices shift by one; the drawer-close side-effect in `MainActivity` is updated from step 5 → 6 accordingly.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)