### PR TITLE
feat: mutual troupe confirmation + bye/MP bonus machination slot

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
@@ -164,6 +164,14 @@ sealed interface CharacterEvent {
     // LunaChron API — match result verification (opponent approves or contests)
     data class VerifyMatchResult(val campaignId: String, val resultId: String, val agree: Boolean) : CharacterEvent
 
+    // LunaChron API — round troupe confirmation (before a match, mutual reveal)
+    data class ConfirmRoundTroupe(
+        val campaignId: String,
+        val roundNumber: Int,
+        val troupeData: String,
+        val targetDeviceId: String? = null   // host only: confirm for a local player
+    ) : CharacterEvent
+
     // LunaChron API — machinations phase
     data class SubmitMachination(
         val campaignId: String,

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
@@ -153,6 +153,13 @@ data class OnlineCampaignMember(
     val powerPoints: Int = 0
 )
 
+/** Confirmed troupe snapshot for one player in a round. */
+@Serializable
+data class OnlineRoundTroupe(
+    val deviceId: String,
+    val troupeData: String   // base64 share string, same format as OnlineCampaignMember.troupeData
+)
+
 @Serializable
 data class OnlineCampaignDetail(
     val id: String,
@@ -168,7 +175,13 @@ data class OnlineCampaignDetail(
     val currentRound: Int = 1,
     val phase: String = "GAME",
     val machinations: List<OnlineMachinationEntry> = emptyList(),
-    val matchResults: List<OnlineMatchResult> = emptyList()
+    val matchResults: List<OnlineMatchResult> = emptyList(),
+    // Confirmed troupe snapshots for the current round — only populated for pairs
+    // where both players in a scheduled game have confirmed. Empty for round 1
+    // (use OnlineCampaignMember.troupeData instead).
+    val roundTroupes: List<OnlineRoundTroupe> = emptyList(),
+    // Previous round's confirmed troupes — no gate, used for new-character diff.
+    val previousRoundTroupes: List<OnlineRoundTroupe> = emptyList()
 )
 
 /** A single SUPPORT/SABOTAGE machination choice within a submitted entry. */
@@ -363,6 +376,9 @@ data class CharacterState(
     val isSubmittingMatchResult: Boolean = false,
     val matchResultSubmitted: Boolean = false,
     val isVerifyingMatchResult: Boolean = false,
+
+    // Online round troupe confirmation
+    val isConfirmingRoundTroupe: Boolean = false,
 
     // Online machinations phase
     val isSubmittingMachination: Boolean = false,

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
@@ -150,7 +150,8 @@ data class OnlineCampaignMember(
     val losses: Int = 0,
     val victoryPoints: Int = 0,
     val matchPoints: Int = 0,
-    val powerPoints: Int = 0
+    val powerPoints: Int = 0,
+    val bonusMp: Int = 0
 )
 
 /** Confirmed troupe snapshot for one player in a round. */

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -563,6 +563,16 @@ class CharacterViewModel(
                     is ApiResult.Error -> _state.update { it.copy(isVerifyingMatchResult = false, onlineCampaignError = r.message) }
                 }
             }
+            is CharacterEvent.ConfirmRoundTroupe -> viewModelScope.launch {
+                _state.update { it.copy(isConfirmingRoundTroupe = true, onlineCampaignError = null) }
+                when (val r = apiClient.confirmRoundTroupe(event.campaignId, event.roundNumber, event.troupeData, event.targetDeviceId)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isConfirmingRoundTroupe = false) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isConfirmingRoundTroupe = false, onlineCampaignError = r.message) }
+                }
+            }
             is CharacterEvent.PublishOnlineSchedule -> viewModelScope.launch {
                 val rounds = _state.value.pendingOnlineSchedule ?: return@launch
                 val playerCount = _state.value.selectedOnlineCampaign

--- a/app/src/main/java/io/github/garemat/lunachron/api/LunaChronApi.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/api/LunaChronApi.kt
@@ -522,6 +522,41 @@ class LunaChronApi(
         ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
     }
 
+    /**
+     * Confirm this player's troupe snapshot for [roundNumber] before their match.
+     * Once both players in the scheduled game confirm, each can see the other's troupe
+     * via [OnlineCampaignDetail.roundTroupes] returned by [getCampaign].
+     * Pass [targetDeviceId] (host only) to confirm on behalf of a local player.
+     */
+    suspend fun confirmRoundTroupe(
+        campaignId: String,
+        roundNumber: Int,
+        troupeData: String,
+        targetDeviceId: String? = null
+    ): ApiResult<Unit> = try {
+        val body = buildString {
+            append("""{"roundNumber":$roundNumber,"troupeData":""")
+            append(json.encodeToString(troupeData))
+            if (targetDeviceId != null) { append(""","targetDeviceId":"""); append(json.encodeToString(targetDeviceId)) }
+            append("}")
+        }
+        val response = http.post("$BASE_URL/campaigns/$campaignId/confirm-round-troupe") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            200 -> ApiResult.Success(Unit)
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
     /** Submit SUPPORT/SABOTAGE machination choices (and optional attack) for the machinations phase. */
     suspend fun submitMachination(
         campaignId: String,

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CampaignDetailsScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CampaignDetailsScreen.kt
@@ -317,7 +317,7 @@ fun GamesTab(
     val nextRoundMachinationsDone = nextRound?.machinations?.isNotEmpty() == true
 
     // Machinations for this round are stored in currentRound and evaluated with currentRound results
-    fun saveMachinationsAndAttacks(machinations: List<CampaignMachination>, attacks: List<CampaignAttack>) {
+    fun saveMachinationsAndAttacks(machinations: List<CampaignMachination>, attacks: List<CampaignAttack>, spentMpPlayerIds: Set<String> = emptySet()) {
         val newRounds = campaign.rounds.toMutableList()
         val nextRoundNumber = campaign.currentRound + 1
         val nextIdx = newRounds.indexOfFirst { it.roundNumber == nextRoundNumber }
@@ -328,8 +328,14 @@ fun GamesTab(
         if (nextIdx != -1) newRounds[nextIdx] = updatedRound else newRounds.add(updatedRound)
         val apCosts = attacks.groupBy { it.sourcePlayerId }.mapValues { (_, atks) -> atks.sumOf { it.type.cost } }
         val newPlayers = campaign.players.map { p ->
-            val cost = apCosts[p.id] ?: 0
-            if (cost > 0) p.copy(attackPoints = (p.attackPoints - cost).coerceAtLeast(0)) else p
+            val apCost = apCosts[p.id] ?: 0
+            val mpSpend = if (p.id in spentMpPlayerIds) 1 else 0
+            if (apCost > 0 || mpSpend > 0)
+                p.copy(
+                    attackPoints = (p.attackPoints - apCost).coerceAtLeast(0),
+                    machinationPoints = (p.machinationPoints - mpSpend).coerceAtLeast(0)
+                )
+            else p
         }
         viewModel.updateCampaign(campaign.copy(
             rounds = newRounds,
@@ -364,8 +370,8 @@ fun GamesTab(
             nextRound = nextRound,
             viewModel = viewModel,
             theme = theme,
-            onConfirm = { machinations, attacks ->
-                saveMachinationsAndAttacks(machinations, attacks)
+            onConfirm = { machinations, attacks, spentMpPlayerIds ->
+                saveMachinationsAndAttacks(machinations, attacks, spentMpPlayerIds)
                 viewModel.clearMachinationDraft()
                 flowStep = 3
             },
@@ -2372,7 +2378,7 @@ private fun MachinationPhasePanel(
     nextRound: CampaignRound?,
     viewModel: CharacterViewModel,
     theme: io.github.garemat.lunachron.ui.theme.AppThemeProperties,
-    onConfirm: (List<CampaignMachination>, List<CampaignAttack>) -> Unit,
+    onConfirm: (List<CampaignMachination>, List<CampaignAttack>, Set<String>) -> Unit,
     onSaveDraft: () -> Unit
 ) {
     // Opponents are determined by the UPCOMING round's schedule, not the round just played
@@ -2384,14 +2390,18 @@ private fun MachinationPhasePanel(
         .toSet()
 
     val byePlayerIds = nextRound?.skipPlayerIds?.toSet() ?: emptySet()
-    val hasBonusPlayers = byePlayerIds.isNotEmpty()
+    val mpBonusPlayerIds = campaign.players
+        .filter { it.machinationPoints > 0 && it.id !in byePlayerIds }
+        .map { it.id }.toSet()
+    val hasAnyBonusPlayers = byePlayerIds.isNotEmpty() || mpBonusPlayerIds.isNotEmpty()
 
     Column(modifier = Modifier.fillMaxSize().padding(theme.screenPadding)) {
         Text("Machinations & Attacks", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
         Text(
             buildString {
                 append("Each player can use 2 machinations. Targets cannot be scheduled opponents.")
-                if (hasBonusPlayers) append(" Bye players get a bonus 3rd slot.")
+                if (byePlayerIds.isNotEmpty()) append(" Bye players get a bonus 3rd slot.")
+                if (mpBonusPlayerIds.isNotEmpty()) append(" Players with banked MP can spend 1 for a 3rd slot.")
             },
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
@@ -2404,6 +2414,7 @@ private fun MachinationPhasePanel(
                     HorizontalDivider(modifier = Modifier.padding(vertical = theme.verticalSpacing))
                 }
                 val hasBonus = player.id in byePlayerIds
+                val hasMpBonus = player.id in mpBonusPlayerIds
                 val type1 = viewModel.machinationType1[player.id]
                 val type2 = viewModel.machinationType2[player.id]
                 val type3 = viewModel.machinationType3[player.id]
@@ -2411,6 +2422,7 @@ private fun MachinationPhasePanel(
                 PlayerMachinationCard(
                     player = player,
                     hasBonus = hasBonus,
+                    hasMpBonus = hasMpBonus,
                     type1 = type1,
                     onType1Change = { newType ->
                         viewModel.machinationType1[player.id] = newType
@@ -2471,6 +2483,7 @@ private fun MachinationPhasePanel(
                 onClick = {
                     val machinations = mutableListOf<CampaignMachination>()
                     val attacks = mutableListOf<CampaignAttack>()
+                    val spentMpPlayerIds = mutableSetOf<String>()
                     campaign.players.forEach { player ->
                         val t1 = viewModel.machinationType1[player.id]
                         val t2 = viewModel.machinationType2[player.id]
@@ -2480,7 +2493,11 @@ private fun MachinationPhasePanel(
                         val target3 = viewModel.machinationTarget3[player.id] ?: ""
                         if (t1 != null && target1.isNotEmpty()) machinations.add(CampaignMachination(player.id, target1, t1))
                         if (t2 != null && target2.isNotEmpty()) machinations.add(CampaignMachination(player.id, target2, t2))
-                        if (player.id in byePlayerIds && t3 != null && target3.isNotEmpty()) machinations.add(CampaignMachination(player.id, target3, t3))
+                        val has3rd = player.id in byePlayerIds || player.id in mpBonusPlayerIds
+                        if (has3rd && t3 != null && target3.isNotEmpty()) {
+                            machinations.add(CampaignMachination(player.id, target3, t3))
+                            if (player.id in mpBonusPlayerIds) spentMpPlayerIds.add(player.id)
+                        }
                         if (campaign.attacksEnabled && viewModel.machinationIsAttacking[player.id] == true) {
                             val type = viewModel.machinationAttackType[player.id] ?: AttackType.ASSAULT
                             val tPlayer = viewModel.machinationAttackTargetPlayer[player.id] ?: ""
@@ -2490,7 +2507,7 @@ private fun MachinationPhasePanel(
                             }
                         }
                     }
-                    onConfirm(machinations, attacks)
+                    onConfirm(machinations, attacks, spentMpPlayerIds)
                 },
                 modifier = Modifier.weight(1f),
                 shape = theme.cardShape
@@ -2505,6 +2522,7 @@ private fun MachinationPhasePanel(
 private fun PlayerMachinationCard(
     player: CampaignPlayer,
     hasBonus: Boolean,
+    hasMpBonus: Boolean = false,
     type1: MachinationType?,
     onType1Change: (MachinationType?) -> Unit,
     type2: MachinationType?,
@@ -2561,6 +2579,13 @@ private fun PlayerMachinationCard(
                         color = MaterialTheme.colorScheme.primary
                     )
                     Spacer(modifier = Modifier.width(8.dp))
+                } else if (hasMpBonus) {
+                    Text(
+                        "Spend 1 MP",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.tertiary
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
                 }
                 if (attacksEnabled) {
                     Text(
@@ -2600,8 +2625,8 @@ private fun PlayerMachinationCard(
                 )
             }
 
-            // Machination row 3 — bonus slot for bye players, shown after row 2 is filled
-            if (hasBonus && type2 != null) {
+            // Machination row 3 — free for bye players, or spends 1 banked MP
+            if ((hasBonus || hasMpBonus) && type2 != null) {
                 MachinationRowItem(
                     selectedType = type3,
                     onTypeChange = onType3Change,

--- a/app/src/main/java/io/github/garemat/lunachron/ui/MachinationsPhaseUI.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/MachinationsPhaseUI.kt
@@ -93,9 +93,12 @@ internal fun OnlineMachinationsTab(
         .firstOrNull { myDeviceId in it }
         ?.firstOrNull { it != myDeviceId }
 
-    // Bonus 3rd slot for players with a bye in the upcoming round
+    // Bonus 3rd slot: free for bye players, or spendable if player has banked bonus MP
     val hasNextRoundSchedule = campaign.schedule?.containsKey(nextRoundKey) == true
     val hasByeBonus = hasNextRoundSchedule && myNextOpponentId == null
+    val myMember = approvedMembers.find { it.deviceId == myDeviceId }
+    val hasMpBonus = !hasByeBonus && (myMember?.bonusMp ?: 0) > 0
+    val has3rdSlot = hasByeBonus || hasMpBonus
 
     val eligibleTargets = approvedMembers.filter {
         it.deviceId != myDeviceId && it.deviceId != myNextOpponentId
@@ -145,7 +148,7 @@ internal fun OnlineMachinationsTab(
         }
     }
     LaunchedEffect(slot1.selectedType, slot1.targetDeviceId, slot2.selectedType, slot2.targetDeviceId) {
-        if (hasByeBonus && !slot3.abstained && slot3.selectedType != null && slot3.targetDeviceId.isNotEmpty()) {
+        if (has3rdSlot && !slot3.abstained && slot3.selectedType != null && slot3.targetDeviceId.isNotEmpty()) {
             val conflictsWithSlot1 = slot3.selectedType == slot1.selectedType && slot3.targetDeviceId == slot1.targetDeviceId && slot1.targetDeviceId.isNotEmpty()
             val conflictsWithSlot2 = slot3.selectedType == slot2.selectedType && slot3.targetDeviceId == slot2.targetDeviceId && slot2.targetDeviceId.isNotEmpty()
             if (conflictsWithSlot1 || conflictsWithSlot2) {
@@ -188,6 +191,12 @@ internal fun OnlineMachinationsTab(
                         "Bye +1 slot",
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.primary
+                    )
+                } else if (hasMpBonus) {
+                    Text(
+                        "1 bonus MP",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.tertiary
                     )
                 }
                 Spacer(Modifier.weight(1f))
@@ -270,8 +279,8 @@ internal fun OnlineMachinationsTab(
                 )
             }
 
-            // Slot III — bonus for bye players, unlocked after slot II is decided
-            if (hasByeBonus) {
+            // Slot III — free for bye players, or spends 1 banked bonus MP
+            if (has3rdSlot) {
                 item {
                     val slot3Targets = run {
                         var targets = eligibleTargets
@@ -324,7 +333,7 @@ internal fun OnlineMachinationsTab(
                         onEvent(
                             CharacterEvent.SubmitMachination(
                                 campaign.id,
-                                listOfNotNull(slot1.toChoice(), slot2.toChoice(), if (hasByeBonus) slot3.toChoice() else null),
+                                listOfNotNull(slot1.toChoice(), slot2.toChoice(), if (has3rdSlot) slot3.toChoice() else null),
                                 atk.toAttack()
                             )
                         )

--- a/app/src/main/java/io/github/garemat/lunachron/ui/MachinationsPhaseUI.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/MachinationsPhaseUI.kt
@@ -93,6 +93,10 @@ internal fun OnlineMachinationsTab(
         .firstOrNull { myDeviceId in it }
         ?.firstOrNull { it != myDeviceId }
 
+    // Bonus 3rd slot for players with a bye in the upcoming round
+    val hasNextRoundSchedule = campaign.schedule?.containsKey(nextRoundKey) == true
+    val hasByeBonus = hasNextRoundSchedule && myNextOpponentId == null
+
     val eligibleTargets = approvedMembers.filter {
         it.deviceId != myDeviceId && it.deviceId != myNextOpponentId
     }
@@ -111,6 +115,13 @@ internal fun OnlineMachinationsTab(
             else MachSlotState()
         )
     }
+    var slot3 by remember(mySubmission) {
+        val c = mySubmission?.choices?.getOrNull(2)
+        mutableStateOf(
+            if (c != null) MachSlotState(selectedType = c.type, targetDeviceId = c.targetDeviceId)
+            else MachSlotState()
+        )
+    }
     var atk by remember(mySubmission) {
         val a = mySubmission?.attack
         mutableStateOf(
@@ -123,7 +134,7 @@ internal fun OnlineMachinationsTab(
         )
     }
 
-    // Clear slot2 target if it conflicts with slot1 after slot1 is edited
+    // Clear downstream slots when an earlier slot's target creates a conflict
     LaunchedEffect(slot1.selectedType, slot1.targetDeviceId) {
         if (!slot2.abstained && slot2.selectedType != null && slot2.targetDeviceId.isNotEmpty() &&
             slot2.selectedType == slot1.selectedType &&
@@ -131,6 +142,15 @@ internal fun OnlineMachinationsTab(
             slot1.targetDeviceId.isNotEmpty()
         ) {
             slot2 = slot2.copy(targetDeviceId = "", isOpen = true)
+        }
+    }
+    LaunchedEffect(slot1.selectedType, slot1.targetDeviceId, slot2.selectedType, slot2.targetDeviceId) {
+        if (hasByeBonus && !slot3.abstained && slot3.selectedType != null && slot3.targetDeviceId.isNotEmpty()) {
+            val conflictsWithSlot1 = slot3.selectedType == slot1.selectedType && slot3.targetDeviceId == slot1.targetDeviceId && slot1.targetDeviceId.isNotEmpty()
+            val conflictsWithSlot2 = slot3.selectedType == slot2.selectedType && slot3.targetDeviceId == slot2.targetDeviceId && slot2.targetDeviceId.isNotEmpty()
+            if (conflictsWithSlot1 || conflictsWithSlot2) {
+                slot3 = slot3.copy(targetDeviceId = "", isOpen = true)
+            }
         }
     }
 
@@ -163,6 +183,13 @@ internal fun OnlineMachinationsTab(
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold
                 )
+                if (hasByeBonus) {
+                    Text(
+                        "Bye +1 slot",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
                 Spacer(Modifier.weight(1f))
                 Text(
                     "$submittedCount / $totalCount submitted",
@@ -243,6 +270,30 @@ internal fun OnlineMachinationsTab(
                 )
             }
 
+            // Slot III — bonus for bye players, unlocked after slot II is decided
+            if (hasByeBonus) {
+                item {
+                    val slot3Targets = run {
+                        var targets = eligibleTargets
+                        if (slot3.selectedType != null && slot1.targetDeviceId.isNotEmpty() && slot3.selectedType == slot1.selectedType)
+                            targets = targets.filter { it.deviceId != slot1.targetDeviceId }
+                        if (slot3.selectedType != null && slot2.targetDeviceId.isNotEmpty() && slot3.selectedType == slot2.selectedType)
+                            targets = targets.filter { it.deviceId != slot2.targetDeviceId }
+                        targets
+                    }
+                    MachinationSlotCard(
+                        label = "Operation III",
+                        slot = slot3,
+                        targets = slot3Targets,
+                        rankOf = rankOf,
+                        totalPlayers = approvedMembers.size,
+                        locked = !slot2.isDecided,
+                        onUpdate = { slot3 = it },
+                        onClear = { slot3 = MachSlotState() }
+                    )
+                }
+            }
+
             // Attack section
             if (attacksEnabled && eligibleTargets.isNotEmpty()) {
                 item {
@@ -273,7 +324,7 @@ internal fun OnlineMachinationsTab(
                         onEvent(
                             CharacterEvent.SubmitMachination(
                                 campaign.id,
-                                listOfNotNull(slot1.toChoice(), slot2.toChoice()),
+                                listOfNotNull(slot1.toChoice(), slot2.toChoice(), if (hasByeBonus) slot3.toChoice() else null),
                                 atk.toAttack()
                             )
                         )

--- a/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
@@ -5,6 +5,8 @@ package io.github.garemat.lunachron.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -729,6 +731,7 @@ private fun TroupeDetailSheet(
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
             .padding(horizontal = 20.dp)
             .padding(bottom = 32.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
@@ -745,7 +748,7 @@ private fun TroupeDetailSheet(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
             confirmedData == null && currentRound > 1 -> Text(
-                "Troupe not yet confirmed for Round $currentRound.\nShowing last known troupe.",
+                "Troupe not yet confirmed for Round $currentRound. Showing last known troupe.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -755,25 +758,73 @@ private fun TroupeDetailSheet(
                 color = MaterialTheme.colorScheme.error
             )
             else -> {
-                Text(currentTroupe.troupeName, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.SemiBold)
-                currentTroupe.characterIds.forEach { charId ->
+                Text(
+                    currentTroupe.troupeName,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                currentTroupe.characterIds.forEachIndexed { index, charId ->
+                    val character = state.characters.find { it.id == charId }
                     val isNew = charId !in previousCharIds && previousCharIds.isNotEmpty()
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        Text("·", style = MaterialTheme.typography.bodySmall)
-                        Text(
-                            state.characters.find { it.id == charId }?.name ?: "Character #$charId",
-                            style = MaterialTheme.typography.bodySmall,
-                            modifier = Modifier.weight(1f)
+                    val upgradeIds = currentTroupe.equippedUpgrades[charId] ?: emptyList()
+                    val upgrades = upgradeIds.mapNotNull { uid -> state.upgradeCards.find { it.id == uid } }
+
+                    if (index > 0) {
+                        HorizontalDivider(
+                            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
                         )
-                        if (isNew) {
-                            SuggestionChip(
-                                onClick = {},
-                                label = { Text("New R$currentRound", style = MaterialTheme.typography.labelSmall) },
-                                modifier = Modifier.height(24.dp)
-                            )
+                    }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.Top
+                    ) {
+                        if (character != null) {
+                            CharacterPortrait(character = character, size = 48.dp)
+                        } else {
+                            Box(
+                                modifier = Modifier
+                                    .size(48.dp)
+                                    .clip(CircleShape)
+                                    .background(MaterialTheme.colorScheme.surfaceVariant),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text("?", style = MaterialTheme.typography.titleMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            }
+                        }
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(2.dp)
+                        ) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(6.dp)
+                            ) {
+                                Text(
+                                    character?.name ?: "Character #$charId",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    fontWeight = FontWeight.Medium,
+                                    modifier = Modifier.weight(1f, fill = false)
+                                )
+                                if (isNew) {
+                                    SuggestionChip(
+                                        onClick = {},
+                                        label = {
+                                            Text("New R$currentRound",
+                                                style = MaterialTheme.typography.labelSmall)
+                                        },
+                                        modifier = Modifier.height(22.dp)
+                                    )
+                                }
+                            }
+                            upgrades.forEach { upgrade ->
+                                Text(
+                                    upgrade.name,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
@@ -155,7 +155,8 @@ fun OnlineCampaignDetailScreen(
                         state = state,
                         isHost = isHost,
                         onEvent = onEvent,
-                        onDecodeTroupe = onDecodeTroupe
+                        onDecodeTroupe = onDecodeTroupe,
+                        onEncodeTroupe = onEncodeTroupe
                     )
                 }
                 else -> {
@@ -498,7 +499,8 @@ private fun ActiveCampaignHome(
     state: CharacterState,
     isHost: Boolean,
     onEvent: (CharacterEvent) -> Unit,
-    onDecodeTroupe: (String) -> Troupe?
+    onDecodeTroupe: (String) -> Troupe?,
+    onEncodeTroupe: (Troupe) -> String
 ) {
     val theme = LocalAppThemeProperties.current
     var activeTab by remember { mutableStateOf(ActiveTab.RANKINGS) }
@@ -532,7 +534,8 @@ private fun ActiveCampaignHome(
 
         when (activeTab) {
             ActiveTab.RANKINGS    -> OnlineRankingsTab(
-                campaign = campaign, state = state, isHost = isHost, onEvent = onEvent, onDecodeTroupe = onDecodeTroupe)
+                campaign = campaign, state = state, isHost = isHost, onEvent = onEvent,
+                onDecodeTroupe = onDecodeTroupe)
             ActiveTab.SCHEDULE    -> OnlineScheduleTabContent(
                 campaign = campaign,
                 showCurrentRoundScores = inMachinationsPhase
@@ -540,7 +543,9 @@ private fun ActiveCampaignHome(
             ActiveTab.MACHINATIONS -> if (inMachinationsPhase) {
                 OnlineMachinationsTab(campaign = campaign, state = state, onEvent = onEvent, onDecodeTroupe = onDecodeTroupe)
             } else {
-                OnlineResultsTab(campaign = campaign, state = state, onEvent = onEvent, onDecodeTroupe = onDecodeTroupe)
+                OnlineResultsTab(
+                    campaign = campaign, state = state, onEvent = onEvent,
+                    onDecodeTroupe = onDecodeTroupe, onEncodeTroupe = onEncodeTroupe)
             }
         }
     }
@@ -548,6 +553,7 @@ private fun ActiveCampaignHome(
 
 // ── Rankings tab ──────────────────────────────────────────────────────────────
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun OnlineRankingsTab(
     campaign: OnlineCampaignDetail,
@@ -559,6 +565,20 @@ private fun OnlineRankingsTab(
     val theme = LocalAppThemeProperties.current
     val approved = campaign.members.filter { it.status == "APPROVED" }
         .sortedByDescending { it.powerPoints }
+
+    var sheetMember by remember { mutableStateOf<OnlineCampaignMember?>(null) }
+    val sheetMemberValue = sheetMember
+    if (sheetMemberValue != null) {
+        ModalBottomSheet(onDismissRequest = { sheetMember = null }) {
+            TroupeDetailSheet(
+                member = sheetMemberValue,
+                campaign = campaign,
+                state = state,
+                onDecodeTroupe = onDecodeTroupe,
+                theme = theme
+            )
+        }
+    }
 
     if (approved.isEmpty()) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -627,8 +647,14 @@ private fun OnlineRankingsTab(
                     }
                 }
                 itemsIndexed(tierMembers) { idx, member ->
-                    OnlineRankingCard(member = member, position = positions[member.deviceId] ?: 0,
-                        rankColor = tierInfo.second, rowIndex = idx, theme = theme)
+                    OnlineRankingCard(
+                        member = member,
+                        position = positions[member.deviceId] ?: 0,
+                        rankColor = tierInfo.second,
+                        rowIndex = idx,
+                        theme = theme,
+                        onClick = { sheetMember = member }
+                    )
                 }
             }
         }
@@ -642,10 +668,12 @@ private fun OnlineRankingCard(
     position: Int,
     rankColor: Color,
     rowIndex: Int,
-    theme: io.github.garemat.lunachron.ui.theme.AppThemeProperties
+    theme: io.github.garemat.lunachron.ui.theme.AppThemeProperties,
+    onClick: () -> Unit = {}
 ) {
     val bgAlpha = if (rowIndex % 2 == 0) 0.07f else 0.13f
     Card(
+        onClick = onClick,
         modifier = Modifier.fillMaxWidth(),
         shape = theme.cardShape,
         colors = CardDefaults.cardColors(containerColor = rankColor.copy(alpha = bgAlpha))
@@ -673,6 +701,82 @@ private fun OnlineRankingCard(
             Spacer(Modifier.width(12.dp))
             Box(Modifier.width(48.dp), Alignment.CenterEnd) {
                 Text("${member.powerPoints}", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.ExtraBold, color = MaterialTheme.colorScheme.onSurface)
+            }
+        }
+    }
+}
+
+// ── Troupe detail bottom sheet ────────────────────────────────────────────────
+
+@Composable
+private fun TroupeDetailSheet(
+    member: OnlineCampaignMember,
+    campaign: OnlineCampaignDetail,
+    state: CharacterState,
+    onDecodeTroupe: (String) -> Troupe?,
+    theme: io.github.garemat.lunachron.ui.theme.AppThemeProperties
+) {
+    // For round 1, use the member's initial troupe_data; for later rounds, prefer confirmed snapshot.
+    val currentRound = campaign.currentRound
+    val confirmedData = campaign.roundTroupes.find { it.deviceId == member.deviceId }?.troupeData
+    val troupeDataToShow = if (currentRound == 1) member.troupeData else (confirmedData ?: member.troupeData)
+
+    val currentTroupe = troupeDataToShow?.let { onDecodeTroupe(it) }
+    val previousTroupe = campaign.previousRoundTroupes.find { it.deviceId == member.deviceId }
+        ?.troupeData?.let { onDecodeTroupe(it) }
+    val previousCharIds = previousTroupe?.characterIds?.toSet() ?: emptySet()
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
+            .padding(bottom = 32.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text(
+            member.username,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold
+        )
+        when {
+            troupeDataToShow == null -> Text(
+                "No troupe data available.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            confirmedData == null && currentRound > 1 -> Text(
+                "Troupe not yet confirmed for Round $currentRound.\nShowing last known troupe.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            currentTroupe == null -> Text(
+                "Could not decode troupe data.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error
+            )
+            else -> {
+                Text(currentTroupe.troupeName, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.SemiBold)
+                currentTroupe.characterIds.forEach { charId ->
+                    val isNew = charId !in previousCharIds && previousCharIds.isNotEmpty()
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text("·", style = MaterialTheme.typography.bodySmall)
+                        Text(
+                            state.characters.find { it.id == charId }?.name ?: "Character #$charId",
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier.weight(1f)
+                        )
+                        if (isNew) {
+                            SuggestionChip(
+                                onClick = {},
+                                label = { Text("New R$currentRound", style = MaterialTheme.typography.labelSmall) },
+                                modifier = Modifier.height(24.dp)
+                            )
+                        }
+                    }
+                }
             }
         }
     }
@@ -868,8 +972,10 @@ private fun OnlineResultsTab(
     campaign: OnlineCampaignDetail,
     state: CharacterState,
     onEvent: (CharacterEvent) -> Unit,
-    onDecodeTroupe: (String) -> Troupe?
+    onDecodeTroupe: (String) -> Troupe?,
+    onEncodeTroupe: (Troupe) -> String
 ) {
+    val theme = LocalAppThemeProperties.current
     val myDeviceId = state.backendDeviceId
     val currentRound = campaign.currentRound
     val roundKey = "round$currentRound"
@@ -884,12 +990,17 @@ private fun OnlineResultsTab(
     val opponentMember = campaign.members.find { it.deviceId == opponentId }
     val myMember = campaign.members.find { it.deviceId == myDeviceId }
 
+    // Troupe confirmation state for this round (rounds > 1 only)
+    val myConfirmed = campaign.roundTroupes.any { it.deviceId == myDeviceId }
+    val opponentConfirmed = opponentId != null && campaign.roundTroupes.any { it.deviceId == opponentId }
+
     // Find any existing match result for this game
     val existingResult = campaign.matchResults.firstOrNull {
         it.roundNumber == currentRound && it.gameNumber == myGameNumber
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.weight(1f)) {
         when {
             myGameEntry == null -> {
                 Column(
@@ -972,7 +1083,86 @@ private fun OnlineResultsTab(
                 )
             }
         }
-    }
+        } // closes Box
+
+        // Troupe confirmation (rounds 2+ with a scheduled game)
+        if (currentRound > 1 && myGameEntry != null) {
+            val troupeDataToConfirm = myMember?.troupeData
+            Spacer(Modifier.height(8.dp))
+            Card(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
+                shape = theme.cardShape,
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text(
+                        "Round $currentRound Troupe",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    when {
+                        myConfirmed && opponentConfirmed -> {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Icon(Icons.Default.CheckCircle, contentDescription = null,
+                                    modifier = Modifier.size(18.dp),
+                                    tint = MaterialTheme.colorScheme.primary)
+                                Spacer(Modifier.width(6.dp))
+                                Text(
+                                    "Both confirmed — view ${opponentMember?.username ?: "opponent"}'s troupe in Rankings",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                        myConfirmed -> {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Icon(Icons.Default.Schedule, contentDescription = null,
+                                    modifier = Modifier.size(18.dp),
+                                    tint = MaterialTheme.colorScheme.outline)
+                                Spacer(Modifier.width(6.dp))
+                                Text(
+                                    "Confirmed — waiting for ${opponentMember?.username ?: "opponent"}",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                        else -> {
+                            Text(
+                                "Confirm your troupe so your opponent can view it before the match.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Spacer(Modifier.height(8.dp))
+                            Button(
+                                onClick = {
+                                    if (troupeDataToConfirm != null) {
+                                        onEvent(CharacterEvent.ConfirmRoundTroupe(
+                                            campaignId = campaign.id,
+                                            roundNumber = currentRound,
+                                            troupeData = troupeDataToConfirm
+                                        ))
+                                    }
+                                },
+                                enabled = troupeDataToConfirm != null && !state.isConfirmingRoundTroupe,
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                if (state.isConfirmingRoundTroupe) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(18.dp),
+                                        strokeWidth = 2.dp
+                                    )
+                                } else {
+                                    Text("Confirm Troupe")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    } // closes Column
 }
 
 // OnlineMachinationsTab is in MachinationsPhaseUI.kt

--- a/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
@@ -2139,14 +2139,22 @@ private fun AdminPanelSheet(
                 }
                 items(localMembers) { localMember ->
                     val submitted = campaign.machinations.find { it.deviceId == localMember.deviceId }
+                    val nextRoundKey2 = "round${campaign.currentRound + 1}"
+                    val nextRoundGames2 = campaign.schedule?.get(nextRoundKey2) ?: emptyMap()
+                    val localNextOpp = nextRoundGames2.values
+                        .firstOrNull { localMember.deviceId in it }
+                        ?.firstOrNull { it != localMember.deviceId }
+                    val localHasByeBonus = campaign.schedule?.containsKey(nextRoundKey2) == true && localNextOpp == null
+                    val localHasMpBonus = !localHasByeBonus && localMember.bonusMp > 0
                     val otherApproved = campaign.members.filter {
-                        it.status == "APPROVED" && it.deviceId != localMember.deviceId
+                        it.status == "APPROVED" && it.deviceId != localMember.deviceId && it.deviceId != localNextOpp
                     }
                     AdminLocalMachinationCard(
                         member        = localMember,
                         campaignId    = campaign.id,
                         otherMembers  = otherApproved,
                         submitted     = submitted,
+                        has3rdSlot    = localHasByeBonus || localHasMpBonus,
                         isSubmitting  = state.isSubmittingMachination,
                         onEvent       = onEvent,
                         theme         = theme
@@ -2415,12 +2423,14 @@ private fun AdminLocalMachinationCard(
     campaignId: String,
     otherMembers: List<OnlineCampaignMember>,
     submitted: OnlineMachinationEntry?,
+    has3rdSlot: Boolean = false,
     isSubmitting: Boolean,
     onEvent: (CharacterEvent) -> Unit,
     theme: io.github.garemat.lunachron.ui.theme.AppThemeProperties
 ) {
     var choice1 by remember(submitted) { mutableStateOf(submitted?.choices?.getOrNull(0)) }
     var choice2 by remember(submitted) { mutableStateOf(submitted?.choices?.getOrNull(1)) }
+    var choice3 by remember(submitted) { mutableStateOf(submitted?.choices?.getOrNull(2)) }
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -2516,13 +2526,57 @@ private fun AdminLocalMachinationCard(
                             label = { Text("Sabotage", style = MaterialTheme.typography.labelSmall) }
                         )
                     }
+
+                    // Machination 3 — only for bye/bonus-MP players
+                    if (has3rdSlot) {
+                        HorizontalDivider()
+                        val row3Targets = otherMembers.filter {
+                            choice3 == null ||
+                            choice3?.type != choice1?.type || it.deviceId != choice1?.targetDeviceId ||
+                            choice3?.type != choice2?.type || it.deviceId != choice2?.targetDeviceId
+                        }
+                        Text("Machination 3", style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                            FilterChip(selected = choice3 == null, onClick = { choice3 = null },
+                                label = { Text("None", style = MaterialTheme.typography.labelSmall) })
+                            row3Targets.forEach { m ->
+                                FilterChip(
+                                    selected = choice3?.targetDeviceId == m.deviceId,
+                                    onClick = { choice3 = OnlineMachinationChoice(m.deviceId, choice3?.type ?: "SUPPORT") },
+                                    label = { Text(m.username, style = MaterialTheme.typography.labelSmall) }
+                                )
+                            }
+                        }
+                        if (choice3 != null) {
+                            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                                FilterChip(
+                                    selected = choice3?.type == "SUPPORT",
+                                    onClick = { choice3 = choice3?.copy(type = "SUPPORT") },
+                                    leadingIcon = if (choice3?.type == "SUPPORT") {
+                                        { Icon(Icons.Default.Favorite, null, Modifier.size(14.dp)) }
+                                    } else null,
+                                    label = { Text("Support", style = MaterialTheme.typography.labelSmall) }
+                                )
+                                FilterChip(
+                                    selected = choice3?.type == "SABOTAGE",
+                                    onClick = { choice3 = choice3?.copy(type = "SABOTAGE") },
+                                    leadingIcon = if (choice3?.type == "SABOTAGE") {
+                                        { Icon(Icons.Default.Dangerous, null, Modifier.size(14.dp)) }
+                                    } else null,
+                                    label = { Text("Sabotage", style = MaterialTheme.typography.labelSmall) }
+                                )
+                            }
+                        }
+                    }
                 }
             }
 
             Button(
                 onClick = {
                     onEvent(CharacterEvent.SubmitLocalMachination(
-                        campaignId, member.deviceId, listOfNotNull(choice1, choice2)))
+                        campaignId, member.deviceId, listOfNotNull(choice1, choice2, if (has3rdSlot) choice3 else null)))
                 },
                 enabled = !isSubmitting,
                 modifier = Modifier.fillMaxWidth()

--- a/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
@@ -721,7 +721,7 @@ private fun TroupeDetailSheet(
     // For round 1, use the member's initial troupe_data; for later rounds, prefer confirmed snapshot.
     val currentRound = campaign.currentRound
     val confirmedData = campaign.roundTroupes.find { it.deviceId == member.deviceId }?.troupeData
-    val troupeDataToShow = if (currentRound == 1) member.troupeData else (confirmedData ?: member.troupeData)
+    val troupeDataToShow = if (currentRound == 1 || member.isLocal) member.troupeData else (confirmedData ?: member.troupeData)
 
     val currentTroupe = troupeDataToShow?.let { onDecodeTroupe(it) }
     val previousTroupe = campaign.previousRoundTroupes.find { it.deviceId == member.deviceId }
@@ -747,7 +747,7 @@ private fun TroupeDetailSheet(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            confirmedData == null && currentRound > 1 -> Text(
+            !member.isLocal && confirmedData == null && currentRound > 1 -> Text(
                 "Troupe not yet confirmed for Round $currentRound. Showing last known troupe.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
@@ -1044,6 +1044,19 @@ private fun OnlineResultsTab(
     // Troupe confirmation state for this round (rounds > 1 only)
     val myConfirmed = campaign.roundTroupes.any { it.deviceId == myDeviceId }
     val opponentConfirmed = opponentId != null && campaign.roundTroupes.any { it.deviceId == opponentId }
+    val opponentIsLocal = opponentMember?.isLocal == true
+    val myTroupeData = myMember?.troupeData
+
+    // Local players don't use the app — auto-confirm on their behalf when they're the opponent
+    LaunchedEffect(campaign.id, currentRound, myConfirmed, opponentIsLocal) {
+        if (currentRound > 1 && myGameEntry != null && opponentIsLocal && !myConfirmed && myTroupeData != null) {
+            onEvent(CharacterEvent.ConfirmRoundTroupe(
+                campaignId = campaign.id,
+                roundNumber = currentRound,
+                troupeData = myTroupeData
+            ))
+        }
+    }
 
     // Find any existing match result for this game
     val existingResult = campaign.matchResults.firstOrNull {
@@ -1136,8 +1149,8 @@ private fun OnlineResultsTab(
         }
         } // closes Box
 
-        // Troupe confirmation (rounds 2+ with a scheduled game)
-        if (currentRound > 1 && myGameEntry != null) {
+        // Troupe confirmation (rounds 2+ with a scheduled game, not when opponent is local)
+        if (currentRound > 1 && myGameEntry != null && !opponentIsLocal) {
             val troupeDataToConfirm = myMember?.troupeData
             Spacer(Modifier.height(8.dp))
             Card(


### PR DESCRIPTION
## Description

Adds three related online campaign improvements:

**Mutual troupe confirmation (rounds 2+)**
- Players confirm their current troupe snapshot before each match; both must confirm before either can view the opponent's troupe
- Tapping a ranking card opens a troupe detail sheet showing character portraits, equipped upgrades, and a "New R*N*" chip for characters added since the previous round
- Local players are auto-confirmed silently via `LaunchedEffect` (they don't have the app), and the backend auto-inserts their stored troupe into `round_troupe_confirmations`
- Requires backend: `bonus_mp` column, updated GET `/campaigns/{id}` (returns `roundTroupes`, `previousRoundTroupes`, `bonusMp`), new POST `/campaigns/{id}/confirm-round-troupe`

**Bye/bonus MP 3rd machination slot** (includes #160 merged into this branch)
- Round-1 bye players receive a free 3rd machination slot; players with a banked `bonus_mp` credit can spend it for a 3rd slot at any point in the campaign
- Works in: local campaign `PlayerMachinationCard`, online `MachinationsPhaseUI`, and the host `AdminLocalMachinationCard` for local players
- `bonus_mp` is seeded on schedule publish; decremented when a non-bye player uses their credit
- Requires backend: `ALTER TABLE campaign_members ADD bonus_mp NUMBER(5) DEFAULT 0 NOT NULL`; updated schedule publish and submit-machination handlers

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)