### PR TITLE
feat: allow bye reassignment before publishing online campaign schedule

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
@@ -125,6 +125,7 @@ sealed interface CharacterEvent {
     data class UnlockOnlineCampaign(val campaignId: String) : CharacterEvent
     data class SetOnlineScheduleRoundCount(val count: Int) : CharacterEvent
     data class GenerateOnlineSchedule(val campaignId: String, val totalRounds: Int) : CharacterEvent
+    data class SwapScheduleBye(val roundNumber: Int, val newByePlayerId: String) : CharacterEvent
     data class PublishOnlineSchedule(val campaignId: String) : CharacterEvent
 
     // LunaChron API — troupe sharing + ready

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
@@ -348,6 +348,7 @@ data class CharacterState(
     val isPublishingSchedule: Boolean = false,
     val pendingOnlineSchedule: List<CampaignRound>? = null,
     val onlineScheduleRoundCount: Int = 0,
+    val pendingScheduleError: String? = null,
 
     // Online campaign troupe + ready
     val isUploadingTroupe: Boolean = false,

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -436,7 +436,16 @@ class CharacterViewModel(
                     ?.members?.filter { it.status == "APPROVED" } ?: return
                 val playerIds = members.map { it.deviceId }
                 val schedule = generateRoundRobinSchedule(playerIds, event.totalRounds)
-                _state.update { it.copy(pendingOnlineSchedule = schedule) }
+                _state.update { it.copy(pendingOnlineSchedule = schedule, pendingScheduleError = null) }
+            }
+            is CharacterEvent.SwapScheduleBye -> {
+                val schedule = _state.value.pendingOnlineSchedule ?: return
+                val playerCount = _state.value.selectedOnlineCampaign
+                    ?.members?.count { it.status == "APPROVED" } ?: return
+                when (val result = swapScheduleBye(schedule, playerCount, event.roundNumber, event.newByePlayerId)) {
+                    is ScheduleSwapResult.Success -> _state.update { it.copy(pendingOnlineSchedule = result.schedule, pendingScheduleError = null) }
+                    is ScheduleSwapResult.Error -> _state.update { it.copy(pendingScheduleError = result.message) }
+                }
             }
             is CharacterEvent.UploadOnlineTroupe -> viewModelScope.launch {
                 _state.update { it.copy(isUploadingTroupe = true, onlineCampaignError = null) }
@@ -556,6 +565,13 @@ class CharacterViewModel(
             }
             is CharacterEvent.PublishOnlineSchedule -> viewModelScope.launch {
                 val rounds = _state.value.pendingOnlineSchedule ?: return@launch
+                val playerCount = _state.value.selectedOnlineCampaign
+                    ?.members?.count { it.status == "APPROVED" } ?: return@launch
+                val validationError = validateSchedule(rounds, playerCount)
+                if (validationError != null) {
+                    _state.update { it.copy(pendingScheduleError = validationError) }
+                    return@launch
+                }
                 _state.update { it.copy(isPublishingSchedule = true, onlineCampaignError = null) }
                 // Convert List<CampaignRound> → Map<String, Map<String, List<String>>>
                 val backendSchedule = rounds.associate { round ->
@@ -1361,6 +1377,85 @@ class CharacterViewModel(
 
             CampaignRound(roundNumber = roundNumber, games = games, skipPlayerIds = skipIds)
         }
+    }
+
+    private sealed interface ScheduleSwapResult {
+        data class Success(val schedule: List<CampaignRound>) : ScheduleSwapResult
+        data class Error(val message: String) : ScheduleSwapResult
+    }
+
+    private fun swapScheduleBye(
+        schedule: List<CampaignRound>,
+        playerCount: Int,
+        targetRoundNumber: Int,
+        newByePlayerId: String
+    ): ScheduleSwapResult {
+        if (playerCount % 2 == 0) return ScheduleSwapResult.Error("No byes exist in an even-player schedule")
+        val targetRound = schedule.find { it.roundNumber == targetRoundNumber }
+            ?: return ScheduleSwapResult.Error("Round $targetRoundNumber not found")
+        val currentByeHolder = targetRound.skipPlayerIds.firstOrNull()
+            ?: return ScheduleSwapResult.Error("Round $targetRoundNumber has no bye")
+        if (currentByeHolder == newByePlayerId) return ScheduleSwapResult.Success(schedule)
+
+        // Find newByePlayerId's bye in the same schedule cycle as targetRound
+        val cycleLength = playerCount
+        val targetCycle = (targetRoundNumber - 1) / cycleLength
+        val sourceRound = schedule.find { r ->
+            r.skipPlayerIds.contains(newByePlayerId) && (r.roundNumber - 1) / cycleLength == targetCycle
+        } ?: return ScheduleSwapResult.Error("That player's bye is in a different cycle and can't be swapped here")
+
+        // targetRound: swap newByePlayerId out of their game, put currentByeHolder in
+        val newTargetGames = targetRound.games.map { game ->
+            if (newByePlayerId in game.playerIds)
+                game.copy(playerIds = game.playerIds.map { if (it == newByePlayerId) currentByeHolder else it })
+            else game
+        }
+        // sourceRound: swap currentByeHolder out of their game, put newByePlayerId in
+        val newSourceGames = sourceRound.games.map { game ->
+            if (currentByeHolder in game.playerIds)
+                game.copy(playerIds = game.playerIds.map { if (it == currentByeHolder) newByePlayerId else it })
+            else game
+        }
+        val newSchedule = schedule.map { r ->
+            when (r.roundNumber) {
+                targetRoundNumber -> targetRound.copy(games = newTargetGames, skipPlayerIds = listOf(newByePlayerId))
+                sourceRound.roundNumber -> sourceRound.copy(games = newSourceGames, skipPlayerIds = listOf(currentByeHolder))
+                else -> r
+            }
+        }
+        return ScheduleSwapResult.Success(newSchedule)
+    }
+
+    private fun validateSchedule(schedule: List<CampaignRound>, playerCount: Int): String? {
+        if (playerCount % 2 == 0) return null
+        val cycleLength = playerCount
+        val allPlayerIds = (schedule.flatMap { it.games.flatMap { g -> g.playerIds } } + schedule.flatMap { it.skipPlayerIds }).distinct()
+        val cycles = schedule.groupBy { (it.roundNumber - 1) / cycleLength }
+        for ((_, rounds) in cycles) {
+            val byeCounts = mutableMapOf<String, Int>()
+            for (round in rounds) {
+                for (id in round.skipPlayerIds) byeCounts[id] = (byeCounts[id] ?: 0) + 1
+            }
+            for ((_, count) in byeCounts) {
+                if (count > 1) return "A player has more than one bye in a cycle"
+            }
+            if (rounds.size == cycleLength) {
+                for (playerId in allPlayerIds) {
+                    if ((byeCounts[playerId] ?: 0) == 0) return "A player is missing their bye in a full cycle"
+                }
+            }
+        }
+        val gameCounts = mutableMapOf<String, Int>()
+        for (round in schedule) {
+            for (game in round.games) {
+                for (id in game.playerIds) gameCounts[id] = (gameCounts[id] ?: 0) + 1
+            }
+        }
+        val counts = gameCounts.values
+        if (counts.isNotEmpty() && counts.max() - counts.min() > 1) {
+            return "Players have unequal numbers of games"
+        }
+        return null
     }
 
     fun updateCampaign(campaign: Campaign) {

--- a/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
@@ -1655,9 +1655,32 @@ private fun ScheduleGenerationSection(
             if (pendingSchedule != null) {
                 HorizontalDivider()
                 Text("Preview", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                SchedulePreview(rounds = pendingSchedule, members = approvedMembers)
-                Button(onClick = { onEvent(CharacterEvent.PublishOnlineSchedule(campaignId)) },
-                    enabled = !state.isPublishingSchedule, modifier = Modifier.fillMaxWidth()) {
+                SchedulePreview(
+                    rounds = pendingSchedule,
+                    members = approvedMembers,
+                    onSwapBye = { roundNumber, newByePlayerId ->
+                        onEvent(CharacterEvent.SwapScheduleBye(roundNumber, newByePlayerId))
+                    }
+                )
+                if (state.pendingScheduleError != null) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(MaterialTheme.colorScheme.errorContainer, MaterialTheme.shapes.small)
+                            .padding(horizontal = 12.dp, vertical = 8.dp)
+                    ) {
+                        Icon(Icons.Default.Warning, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.onErrorContainer)
+                        Text(state.pendingScheduleError, style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onErrorContainer)
+                    }
+                }
+                Button(
+                    onClick = { onEvent(CharacterEvent.PublishOnlineSchedule(campaignId)) },
+                    enabled = !state.isPublishingSchedule && state.pendingScheduleError == null,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
                     if (state.isPublishingSchedule) CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
                     else { Icon(Icons.Default.Publish, null, Modifier.size(18.dp)); Spacer(Modifier.width(6.dp)); Text("Publish Schedule") }
                 }
@@ -1667,7 +1690,11 @@ private fun ScheduleGenerationSection(
 }
 
 @Composable
-private fun SchedulePreview(rounds: List<CampaignRound>, members: List<OnlineCampaignMember>) {
+private fun SchedulePreview(
+    rounds: List<CampaignRound>,
+    members: List<OnlineCampaignMember>,
+    onSwapBye: ((roundNumber: Int, newByePlayerId: String) -> Unit)? = null
+) {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         rounds.forEach { round ->
             Text("Round ${round.roundNumber}", style = MaterialTheme.typography.labelMedium,
@@ -1686,7 +1713,33 @@ private fun SchedulePreview(rounds: List<CampaignRound>, members: List<OnlineCam
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(Icons.Default.Pause, null, Modifier.size(14.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
                     Spacer(Modifier.width(4.dp))
-                    Text("Bye: ${byeNames.joinToString(", ")}", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("Bye: ${byeNames.joinToString(", ")}", style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.weight(1f))
+                    if (onSwapBye != null) {
+                        var dropdownOpen by remember { mutableStateOf(false) }
+                        val playingIds = round.games.flatMap { it.playerIds }
+                        Box {
+                            IconButton(onClick = { dropdownOpen = true }, modifier = Modifier.size(24.dp)) {
+                                Icon(Icons.Default.SwapHoriz, "Move bye", Modifier.size(16.dp),
+                                    tint = MaterialTheme.colorScheme.primary)
+                            }
+                            DropdownMenu(expanded = dropdownOpen, onDismissRequest = { dropdownOpen = false }) {
+                                Text("Give bye to…", style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp))
+                                playingIds.forEach { playerId ->
+                                    val name = members.find { it.deviceId == playerId }?.username ?: playerId
+                                    DropdownMenuItem(
+                                        text = { Text(name, style = MaterialTheme.typography.bodySmall) },
+                                        onClick = {
+                                            dropdownOpen = false
+                                            onSwapBye(round.roundNumber, playerId)
+                                        }
+                                    )
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description

Adds an editing step to the online campaign schedule preview so the host can reassign bye slots before publishing.

When a round has a bye (odd player count), a swap icon appears on the bye row. Tapping it opens a dropdown — "Give bye to…" — listing every player active in that round. Selecting a player triggers a **bye-move**: the system finds that player's existing bye within the same schedule cycle and swaps the two slots atomically, updating game assignments in both rounds so that game counts and bye counts remain balanced.

Validation runs both on each swap attempt and as a gate before publishing. If any player has 0 or 2+ byes in a full cycle, or game counts are unequal, an error chip appears inline and the Publish button is disabled.

- `SwapScheduleBye(roundNumber, newByePlayerId)` event + `swapScheduleBye()` ViewModel function handle the swap logic
- `validateSchedule()` checks bye counts per cycle and game count balance; also called in `PublishOnlineSchedule` as a hard gate
- `pendingScheduleError: String?` in `CharacterState` carries both swap errors and validation errors to the UI
- Cross-cycle swaps are rejected with a clear error message

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)