### PR TITLE
feat: offline data migration via transfer code and QR

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/Character.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/Character.kt
@@ -328,3 +328,12 @@ data class CharacterGameStat(
     val stones: Int,
     val died: Boolean
 )
+
+@Serializable
+data class MigrationPayload(
+    val version: Int = 1,
+    val username: String,
+    val troupes: List<Troupe>,
+    val campaigns: List<Campaign>,
+    val gameResults: List<GameResult>
+)

--- a/app/src/main/java/io/github/garemat/lunachron/Character.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/Character.kt
@@ -336,6 +336,6 @@ data class MigrationPayload(
     val troupes: List<Troupe>,
     val campaigns: List<Campaign>,
     val gameResults: List<GameResult>,
-    val sessionToken: String? = null,
     val backendDeviceId: String? = null,
+    val expiresAt: Long = 0,
 )

--- a/app/src/main/java/io/github/garemat/lunachron/Character.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/Character.kt
@@ -336,6 +336,7 @@ data class MigrationPayload(
     val troupes: List<Troupe>,
     val campaigns: List<Campaign>,
     val gameResults: List<GameResult>,
+    val sessionToken: String? = null,
     val backendDeviceId: String? = null,
     val expiresAt: Long = 0,
 )

--- a/app/src/main/java/io/github/garemat/lunachron/Character.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/Character.kt
@@ -335,5 +335,7 @@ data class MigrationPayload(
     val username: String,
     val troupes: List<Troupe>,
     val campaigns: List<Campaign>,
-    val gameResults: List<GameResult>
+    val gameResults: List<GameResult>,
+    val sessionToken: String? = null,
+    val backendDeviceId: String? = null,
 )

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
@@ -174,7 +174,7 @@ sealed interface CharacterEvent {
 
     // Data migration
     data object GenerateMigrationExport : CharacterEvent
-    data class ImportMigrationData(val code: String) : CharacterEvent
+    data class ImportMigrationData(val code: String, val transferRegistration: Boolean) : CharacterEvent
     data object ClearMigrationState : CharacterEvent
 
     // LunaChron API — machinations phase

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
@@ -172,6 +172,11 @@ sealed interface CharacterEvent {
         val targetDeviceId: String? = null   // host only: confirm for a local player
     ) : CharacterEvent
 
+    // Data migration
+    data object GenerateMigrationExport : CharacterEvent
+    data class ImportMigrationData(val code: String) : CharacterEvent
+    data object ClearMigrationState : CharacterEvent
+
     // LunaChron API — machinations phase
     data class SubmitMachination(
         val campaignId: String,

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
@@ -391,7 +391,17 @@ data class CharacterState(
     // UI overlay triggers for campaign detail top bar actions (hoisted so MainActivity can set them)
     val showCampaignAdminPanel: Boolean = false,
     val showCampaignDeleteDialog: Boolean = false,
+
+    // Data migration
+    val migrationExportCode: String? = null,
+    val migrationImportStatus: MigrationImportStatus? = null,
 )
+
+sealed class MigrationImportStatus {
+    data object Loading : MigrationImportStatus()
+    data object Success : MigrationImportStatus()
+    data class Error(val message: String) : MigrationImportStatus()
+}
 
 @Serializable
 data class CharacterPlayState(

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -893,9 +893,10 @@ class CharacterViewModel(
                 runCatching {
                     val payload = MigrationPayload(
                         username = _state.value.name,
-                        troupes = _state.value.troupes,
-                        campaigns = _state.value.campaigns,
+                        troupes = state.value.troupes,
+                        campaigns = state.value.campaigns,
                         gameResults = gameResults.value,
+                        sessionToken = prefs.getString("api_session_token", null),
                         backendDeviceId = prefs.getString("api_backend_device_id", null),
                         expiresAt = System.currentTimeMillis() + 15 * 60 * 1000L
                     )
@@ -929,9 +930,12 @@ class CharacterViewModel(
                         prefs.edit { putString("player_name", payload.username) }
                         _state.update { it.copy(name = payload.username) }
                     }
-                    if (event.transferRegistration && !payload.backendDeviceId.isNullOrBlank()) {
-                        prefs.edit { putString("api_backend_device_id", payload.backendDeviceId) }
-                        _state.update { it.copy(backendDeviceId = payload.backendDeviceId) }
+                    if (event.transferRegistration && !payload.sessionToken.isNullOrBlank()) {
+                        prefs.edit {
+                            putString("api_session_token", payload.sessionToken)
+                            putString("api_backend_device_id", payload.backendDeviceId)
+                        }
+                        _state.update { it.copy(isRegistered = true, backendDeviceId = payload.backendDeviceId ?: "") }
                     }
                 }.onSuccess {
                     _state.update { it.copy(migrationImportStatus = MigrationImportStatus.Success) }

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -896,8 +896,8 @@ class CharacterViewModel(
                         troupes = _state.value.troupes,
                         campaigns = _state.value.campaigns,
                         gameResults = gameResults.value,
-                        sessionToken = prefs.getString("api_session_token", null),
-                        backendDeviceId = prefs.getString("api_backend_device_id", null)
+                        backendDeviceId = prefs.getString("api_backend_device_id", null),
+                        expiresAt = System.currentTimeMillis() + 15 * 60 * 1000L
                     )
                     DataMigration.encode(payload)
                 }.onSuccess { code ->
@@ -929,12 +929,9 @@ class CharacterViewModel(
                         prefs.edit { putString("player_name", payload.username) }
                         _state.update { it.copy(name = payload.username) }
                     }
-                    if (!payload.sessionToken.isNullOrBlank() && !payload.backendDeviceId.isNullOrBlank()) {
-                        prefs.edit {
-                            putString("api_session_token", payload.sessionToken)
-                            putString("api_backend_device_id", payload.backendDeviceId)
-                        }
-                        _state.update { it.copy(isRegistered = true, backendDeviceId = payload.backendDeviceId) }
+                    if (event.transferRegistration && !payload.backendDeviceId.isNullOrBlank()) {
+                        prefs.edit { putString("api_backend_device_id", payload.backendDeviceId) }
+                        _state.update { it.copy(backendDeviceId = payload.backendDeviceId) }
                     }
                 }.onSuccess {
                     _state.update { it.copy(migrationImportStatus = MigrationImportStatus.Success) }

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -889,6 +889,55 @@ class CharacterViewModel(
             }
             CharacterEvent.DismissImageUpdate -> _state.update { it.copy(pendingImageUpdate = null) }
 
+            CharacterEvent.GenerateMigrationExport -> viewModelScope.launch(Dispatchers.IO) {
+                runCatching {
+                    val payload = MigrationPayload(
+                        username = _state.value.name,
+                        troupes = _state.value.troupes,
+                        campaigns = _state.value.campaigns,
+                        gameResults = gameResults.value
+                    )
+                    DataMigration.encode(payload)
+                }.onSuccess { code ->
+                    _state.update { it.copy(migrationExportCode = code) }
+                }.onFailure { e ->
+                    _state.update { it.copy(errorMessage = "Export failed: ${e.message}") }
+                }
+            }
+
+            is CharacterEvent.ImportMigrationData -> viewModelScope.launch(Dispatchers.IO) {
+                _state.update { it.copy(migrationImportStatus = MigrationImportStatus.Loading) }
+                runCatching {
+                    val payload = DataMigration.decode(event.code)
+                    val idMap = mutableMapOf<Int, Int>()
+                    payload.troupes.forEach { troupe ->
+                        val newId = repository.upsertTroupe(troupe.copy(id = 0)).toInt()
+                        idMap[troupe.id] = newId
+                    }
+                    payload.campaigns.forEach { campaign ->
+                        val remappedPlayers = campaign.players.map { player ->
+                            player.copy(troupeId = idMap[player.troupeId] ?: player.troupeId)
+                        }
+                        repository.upsertCampaign(campaign.copy(id = 0, players = remappedPlayers))
+                    }
+                    payload.gameResults.forEach { result ->
+                        repository.upsertGameResult(result.copy(id = 0))
+                    }
+                    if (payload.username.isNotBlank()) {
+                        prefs.edit { putString("player_name", payload.username) }
+                        _state.update { it.copy(name = payload.username) }
+                    }
+                }.onSuccess {
+                    _state.update { it.copy(migrationImportStatus = MigrationImportStatus.Success) }
+                }.onFailure { e ->
+                    _state.update { it.copy(migrationImportStatus = MigrationImportStatus.Error(e.message ?: "Invalid code")) }
+                }
+            }
+
+            CharacterEvent.ClearMigrationState -> _state.update {
+                it.copy(migrationExportCode = null, migrationImportStatus = null)
+            }
+
             else -> {}
         }
     }

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -895,7 +895,9 @@ class CharacterViewModel(
                         username = _state.value.name,
                         troupes = _state.value.troupes,
                         campaigns = _state.value.campaigns,
-                        gameResults = gameResults.value
+                        gameResults = gameResults.value,
+                        sessionToken = prefs.getString("api_session_token", null),
+                        backendDeviceId = prefs.getString("api_backend_device_id", null)
                     )
                     DataMigration.encode(payload)
                 }.onSuccess { code ->
@@ -926,6 +928,13 @@ class CharacterViewModel(
                     if (payload.username.isNotBlank()) {
                         prefs.edit { putString("player_name", payload.username) }
                         _state.update { it.copy(name = payload.username) }
+                    }
+                    if (!payload.sessionToken.isNullOrBlank() && !payload.backendDeviceId.isNullOrBlank()) {
+                        prefs.edit {
+                            putString("api_session_token", payload.sessionToken)
+                            putString("api_backend_device_id", payload.backendDeviceId)
+                        }
+                        _state.update { it.copy(isRegistered = true, backendDeviceId = payload.backendDeviceId) }
                     }
                 }.onSuccess {
                     _state.update { it.copy(migrationImportStatus = MigrationImportStatus.Success) }

--- a/app/src/main/java/io/github/garemat/lunachron/DataMigration.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/DataMigration.kt
@@ -1,0 +1,29 @@
+package io.github.garemat.lunachron
+
+import android.util.Base64
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
+
+object DataMigration {
+
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    fun encode(payload: MigrationPayload): String {
+        val jsonBytes = json.encodeToString(payload).toByteArray(Charsets.UTF_8)
+        val compressed = ByteArrayOutputStream().use { baos ->
+            GZIPOutputStream(baos).use { it.write(jsonBytes) }
+            baos.toByteArray()
+        }
+        return Base64.encodeToString(compressed, Base64.URL_SAFE or Base64.NO_WRAP)
+    }
+
+    fun decode(code: String): MigrationPayload {
+        val compressed = Base64.decode(code.trim(), Base64.URL_SAFE)
+        val jsonBytes = GZIPInputStream(ByteArrayInputStream(compressed)).use { it.readBytes() }
+        return json.decodeFromString(jsonBytes.toString(Charsets.UTF_8))
+    }
+}

--- a/app/src/main/java/io/github/garemat/lunachron/DataMigration.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/DataMigration.kt
@@ -24,6 +24,10 @@ object DataMigration {
     fun decode(code: String): MigrationPayload {
         val compressed = Base64.decode(code.trim(), Base64.URL_SAFE)
         val jsonBytes = GZIPInputStream(ByteArrayInputStream(compressed)).use { it.readBytes() }
-        return json.decodeFromString(jsonBytes.toString(Charsets.UTF_8))
+        val payload = json.decodeFromString<MigrationPayload>(jsonBytes.toString(Charsets.UTF_8))
+        if (payload.expiresAt > 0 && System.currentTimeMillis() > payload.expiresAt) {
+            throw IllegalStateException("This code has expired. Generate a new one on the source device.")
+        }
+        return payload
     }
 }

--- a/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
@@ -490,7 +490,18 @@ class MainActivity : ComponentActivity() {
                                     SettingsScreen(
                                         state = state,
                                         onEvent = viewModel::onEvent,
-                                        onNavigateBack = { navController.safePopBackStack() }
+                                        onNavigateBack = { navController.safePopBackStack() },
+                                        onNavigateToMigration = { navController.navigate(Screen.DataMigration.route) }
+                                    )
+                                }
+                                composable(Screen.DataMigration.route) {
+                                    DataMigrationScreen(
+                                        state = state,
+                                        onEvent = viewModel::onEvent,
+                                        onNavigateBack = {
+                                            viewModel.onEvent(CharacterEvent.ClearMigrationState)
+                                            navController.safePopBackStack()
+                                        }
                                     )
                                 }
                                 composable(Screen.Rules.route) {

--- a/app/src/main/java/io/github/garemat/lunachron/NearbyManager.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/NearbyManager.kt
@@ -60,9 +60,10 @@ class NearbyManager(private val context: Context) {
     private var scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     private val nsdManager = context.getSystemService(Context.NSD_SERVICE) as NsdManager
-    private val wifiP2pManager = context.getSystemService(Context.WIFI_P2P_SERVICE) as WifiP2pManager
+    private val wifiP2pManager: WifiP2pManager? =
+        context.getSystemService(Context.WIFI_P2P_SERVICE) as? WifiP2pManager
     private val wifiP2pChannel: WifiP2pManager.Channel? =
-        wifiP2pManager.initialize(context, context.mainLooper, null)
+        wifiP2pManager?.initialize(context, context.mainLooper, null)
 
     private val _connectedEndpoints = MutableStateFlow<Set<String>>(emptySet())
     val connectedEndpoints = _connectedEndpoints.asStateFlow()
@@ -143,8 +144,8 @@ class NearbyManager(private val context: Context) {
         val serviceInfo = WifiP2pDnsSdServiceInfo.newInstance(
             localName, "_moonstone._tcp.", mapOf("port" to WIFI_DIRECT_PORT.toString())
         )
-        wifiP2pManager.addLocalService(ch, serviceInfo, noopListener("addLocalService"))
-        wifiP2pManager.createGroup(ch, object : WifiP2pManager.ActionListener {
+        wifiP2pManager?.addLocalService(ch, serviceInfo, noopListener("addLocalService"))
+        wifiP2pManager?.createGroup(ch, object : WifiP2pManager.ActionListener {
             override fun onSuccess() {
                 Log.i(TAG, "Wi-Fi Direct group created, listening on port $WIFI_DIRECT_PORT")
                 startAccepting(ss)
@@ -233,7 +234,7 @@ class NearbyManager(private val context: Context) {
             override fun onReceive(ctx: Context, intent: Intent) {
                 if (intent.action != WifiP2pManager.WIFI_P2P_CONNECTION_CHANGED_ACTION) return
                 val targetId = pendingWifiDirectEndpointId ?: return
-                wifiP2pManager.requestConnectionInfo(ch) { info ->
+                wifiP2pManager?.requestConnectionInfo(ch) { info ->
                     Log.d(TAG, "Wi-Fi Direct conn info: groupFormed=${info?.groupFormed}, isGroupOwner=${info?.isGroupOwner}")
                     if (info?.groupFormed == true && !info.isGroupOwner) {
                         val goAddress = info.groupOwnerAddress?.hostAddress ?: return@requestConnectionInfo
@@ -254,7 +255,7 @@ class NearbyManager(private val context: Context) {
         context.registerReceiver(receiver, filter)
         wifiDirectReceiver = receiver
 
-        wifiP2pManager.setDnsSdResponseListeners(ch,
+        wifiP2pManager?.setDnsSdResponseListeners(ch,
             { instanceName, _, device ->
                 val endpointId = "p2p_${device.deviceAddress}"
                 wifiDirectDevices[endpointId] = device
@@ -263,8 +264,8 @@ class NearbyManager(private val context: Context) {
             { _, _, _ -> }
         )
         val serviceRequest = WifiP2pDnsSdServiceRequest.newInstance()
-        wifiP2pManager.addServiceRequest(ch, serviceRequest, noopListener("addServiceRequest"))
-        wifiP2pManager.discoverServices(ch, noopListener("p2p discoverServices"))
+        wifiP2pManager?.addServiceRequest(ch, serviceRequest, noopListener("addServiceRequest"))
+        wifiP2pManager?.discoverServices(ch, noopListener("p2p discoverServices"))
     }
 
     // ── Client connection ─────────────────────────────────────────────────────
@@ -295,7 +296,7 @@ class NearbyManager(private val context: Context) {
                 }
                 pendingWifiDirectEndpointId = endpointId
                 val config = WifiP2pConfig().apply { deviceAddress = device.deviceAddress }
-                wifiP2pManager.connect(ch, config, object : WifiP2pManager.ActionListener {
+                wifiP2pManager?.connect(ch, config, object : WifiP2pManager.ActionListener {
                     override fun onSuccess() {}
                     override fun onFailure(reason: Int) {
                         Log.e(TAG, "Wi-Fi Direct connect failed: $reason")
@@ -350,16 +351,16 @@ class NearbyManager(private val context: Context) {
     @SuppressLint("MissingPermission")
     private fun stopWifiDirectAdvertising() {
         val ch = wifiP2pChannel ?: return
-        wifiP2pManager.clearLocalServices(ch, noopListener("clearLocalServices"))
-        wifiP2pManager.removeGroup(ch, noopListener("removeGroup"))
+        wifiP2pManager?.clearLocalServices(ch, noopListener("clearLocalServices"))
+        wifiP2pManager?.removeGroup(ch, noopListener("removeGroup"))
     }
 
     private fun stopWifiDirectDiscovery() {
         wifiDirectReceiver?.let { try { context.unregisterReceiver(it) } catch (_: Exception) {} }
         wifiDirectReceiver = null
         val ch = wifiP2pChannel ?: return
-        wifiP2pManager.clearServiceRequests(ch, noopListener("clearServiceRequests"))
-        wifiP2pManager.stopPeerDiscovery(ch, noopListener("stopPeerDiscovery"))
+        wifiP2pManager?.clearServiceRequests(ch, noopListener("clearServiceRequests"))
+        wifiP2pManager?.stopPeerDiscovery(ch, noopListener("stopPeerDiscovery"))
     }
 
     private fun openConnection(endpointId: String, socket: Socket) {

--- a/app/src/main/java/io/github/garemat/lunachron/ui/DataMigrationScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/DataMigrationScreen.kt
@@ -1,0 +1,284 @@
+package io.github.garemat.lunachron.ui
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.QrCodeScanner
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.garemat.lunachron.BarcodeUtils
+import io.github.garemat.lunachron.CharacterEvent
+import io.github.garemat.lunachron.CharacterState
+import io.github.garemat.lunachron.MigrationImportStatus
+import io.github.garemat.lunachron.ui.theme.LocalAppThemeProperties
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DataMigrationScreen(
+    state: CharacterState,
+    onEvent: (CharacterEvent) -> Unit,
+    onNavigateBack: () -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    var selectedTab by remember { mutableIntStateOf(0) }
+    val tabs = listOf("Export", "Import")
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Transfer Data", style = theme.titleStyle) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    titleContentColor = MaterialTheme.colorScheme.primary,
+                    navigationIconContentColor = MaterialTheme.colorScheme.primary
+                )
+            )
+        }
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            TabRow(selectedTabIndex = selectedTab) {
+                tabs.forEachIndexed { index, title ->
+                    Tab(
+                        selected = selectedTab == index,
+                        onClick = { selectedTab = index },
+                        text = { Text(title, style = theme.labelStyle) }
+                    )
+                }
+            }
+            when (selectedTab) {
+                0 -> ExportTab(state = state, onEvent = onEvent, theme = theme)
+                1 -> ImportTab(state = state, onEvent = onEvent, theme = theme)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExportTab(
+    state: CharacterState,
+    onEvent: (CharacterEvent) -> Unit,
+    theme: io.github.garemat.lunachron.ui.theme.AppThemeProperties
+) {
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        if (state.migrationExportCode == null) {
+            onEvent(CharacterEvent.GenerateMigrationExport)
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(theme.screenPadding),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.height(theme.verticalSpacing))
+
+        if (state.migrationExportCode == null) {
+            CircularProgressIndicator()
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+            Text("Generating…", style = MaterialTheme.typography.bodyMedium)
+        } else {
+            val qrBitmap = remember(state.migrationExportCode) {
+                BarcodeUtils.generateQrCode(state.migrationExportCode, size = 512)
+            }
+            if (qrBitmap != null) {
+                Image(
+                    bitmap = qrBitmap.asImageBitmap(),
+                    contentDescription = "Migration QR code",
+                    modifier = Modifier.size(240.dp)
+                )
+                Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+                Text(
+                    "Scan on the new device to import",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center
+                )
+            }
+
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+
+            Text(
+                "Or copy the code below",
+                style = theme.headerStyle.copy(fontSize = 16.sp),
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+
+            OutlinedTextField(
+                value = state.migrationExportCode,
+                onValueChange = {},
+                readOnly = true,
+                modifier = Modifier.fillMaxWidth(),
+                shape = theme.cardShape,
+                minLines = 3,
+                maxLines = 6
+            )
+
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+
+            OutlinedButton(
+                onClick = {
+                    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                    clipboard.setPrimaryClip(ClipData.newPlainText("LunaChron migration code", state.migrationExportCode))
+                    Toast.makeText(context, "Code copied", Toast.LENGTH_SHORT).show()
+                },
+                modifier = Modifier.fillMaxWidth(),
+                shape = theme.cardShape
+            ) {
+                Icon(Icons.Default.ContentCopy, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Copy code", style = theme.buttonTextStyle)
+            }
+
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+            Text(
+                "Use the QR code to transfer to a new device. Use the text code when switching installation methods (e.g. GitHub → Play Store). Each code is a one-time snapshot — importing does not affect existing data on the target device.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(theme.verticalSpacing))
+        }
+    }
+}
+
+@Composable
+private fun ImportTab(
+    state: CharacterState,
+    onEvent: (CharacterEvent) -> Unit,
+    theme: io.github.garemat.lunachron.ui.theme.AppThemeProperties
+) {
+    var code by remember { mutableStateOf("") }
+    var showScanner by remember { mutableStateOf(false) }
+
+    if (showScanner) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            QrScanner(onResult = { scanned ->
+                code = scanned
+                showScanner = false
+            })
+            IconButton(
+                onClick = { showScanner = false },
+                modifier = Modifier.align(Alignment.TopStart).padding(8.dp)
+            ) {
+                Icon(
+                    Icons.Default.ArrowBack,
+                    contentDescription = "Stop scanning",
+                    tint = MaterialTheme.colorScheme.onPrimary
+                )
+            }
+        }
+        return
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(theme.screenPadding),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.height(theme.verticalSpacing))
+
+        Text("Paste or scan your migration code", style = theme.headerStyle.copy(fontSize = 18.sp))
+        Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+
+        OutlinedTextField(
+            value = code,
+            onValueChange = {
+                code = it
+                if (state.migrationImportStatus != null) onEvent(CharacterEvent.ClearMigrationState)
+            },
+            label = { Text("Migration code") },
+            modifier = Modifier.fillMaxWidth(),
+            shape = theme.cardShape,
+            minLines = 3,
+            maxLines = 6,
+            isError = state.migrationImportStatus is MigrationImportStatus.Error
+        )
+
+        Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+
+        OutlinedButton(
+            onClick = { showScanner = true },
+            modifier = Modifier.fillMaxWidth(),
+            shape = theme.cardShape
+        ) {
+            Icon(Icons.Default.QrCodeScanner, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Scan QR code", style = theme.buttonTextStyle)
+        }
+
+        Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+
+        Button(
+            onClick = { onEvent(CharacterEvent.ImportMigrationData(code.trim())) },
+            enabled = code.isNotBlank() && state.migrationImportStatus !is MigrationImportStatus.Loading && state.migrationImportStatus !is MigrationImportStatus.Success,
+            modifier = Modifier.fillMaxWidth(),
+            shape = theme.cardShape
+        ) {
+            if (state.migrationImportStatus is MigrationImportStatus.Loading) {
+                CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Importing…", style = theme.buttonTextStyle)
+            } else {
+                Text("Import data", style = theme.buttonTextStyle)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(theme.verticalSpacing))
+
+        when (val status = state.migrationImportStatus) {
+            is MigrationImportStatus.Success -> {
+                ThemedCard(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        "Data imported successfully. Your troupes, campaigns, and game history have been added to this device.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier = Modifier.padding(theme.cardContentPadding)
+                    )
+                }
+            }
+            is MigrationImportStatus.Error -> {
+                Text(
+                    status.message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = TextAlign.Center
+                )
+            }
+            else -> {}
+        }
+
+        Spacer(modifier = Modifier.height(theme.verticalSpacing))
+    }
+}

--- a/app/src/main/java/io/github/garemat/lunachron/ui/DataMigrationScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/DataMigrationScreen.kt
@@ -158,7 +158,7 @@ private fun ExportTab(
 
             Spacer(modifier = Modifier.height(theme.verticalSpacing))
             Text(
-                "Use the QR code to transfer to a new device. Use the text code when switching installation methods (e.g. GitHub → Play Store). Each code is a one-time snapshot — importing does not affect existing data on the target device.",
+                "Use the QR code to transfer to a new device. Use the text code when switching installation methods (e.g. GitHub → Play Store). Codes expire after 15 minutes — if yours expires, come back here to generate a fresh one. Importing adds to existing data on the target device rather than replacing it.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center
@@ -176,6 +176,7 @@ private fun ImportTab(
 ) {
     var code by remember { mutableStateOf("") }
     var showScanner by remember { mutableStateOf(false) }
+    var transferRegistration by remember(state.isRegistered) { mutableStateOf(!state.isRegistered) }
 
     if (showScanner) {
         Box(modifier = Modifier.fillMaxSize()) {
@@ -237,8 +238,34 @@ private fun ImportTab(
 
         Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
 
+        ThemedCard(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(theme.cardContentPadding)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text("Transfer campaign registration", style = theme.headerStyle.copy(fontSize = 16.sp), modifier = Modifier.weight(1f))
+                    Switch(checked = transferRegistration, onCheckedChange = { transferRegistration = it })
+                }
+                Text(
+                    if (state.isRegistered)
+                        "This device is already registered. Enabling this will replace your current campaign identity with the one from the source device."
+                    else
+                        "Transfers your campaign memberships to this device. You will need to re-register after importing.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (state.isRegistered && transferRegistration)
+                        MaterialTheme.colorScheme.error
+                    else
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+
         Button(
-            onClick = { onEvent(CharacterEvent.ImportMigrationData(code.trim())) },
+            onClick = { onEvent(CharacterEvent.ImportMigrationData(code.trim(), transferRegistration)) },
             enabled = code.isNotBlank() && state.migrationImportStatus !is MigrationImportStatus.Loading && state.migrationImportStatus !is MigrationImportStatus.Success,
             modifier = Modifier.fillMaxWidth(),
             shape = theme.cardShape

--- a/app/src/main/java/io/github/garemat/lunachron/ui/DataMigrationScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/DataMigrationScreen.kt
@@ -158,7 +158,7 @@ private fun ExportTab(
 
             Spacer(modifier = Modifier.height(theme.verticalSpacing))
             Text(
-                "Use the QR code to transfer to a new device. Use the text code when switching installation methods (e.g. GitHub → Play Store). Codes expire after 15 minutes — if yours expires, come back here to generate a fresh one. Importing adds to existing data on the target device rather than replacing it.",
+                "Use the QR code to transfer to a new device. Use the text code when switching installation methods (e.g. GitHub → Play Store). Codes expire after 15 minutes. Keep this code private — anyone who has it can access your campaigns.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center
@@ -252,7 +252,7 @@ private fun ImportTab(
                     if (state.isRegistered)
                         "This device is already registered. Enabling this will replace your current campaign identity with the one from the source device."
                     else
-                        "Transfers your campaign memberships to this device. You will need to re-register after importing.",
+                        "Transfers your campaign memberships and session to this device. The source device will remain logged in until its session expires.",
                     style = MaterialTheme.typography.bodySmall,
                     color = if (state.isRegistered && transferRegistration)
                         MaterialTheme.colorScheme.error

--- a/app/src/main/java/io/github/garemat/lunachron/ui/DataMigrationScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/DataMigrationScreen.kt
@@ -158,9 +158,16 @@ private fun ExportTab(
 
             Spacer(modifier = Modifier.height(theme.verticalSpacing))
             Text(
-                "Use the QR code to transfer to a new device. Use the text code when switching installation methods (e.g. GitHub → Play Store). Codes expire after 15 minutes. Keep this code private — anyone who has it can access your campaigns.",
+                "Use the QR code to transfer to a new device. Use the text code when switching installation methods (e.g. GitHub → Play Store). Codes expire after 15 minutes.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+            Text(
+                "Keep this code private — anyone who has it can access your campaigns.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
                 textAlign = TextAlign.Center
             )
             Spacer(modifier = Modifier.height(theme.verticalSpacing))

--- a/app/src/main/java/io/github/garemat/lunachron/ui/Screen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/Screen.kt
@@ -33,4 +33,5 @@ sealed class Screen(val route: String) {
     data object CampaignDetails : Screen("campaign_details/{campaignId}") {
         fun createRoute(campaignId: Int) = "campaign_details/$campaignId"
     }
+    data object DataMigration : Screen("data_migration")
 }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/SettingsScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/SettingsScreen.kt
@@ -31,7 +31,8 @@ import io.github.garemat.lunachron.ui.theme.LocalAppThemeProperties
 fun SettingsScreen(
     state: CharacterState,
     onEvent: (CharacterEvent) -> Unit,
-    onNavigateBack: () -> Unit
+    onNavigateBack: () -> Unit,
+    onNavigateToMigration: () -> Unit = {}
 ) {
     var name by remember { mutableStateOf(state.name) }
     var showRegisterDialog by remember { mutableStateOf(false) }
@@ -120,6 +121,15 @@ fun SettingsScreen(
                         Text("Register device", style = theme.buttonTextStyle)
                     }
                 }
+            }
+
+            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+            OutlinedButton(
+                onClick = onNavigateToMigration,
+                modifier = Modifier.fillMaxWidth(),
+                shape = theme.cardShape
+            ) {
+                Text("Transfer data to another device", style = theme.buttonTextStyle)
             }
 
             Spacer(modifier = Modifier.height(theme.verticalSpacing))

--- a/tools/emulators.sh
+++ b/tools/emulators.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Launch lunachron_a and lunachron_b emulators for local testing.
+# No extra flags — additional GPU/accel/window flags cause segfaults on this machine.
+
+EMULATOR="$HOME/Android/Sdk/emulator/emulator"
+
+echo "Starting lunachron_a (emulator-5554)..."
+"$EMULATOR" -avd lunachron_a -port 5554 &
+
+echo "Starting lunachron_b (emulator-5556)..."
+"$EMULATOR" -avd lunachron_b -port 5556 &
+
+echo "Waiting for both to boot..."
+ADB="$HOME/Android/Sdk/platform-tools/adb"
+for serial in emulator-5554 emulator-5556; do
+    until [[ "$("$ADB" -s "$serial" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" == "1" ]]; do
+        sleep 5
+    done
+    echo "$serial ready"
+done
+echo "Both emulators up. Run: ./gradlew app:installGithubDebug"


### PR DESCRIPTION
## Summary

Adds a **Transfer Data** screen (Settings → Transfer data to another device) for migrating user data when switching devices or installation methods (e.g. GitHub → Play Store).

This is a **migration** tool — designed for moving from one device to another, not for keeping multiple devices in sync simultaneously.

**What transfers:**
- Username
- Troupes and campaigns (local data)
- Game history
- Campaign registration / session (opt-in toggle)

**Two transfer methods:**
- QR code — scan on the new device
- Copy/paste text code — for cases where QR isn't practical

**Implementation:**
- Fully offline / no backend changes — payload is GZip+Base64 encoded JSON
- Codes carry a 15-minute expiry as a UX nudge (codes also contain a session token, so users are warned to keep them private)
- Import adds to existing data on the target device rather than replacing it
- Room IDs are remapped on insert to avoid primary key collisions
- `CampaignPlayer.troupeId` references are remapped after troupes are inserted with new IDs
- QR scanning uses ZXing (`com.google.zxing:core`, Apache-2.0) — no Google Play Services / ML Kit

## Test plan

- [ ] Export generates a QR code and copyable text code
- [ ] Import via pasted code restores troupes, campaigns, and game history
- [ ] "Transfer campaign registration" toggle defaults off when target device is already registered, with a destructive-action warning in red
- [ ] Importing with the toggle on restores campaign access immediately (session token transferred)
- [ ] Expired code shows a clear error message
- [ ] Invalid/malformed code shows an error without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)