### PR TITLE
fix: make bump-data workflow idempotent on retry

### DIFF
--- a/.github/workflows/bump-data.yml
+++ b/.github/workflows/bump-data.yml
@@ -22,7 +22,17 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
 
+      - name: Check for existing PR
+        id: existing
+        env:
+          TAG: ${{ github.event.client_payload.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR=$(gh pr list --head chore/data-$TAG --json number --jq '.[0].number' 2>/dev/null)
+          echo "pr=$PR" >> $GITHUB_OUTPUT
+
       - name: Create branch and update pins
+        if: steps.existing.outputs.pr == ''
         env:
           TAG: ${{ github.event.client_payload.tag }}
         run: |
@@ -32,9 +42,10 @@ jobs:
           git -C data checkout --quiet $TAG
           git add data.version data
           git commit -m "chore: bump lunachron-data to $TAG"
-          git push origin chore/data-$TAG
+          git push --force-with-lease origin chore/data-$TAG
 
       - name: Open PR and enable auto-merge
+        if: steps.existing.outputs.pr == ''
         env:
           TAG: ${{ github.event.client_payload.tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes a push failure when the workflow retries for a tag that already has a remote branch:

- Adds an early-exit check — if a PR already exists for the tag, all subsequent steps are skipped
- Switches to `--force-with-lease` on push to handle stale remote branches cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)