### PR TITLE
fix: use data submodule to aggregate compendium.json in F-Droid sandbox builds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "data"]
+	path = data
+	url = https://github.com/Garemat/lunachron-data.git

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -137,11 +137,18 @@ android.sourceSets.getByName("androidTest") {
 }
 
 // ---------------------------------------------------------------------------
-// Task: download the pinned lunachron-data release assets into
-// app/src/main/assets/ so the bundled seed is deterministic at build time.
-// The pinned tag is read from data.version in the repo root — this file is
-// committed and updated by CI on each app release, giving F-Droid and local
-// builds a reproducible, auditable data snapshot.
+// Task: produce compendium.json in app/src/main/assets/ so the bundled seed
+// is deterministic at build time.  Two strategies, tried in order:
+//
+// 1. Submodule (preferred — works in F-Droid's sandboxed build environment):
+//    The data/ submodule is pinned to the same tag as data.version.  When
+//    present, aggregate.py is run against the raw source files so no network
+//    access is needed.
+//
+// 2. GitHub API download (fallback for CI builds that don't initialise the
+//    submodule, e.g. the release workflow which already has GITHUB_TOKEN set):
+//    Fetches the pre-built compendium.json release asset.
+//
 // The assets/ folder is gitignored — these files are never committed.
 // ---------------------------------------------------------------------------
 val dataAssetsDir = file("src/main/assets")
@@ -150,9 +157,10 @@ val dataRepo = "garemat/lunachron-data"
 // Read pinned version from data.version in the repo root.
 val dataVersionFile = rootProject.file("data.version")
 val pinnedDataTag = if (dataVersionFile.exists()) dataVersionFile.readText().trim() else "v0.1.0"
+val dataSubmoduleDir = rootProject.file("data")
 
 tasks.register("downloadDataAssets") {
-    description = "Downloads compendium.json from the pinned lunachron-data release (tag in data.version)."
+    description = "Aggregates compendium.json from the data submodule, or downloads it from GitHub as a fallback."
     group = "lunachron"
 
     outputs.files(file("${dataAssetsDir}/$compendiumAsset"))
@@ -164,7 +172,24 @@ tasks.register("downloadDataAssets") {
     doLast {
         dataAssetsDir.mkdirs()
 
-        // Use GITHUB_TOKEN when present (CI) so the API call works against private repos.
+        // Strategy 1: aggregate from the local data submodule (no network needed).
+        if (file("${dataSubmoduleDir}/characters").exists()) {
+            logger.lifecycle("Aggregating $compendiumAsset from data submodule ($pinnedDataTag)...")
+            val process = ProcessBuilder("python3", "scripts/aggregate.py")
+                .directory(dataSubmoduleDir)
+                .redirectErrorStream(true)
+                .also { it.environment()["COMPENDIUM_VERSION"] = pinnedDataTag }
+                .start()
+            val output = process.inputStream.bufferedReader().readText()
+            val exitCode = process.waitFor()
+            if (exitCode != 0) error("aggregate.py failed (exit $exitCode):\n$output")
+            file("${dataSubmoduleDir}/build/$compendiumAsset")
+                .copyTo(file("${dataAssetsDir}/$compendiumAsset"), overwrite = true)
+            logger.lifecycle("$compendiumAsset aggregated from submodule.")
+            return@doLast
+        }
+
+        // Strategy 2: download from GitHub release (requires GITHUB_TOKEN and network).
         val githubToken = System.getenv("GITHUB_TOKEN")
         fun openAuthenticatedStream(url: String): java.io.InputStream {
             val conn = URI(url).toURL().openConnection() as java.net.HttpURLConnection


### PR DESCRIPTION
## Summary

- Adds `lunachron-data` as a git submodule at `data/`, pinned to the tag in `data.version` (currently `v0.2.2`)
- Modifies `downloadDataAssets` in `app/build.gradle.kts` to prefer aggregating `compendium.json` locally from the submodule source files (via `aggregate.py`) when the submodule is present — no network access required
- Keeps the existing GitHub API download as a fallback for CI release builds that have `GITHUB_TOKEN` set and don't initialise the submodule

## Why

F-Droid's build sandbox blocks all outbound network access. The existing `downloadDataAssets` task called the GitHub API to fetch the `compendium.json` release asset, which failed with a 401:

```
java.io.IOException: Server returned HTTP response code: 401 for URL:
  https://api.github.com/repos/garemat/lunachron-data/releases/tags/v0.2.2
```

## Test plan

- [x] `./gradlew assembleFdroidDebug` succeeds locally with submodule present — `compendium.json` is aggregated from submodule (version `v0.2.2`, 133 characters, 92 campaign entries)
- [ ] Verify CI release workflow still passes (uses GitHub API download fallback since it doesn't init the submodule)
- [ ] After merge, update fdroiddata metadata for the new version with `submodules: true` in the build entry

## fdroiddata metadata note

The fix takes effect from the **next** app version. When updating fdroiddata, the new build entry needs:
```yaml
submodules: true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)