### PR TITLE
docs: document Github build flavour in build commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,10 @@ This is an Android project. Use Gradle wrapper from the project root:
 
 ```bash
 # Build debug APK
-./gradlew assembleDebug
+./gradlew assembleGithubDebug
+
+# Install debug APK on connected device/emulator
+./gradlew installGithubDebug
 
 # Build release APK (requires env vars: KEYSTORE_PATH, KEYSTORE_PASSWORD, KEY_ALIAS, KEY_PASSWORD)
 ./gradlew assembleRelease
@@ -51,6 +54,8 @@ This is an Android project. Use Gradle wrapper from the project root:
 # Clean build
 ./gradlew clean
 ```
+
+The app has `github` and `fdroid` build flavours — always use the `Github` variant locally (`installDebug` is ambiguous and will fail).
 
 The app targets SDK 36, min SDK 24, Java 17.
 


### PR DESCRIPTION
## Summary
- Replaces `assembleDebug` with `assembleGithubDebug` and adds `installGithubDebug` in the Build Commands section
- Notes that `installDebug` is ambiguous due to `github`/`fdroid` build flavours and will fail

## Test plan
- [ ] Read the CLAUDE.md build commands section and confirm the variant names are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)