### PR TITLE
feat: point API URL directly at ORDS, reduce timeouts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,10 +77,10 @@ android {
     buildTypes {
         debug {
             // Emulator loopback — change to LAN IP for testing on a physical device.
-            buildConfigField("String", "LUNACHRON_API_URL", "\"https://api.garemat.co.uk\"")
+            buildConfigField("String", "LUNACHRON_API_URL", "\"https://GE122272A5BD5AC-GAREMAT.adb.uk-london-1.oraclecloudapps.com/ords/lunachron\"")
         }
         release {
-            buildConfigField("String", "LUNACHRON_API_URL", "\"https://api.garemat.co.uk\"")
+            buildConfigField("String", "LUNACHRON_API_URL", "\"https://GE122272A5BD5AC-GAREMAT.adb.uk-london-1.oraclecloudapps.com/ords/lunachron\"")
             isMinifyEnabled = false
             isCrunchPngs = false
             // Only apply signingConfig if it exists and storeFile is set.

--- a/app/src/main/java/io/github/garemat/lunachron/api/LunaChronApi.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/api/LunaChronApi.kt
@@ -118,18 +118,15 @@ class LunaChronApi(
     private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true; encodeDefaults = true }
     private val http = client ?: HttpClient(Android) {
         install(HttpTimeout) {
-            // 35s gives headroom above the OCI Function's own 30s timeout so the
-            // function's error (502) reaches us rather than the client timing out first.
-            requestTimeoutMillis = 35_000
-            connectTimeoutMillis = 35_000
-            socketTimeoutMillis  = 35_000
+            // ORDS runs inside ADB — no cold starts, so 15s is ample.
+            requestTimeoutMillis = 15_000
+            connectTimeoutMillis = 15_000
+            socketTimeoutMillis  = 15_000
         }
         install(HttpRequestRetry) {
-            // One retry on timeout — if the cold start exhausted the first attempt,
-            // the container is warm by the time the retry lands.
             maxRetries = 1
             retryOnException(retryOnTimeout = true)
-            delayMillis { 2_000 }
+            delayMillis { 1_000 }
         }
     }
 


### PR DESCRIPTION
## Summary

- OCI API Gateway free-tier quota is exhausted after the deployment was deleted during a backend migration (OCI Functions → ORDS). All service limits show as 0 in the Console; the deployment cannot be recreated.
- Update both debug and release `LUNACHRON_API_URL` to point directly at the ORDS endpoint on Autonomous DB, bypassing the gateway.
- Reduce HTTP timeouts from 35 s → 15 s and retry delay from 2 s → 1 s — ORDS has no cold-start penalty unlike OCI Functions.

## Test plan

- [ ] Build and install a debug APK, trigger device registration — should succeed (201) and return a session token
- [ ] Verify login also works with the new URL
- [ ] Confirm 15 s timeout is sufficient for the slowest observed ORDS response (~2–3 s on a warm DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)