### PR TITLE
feat: give bye players a bonus 3rd machination slot and +1 MP credit

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/Character.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/Character.kt
@@ -292,8 +292,10 @@ data class CampaignAttack(
 data class PlayerMachinationDraft(
     val machType1: MachinationType? = null,
     val machType2: MachinationType? = null,
+    val machType3: MachinationType? = null,
     val target1: String = "",
     val target2: String = "",
+    val target3: String = "",
     val isAttacking: Boolean = false,
     val attackType: AttackType = AttackType.ASSAULT,
     val attackTargetPlayerId: String = "",

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -1217,25 +1217,27 @@ class CharacterViewModel(
     var isViewingCardDraw: Boolean by mutableStateOf(false)
     val machinationType1: SnapshotStateMap<String, MachinationType?> = mutableStateMapOf()
     val machinationType2: SnapshotStateMap<String, MachinationType?> = mutableStateMapOf()
+    val machinationType3: SnapshotStateMap<String, MachinationType?> = mutableStateMapOf()
     val machinationTarget1: SnapshotStateMap<String, String> = mutableStateMapOf()
     val machinationTarget2: SnapshotStateMap<String, String> = mutableStateMapOf()
+    val machinationTarget3: SnapshotStateMap<String, String> = mutableStateMapOf()
     val machinationIsAttacking: SnapshotStateMap<String, Boolean> = mutableStateMapOf()
     val machinationAttackType: SnapshotStateMap<String, AttackType> = mutableStateMapOf()
     val machinationAttackTargetPlayer: SnapshotStateMap<String, String> = mutableStateMapOf()
     val machinationAttackTargetChar: SnapshotStateMap<String, Int> = mutableStateMapOf()
 
     fun initMachinationDraft(campaign: Campaign) {
-        machinationType1.clear(); machinationType2.clear()
-        machinationTarget1.clear(); machinationTarget2.clear()
+        machinationType1.clear(); machinationType2.clear(); machinationType3.clear()
+        machinationTarget1.clear(); machinationTarget2.clear(); machinationTarget3.clear()
         machinationIsAttacking.clear(); machinationAttackType.clear()
         machinationAttackTargetPlayer.clear(); machinationAttackTargetChar.clear()
-        campaign.players.forEach { machinationType1[it.id] = null; machinationType2[it.id] = null }
+        campaign.players.forEach { machinationType1[it.id] = null; machinationType2[it.id] = null; machinationType3[it.id] = null }
         isCampaignMachinating = true
     }
 
     fun clearMachinationDraft() {
-        machinationType1.clear(); machinationType2.clear()
-        machinationTarget1.clear(); machinationTarget2.clear()
+        machinationType1.clear(); machinationType2.clear(); machinationType3.clear()
+        machinationTarget1.clear(); machinationTarget2.clear(); machinationTarget3.clear()
         machinationIsAttacking.clear(); machinationAttackType.clear()
         machinationAttackTargetPlayer.clear(); machinationAttackTargetChar.clear()
         isCampaignMachinating = false
@@ -1246,8 +1248,10 @@ class CharacterViewModel(
             player.id to PlayerMachinationDraft(
                 machType1 = machinationType1[player.id],
                 machType2 = machinationType2[player.id],
+                machType3 = machinationType3[player.id],
                 target1 = machinationTarget1[player.id] ?: "",
                 target2 = machinationTarget2[player.id] ?: "",
+                target3 = machinationTarget3[player.id] ?: "",
                 isAttacking = machinationIsAttacking[player.id] == true,
                 attackType = machinationAttackType[player.id] ?: AttackType.ASSAULT,
                 attackTargetPlayerId = machinationAttackTargetPlayer[player.id] ?: "",
@@ -1259,15 +1263,17 @@ class CharacterViewModel(
 
     fun loadMachinationDraft(campaign: Campaign) {
         val draft = campaign.machinationDraft ?: return
-        machinationType1.clear(); machinationType2.clear()
-        machinationTarget1.clear(); machinationTarget2.clear()
+        machinationType1.clear(); machinationType2.clear(); machinationType3.clear()
+        machinationTarget1.clear(); machinationTarget2.clear(); machinationTarget3.clear()
         machinationIsAttacking.clear(); machinationAttackType.clear()
         machinationAttackTargetPlayer.clear(); machinationAttackTargetChar.clear()
         draft.forEach { (playerId, pd) ->
             machinationType1[playerId] = pd.machType1
             machinationType2[playerId] = pd.machType2
+            machinationType3[playerId] = pd.machType3
             if (pd.target1.isNotEmpty()) machinationTarget1[playerId] = pd.target1
             if (pd.target2.isNotEmpty()) machinationTarget2[playerId] = pd.target2
+            if (pd.target3.isNotEmpty()) machinationTarget3[playerId] = pd.target3
             machinationIsAttacking[playerId] = pd.isAttacking
             machinationAttackType[playerId] = pd.attackType
             if (pd.attackTargetPlayerId.isNotEmpty()) machinationAttackTargetPlayer[playerId] = pd.attackTargetPlayerId
@@ -1330,19 +1336,28 @@ class CharacterViewModel(
                 startingCharacters = startingCharacters,
                 characterGrowthEvery = characterGrowthEvery,
                 upgradeGrowthEvery = upgradeGrowthEvery
-            ) ?: Campaign(
-                id = 0,
-                name = name,
-                description = description,
-                players = players,
-                attacksEnabled = attacksEnabled,
-                totalRounds = totalRounds,
-                gameSize = gameSize,
-                startingCharacters = startingCharacters,
-                characterGrowthEvery = characterGrowthEvery,
-                upgradeGrowthEvery = upgradeGrowthEvery,
-                rounds = generateRoundRobinSchedule(players.map { it.id }, totalRounds)
-            )
+            ) ?: run {
+                val rounds = generateRoundRobinSchedule(players.map { it.id }, totalRounds)
+                // Players with a bye in round 1 miss the pre-round-1 machination phase (it doesn't
+                // exist), so they can't get the normal 3-slot bye bonus there. Give them +1 MP now
+                // as a one-time compensating credit they can spend at any point in the campaign.
+                val round1ByeIds = rounds.firstOrNull()?.skipPlayerIds?.toSet() ?: emptySet()
+                val seededPlayers = if (round1ByeIds.isEmpty()) players else
+                    players.map { if (it.id in round1ByeIds) it.copy(machinationPoints = it.machinationPoints + 1) else it }
+                Campaign(
+                    id = 0,
+                    name = name,
+                    description = description,
+                    players = seededPlayers,
+                    attacksEnabled = attacksEnabled,
+                    totalRounds = totalRounds,
+                    gameSize = gameSize,
+                    startingCharacters = startingCharacters,
+                    characterGrowthEvery = characterGrowthEvery,
+                    upgradeGrowthEvery = upgradeGrowthEvery,
+                    rounds = rounds
+                )
+            }
 
             repository.upsertCampaign(campaign)
             resetNewCampaignFields()

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CampaignDetailsScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CampaignDetailsScreen.kt
@@ -2383,10 +2383,16 @@ private fun MachinationPhasePanel(
         .filter { it != playerId }
         .toSet()
 
+    val byePlayerIds = nextRound?.skipPlayerIds?.toSet() ?: emptySet()
+    val hasBonusPlayers = byePlayerIds.isNotEmpty()
+
     Column(modifier = Modifier.fillMaxSize().padding(theme.screenPadding)) {
         Text("Machinations & Attacks", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
         Text(
-            "Each player can use 2 machinations. Targets cannot be scheduled opponents.",
+            buildString {
+                append("Each player can use 2 machinations. Targets cannot be scheduled opponents.")
+                if (hasBonusPlayers) append(" Bye players get a bonus 3rd slot.")
+            },
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
@@ -2397,29 +2403,45 @@ private fun MachinationPhasePanel(
                 if (index > 0) {
                     HorizontalDivider(modifier = Modifier.padding(vertical = theme.verticalSpacing))
                 }
+                val hasBonus = player.id in byePlayerIds
                 val type1 = viewModel.machinationType1[player.id]
                 val type2 = viewModel.machinationType2[player.id]
+                val type3 = viewModel.machinationType3[player.id]
                 val eligibleTargets = campaign.players.filter { it.id != player.id && it.id !in opponentsOf(player.id) }
                 PlayerMachinationCard(
                     player = player,
+                    hasBonus = hasBonus,
                     type1 = type1,
                     onType1Change = { newType ->
                         viewModel.machinationType1[player.id] = newType
                         if (newType == null) {
                             viewModel.machinationType2[player.id] = null
+                            viewModel.machinationType3[player.id] = null
                             viewModel.machinationTarget1.remove(player.id)
                             viewModel.machinationTarget2.remove(player.id)
+                            viewModel.machinationTarget3.remove(player.id)
                         }
                     },
                     type2 = type2,
                     onType2Change = { newType ->
                         viewModel.machinationType2[player.id] = newType
-                        if (newType == null) viewModel.machinationTarget2.remove(player.id)
+                        if (newType == null) {
+                            viewModel.machinationType3[player.id] = null
+                            viewModel.machinationTarget2.remove(player.id)
+                            viewModel.machinationTarget3.remove(player.id)
+                        }
+                    },
+                    type3 = type3,
+                    onType3Change = { newType ->
+                        viewModel.machinationType3[player.id] = newType
+                        if (newType == null) viewModel.machinationTarget3.remove(player.id)
                     },
                     target1 = viewModel.machinationTarget1[player.id] ?: "",
                     onTarget1Change = { viewModel.machinationTarget1[player.id] = it },
                     target2 = viewModel.machinationTarget2[player.id] ?: "",
                     onTarget2Change = { viewModel.machinationTarget2[player.id] = it },
+                    target3 = viewModel.machinationTarget3[player.id] ?: "",
+                    onTarget3Change = { viewModel.machinationTarget3[player.id] = it },
                     eligibleTargets = eligibleTargets,
                     attacksEnabled = campaign.attacksEnabled,
                     isAttacking = viewModel.machinationIsAttacking[player.id] == true,
@@ -2452,10 +2474,13 @@ private fun MachinationPhasePanel(
                     campaign.players.forEach { player ->
                         val t1 = viewModel.machinationType1[player.id]
                         val t2 = viewModel.machinationType2[player.id]
+                        val t3 = viewModel.machinationType3[player.id]
                         val target1 = viewModel.machinationTarget1[player.id] ?: ""
                         val target2 = viewModel.machinationTarget2[player.id] ?: ""
+                        val target3 = viewModel.machinationTarget3[player.id] ?: ""
                         if (t1 != null && target1.isNotEmpty()) machinations.add(CampaignMachination(player.id, target1, t1))
                         if (t2 != null && target2.isNotEmpty()) machinations.add(CampaignMachination(player.id, target2, t2))
+                        if (player.id in byePlayerIds && t3 != null && target3.isNotEmpty()) machinations.add(CampaignMachination(player.id, target3, t3))
                         if (campaign.attacksEnabled && viewModel.machinationIsAttacking[player.id] == true) {
                             val type = viewModel.machinationAttackType[player.id] ?: AttackType.ASSAULT
                             val tPlayer = viewModel.machinationAttackTargetPlayer[player.id] ?: ""
@@ -2479,14 +2504,19 @@ private fun MachinationPhasePanel(
 @Composable
 private fun PlayerMachinationCard(
     player: CampaignPlayer,
+    hasBonus: Boolean,
     type1: MachinationType?,
     onType1Change: (MachinationType?) -> Unit,
     type2: MachinationType?,
     onType2Change: (MachinationType?) -> Unit,
+    type3: MachinationType?,
+    onType3Change: (MachinationType?) -> Unit,
     target1: String,
     onTarget1Change: (String) -> Unit,
     target2: String,
     onTarget2Change: (String) -> Unit,
+    target3: String,
+    onTarget3Change: (String) -> Unit,
     eligibleTargets: List<CampaignPlayer>,
     attacksEnabled: Boolean,
     isAttacking: Boolean,
@@ -2507,10 +2537,16 @@ private fun PlayerMachinationCard(
     val eligibleTargets2 = if (type1 != null && type1 == type2 && target1.isNotEmpty())
         eligibleTargets.filter { it.id != target1 }
     else eligibleTargets
+    // For row 3: exclude players already targeted with the same type in rows 1 and 2
+    val usedByType3 = buildSet {
+        if (type1 != null && target1.isNotEmpty() && type1 == type3) add(target1)
+        if (type2 != null && target2.isNotEmpty() && type2 == type3) add(target2)
+    }
+    val eligibleTargets3 = eligibleTargets.filter { it.id !in usedByType3 }
 
     ThemedCard(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
-            // Header: name + AP + attack toggle
+            // Header: name + bye badge + AP + attack toggle
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     player.name,
@@ -2518,6 +2554,14 @@ private fun PlayerMachinationCard(
                     fontWeight = FontWeight.Bold,
                     modifier = Modifier.weight(1f)
                 )
+                if (hasBonus) {
+                    Text(
+                        "Bye +1 slot",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
                 if (attacksEnabled) {
                     Text(
                         "${player.attackPoints} AP",
@@ -2552,6 +2596,18 @@ private fun PlayerMachinationCard(
                     target = target2,
                     onTargetChange = onTarget2Change,
                     eligibleTargets = eligibleTargets2,
+                    theme = theme
+                )
+            }
+
+            // Machination row 3 — bonus slot for bye players, shown after row 2 is filled
+            if (hasBonus && type2 != null) {
+                MachinationRowItem(
+                    selectedType = type3,
+                    onTypeChange = onType3Change,
+                    target = target3,
+                    onTargetChange = onTarget3Change,
+                    eligibleTargets = eligibleTargets3,
                     theme = theme
                 )
             }


### PR DESCRIPTION
## Description
Players with a bye in an upcoming campaign round receive a bonus 3rd machination slot during the machination phase. Players who have a bye in round 1 miss that phase entirely, so they receive a one-time +1 MP credit at campaign creation instead.

Changes:
- `PlayerMachinationDraft` / ViewModel draft state extended with `machType3` / `target3`
- `PlayerMachinationCard` shows a "Bye +1 slot" badge and a third `MachinationRowItem` (revealed after row 2 is filled) for bye players only
- Description text in the machination panel notes the bonus when bye players exist
- On campaign creation, round-1 bye players get `machinationPoints + 1` seeded directly into their `CampaignPlayer` record
- No backend changes — all machination logic is local

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)