### PR TITLE
chore: symlink local.properties into new worktrees via hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,15 @@
 {
-  "enabledMcpjsonServers": ["android", "lunachron-kotlin", "lunachron-kls"]
+  "enabledMcpjsonServers": ["android", "lunachron-kotlin", "lunachron-kls"],
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ln -sf /var/home/garemat/lunaChron/lunachron/local.properties ./local.properties"
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

- Adds a `WorktreeCreate` hook to `.claude/settings.json` that symlinks `local.properties` from the main clone into every new worktree
- Prevents Gradle failing to find the Android SDK in fresh worktrees (since `local.properties` is gitignored and not present by default)

## Test plan

- [ ] Create a new worktree — verify `local.properties` is present as a symlink pointing to the main clone's copy
- [ ] Run `./gradlew assembleDebug` from the new worktree without any manual setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)