### PR TITLE
feat: tracking screen redesign

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
@@ -67,6 +67,8 @@ sealed interface CharacterEvent {
     data class SetHideCampaignTab(val hide: Boolean) : CharacterEvent
     data class AddSummonedCharacter(val playerIndex: Int, val characterId: Int, val summonedByCharacterId: Int?) : CharacterEvent
     data class RemoveSummonedCharacter(val playerIndex: Int, val characterId: Int) : CharacterEvent
+    data class ToggleActivated(val playerIndex: Int, val charIndex: Int) : CharacterEvent
+    data class SetStatusToken(val playerIndex: Int, val charIndex: Int, val token: String, val value: Boolean) : CharacterEvent
     data class UpdatePoolResource(val playerIndex: Int, val resourceName: String, val count: Int) : CharacterEvent
     data class UpdateCharacterPoolResource(val playerIndex: Int, val charIndex: Int, val resourceName: String, val count: Int) : CharacterEvent
     data class TransformCharacter(val playerIndex: Int, val charIndex: Int, val targetCharacterId: Int) : CharacterEvent

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
@@ -411,7 +411,9 @@ data class CharacterPlayState(
     val usedAbilities: Map<String, Boolean> = emptyMap(),
     val isFlipped: Boolean = false,
     val isExpanded: Boolean = false,
-    val heldPoolResources: Map<String, Int> = emptyMap()
+    val heldPoolResources: Map<String, Int> = emptyMap(),
+    val isActivatedThisTurn: Boolean = false,
+    val statusTokens: Map<String, Boolean> = emptyMap()
 )
 
 @Serializable

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -1076,7 +1076,7 @@ class CharacterViewModel(
     }
 
     fun startNewGame(troupes: List<Troupe>) {
-        _state.update { it.copy(characterPlayStates = emptyMap(), activeSummons = emptyMap(), currentTurn = 1, activeTroupes = troupes, turnHistory = emptyList(), readyForNextTurn = emptySet(), readyForRewind = emptySet(), winnerName = null, isTie = false) }
+        _state.update { it.copy(characterPlayStates = emptyMap(), activeSummons = emptyMap(), poolResourceCounts = emptyMap(), currentTurn = 1, activeTroupes = troupes, turnHistory = emptyList(), readyForNextTurn = emptySet(), readyForRewind = emptySet(), winnerName = null, isTie = false, gameSession = null) }
     }
 
     fun saveTroupe(troupe: Troupe) {

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -650,6 +650,15 @@ class CharacterViewModel(
             is CharacterEvent.UpdateCharacterHealth -> {
                 updateCharacterState(event.playerIndex, event.charIndex) { it.copy(currentHealth = event.health) }
                 broadcastGameplayUpdate(SessionMessage.GameplayUpdate(event.playerIndex, event.charIndex, health = event.health))
+                if (event.health == 0) {
+                    val cur = _state.value
+                    val baseSize = cur.activeTroupes.getOrNull(event.playerIndex)?.characterIds?.size ?: 0
+                    val summons = cur.activeSummons[event.playerIndex] ?: emptyList()
+                    val summonIndex = event.charIndex - baseSize
+                    if (summonIndex >= 0 && summonIndex < summons.size) {
+                        onEvent(CharacterEvent.RemoveSummonedCharacter(event.playerIndex, summons[summonIndex].characterId))
+                    }
+                }
             }
             is CharacterEvent.UpdateCharacterEnergy -> {
                 updateCharacterState(event.playerIndex, event.charIndex) { it.copy(currentEnergy = event.energy) }
@@ -768,6 +777,12 @@ class CharacterViewModel(
             is CharacterEvent.UpdateCharacterMoonstones -> {
                 updateCharacterState(event.playerIndex, event.charIndex) { it.copy(moonstones = event.stones) }
                 broadcastGameplayUpdate(SessionMessage.GameplayUpdate(event.playerIndex, event.charIndex, moonstones = event.stones))
+            }
+            is CharacterEvent.ToggleActivated -> {
+                updateCharacterState(event.playerIndex, event.charIndex) { it.copy(isActivatedThisTurn = !it.isActivatedThisTurn) }
+            }
+            is CharacterEvent.SetStatusToken -> {
+                updateCharacterState(event.playerIndex, event.charIndex) { it.copy(statusTokens = it.statusTokens + (event.token to event.value)) }
             }
             CharacterEvent.AbandonGame -> {
                 _state.update { it.copy(activeTroupes = emptyList(), characterPlayStates = emptyMap(), currentTurn = 1, gameSession = null, turnHistory = emptyList(), winnerName = null, isTie = false) }
@@ -1045,7 +1060,7 @@ class CharacterViewModel(
         pData.forEachIndexed { pIdx, (_, characters) ->
             characters.forEachIndexed { cIdx, character ->
                 val key = "${pIdx}_$cIdx"; val ps = newStates[key]
-                if (ps != null && ps.currentHealth > 0) newStates[key] = ps.copy(currentEnergy = calculateReplenishedEnergy(character, ps.currentHealth), usedAbilities = emptyMap())
+                if (ps != null && ps.currentHealth > 0) newStates[key] = ps.copy(currentEnergy = calculateReplenishedEnergy(character, ps.currentHealth), usedAbilities = emptyMap(), isActivatedThisTurn = false)
             }
         }
         _state.update { it.copy(characterPlayStates = newStates, currentTurn = it.currentTurn + 1, turnHistory = it.turnHistory + listOf(cur.characterPlayStates), readyForNextTurn = emptySet(), readyForRewind = emptySet()) }

--- a/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/MainActivity.kt
@@ -481,7 +481,9 @@ class MainActivity : ComponentActivity() {
                                         onEvent = viewModel::onEvent,
                                         onQuickStartTroupe = { troupe ->
                                             viewModel.startNewGame(listOf(troupe))
-                                            navController.navigate(Screen.ActiveGame.route)
+                                            navController.navigate(Screen.ActiveGame.route) {
+                                                popUpTo(Screen.Home.route) { inclusive = false }
+                                            }
                                         },
                                         onTargetPositioned = { name, coords -> tutorialCoords[name] = coords }
                                     )

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
@@ -41,8 +41,10 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -565,6 +567,9 @@ private fun CharacterPortraitCell(
         character.magicalDamageMitigation > 0
     }
 
+    val statTextMeasurer = rememberTextMeasurer()
+    val statTextStyle = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp)
+
     var showCombatProfile by remember { mutableStateOf(false) }
     val overlayAlpha by animateFloatAsState(
         targetValue = if (showCombatProfile) 1f else 0f,
@@ -701,7 +706,7 @@ private fun CharacterPortraitCell(
         ) {
             // Stat bundle pill — tappable if character has combat modifiers
             val healthDisplay = if (isDormant) character.health else playState.currentHealth
-            Box(
+            BoxWithConstraints(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clip(MaterialTheme.shapes.small)
@@ -714,10 +719,13 @@ private fun CharacterPortraitCell(
                     .padding(horizontal = 5.dp, vertical = 3.dp),
                 contentAlignment = Alignment.Center
             ) {
+                val wideText = "♥ $healthDisplay  ⚔ ${character.melee}  ${character.meleeRange}\"  ✦ ${character.arcane}  ~ ${statSign(character.evade)}"
+                val compactText = "♥$healthDisplay ⚔${character.melee} ${character.meleeRange}\" ✦${character.arcane} ~${statSign(character.evade)}"
+                val availableWidthPx = with(LocalDensity.current) { maxWidth.roundToPx() }
+                val statText = if (statTextMeasurer.measure(wideText, style = statTextStyle, maxLines = 1).size.width <= availableWidthPx) wideText else compactText
                 Text(
-                    text = "♥ $healthDisplay  ⚔ ${character.melee}  ${character.meleeRange}\"  ✦ ${character.arcane}  💨 ${statSign(character.evade)}",
-                    style = MaterialTheme.typography.labelSmall,
-                    fontSize = 10.sp,
+                    text = statText,
+                    style = statTextStyle,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     textAlign = TextAlign.Center,

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
@@ -283,7 +283,8 @@ fun ActiveGameScreen(
                             val ci = gridItem.charIndex
                             val char = gridItem.character
                             val stateKey = "${pi}_${ci}"
-                            item(key = stateKey) {
+                            val itemKey = if (gridItem.isDormant) "${pi}_dormant_${char.id}" else stateKey
+                            item(key = itemKey) {
                                 val ps = if (isTutorialActive) {
                                     CharacterPlayState(currentHealth = char.health, moonstones = if (ci == 0) 2 else 0)
                                 } else {

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
@@ -80,7 +81,8 @@ private sealed class GameGridItem {
         val charIndex: Int,
         val character: Character,
         val isSummoned: Boolean,
-        val summoner: Character?
+        val summoner: Character?,
+        val isDormant: Boolean = false
     ) : GameGridItem()
 }
 
@@ -157,12 +159,26 @@ fun ActiveGameScreen(
                 val troupeCharIds = troupe.characterIds.toSet()
                 val baseChars = chars.filter { it.id in troupeCharIds }
                 val summonEntries = state.activeSummons[pi] ?: emptyList()
+                val activeSummonIds = summonEntries.map { it.characterId }.toSet()
                 val summonedChars = summonEntries.mapNotNull { e -> state.characters.find { it.id == e.characterId } }
                 (baseChars + summonedChars).forEachIndexed { ci, char ->
                     val isSummoned = ci >= baseChars.size
                     val summonEntry = if (isSummoned) summonEntries.getOrNull(ci - baseChars.size) else null
                     val summoner = summonEntry?.summonedByCharacterId?.let { id -> baseChars.find { it.id == id } }
                     add(GameGridItem.CharItem(pi, ci, char, isSummoned, summoner))
+                }
+                // Dormant summons — potential summons not yet activated
+                val addedDormantIds = mutableSetOf<Int>()
+                baseChars.forEach { summoner ->
+                    summoner.summonsCharacterIds.forEach { summonId ->
+                        if (summonId !in activeSummonIds && summonId !in addedDormantIds) {
+                            val summonChar = state.characters.find { it.id == summonId }
+                            if (summonChar != null) {
+                                addedDormantIds.add(summonId)
+                                add(GameGridItem.CharItem(pi, -1, summonChar, isSummoned = true, summoner = summoner, isDormant = true))
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -249,34 +265,7 @@ fun ActiveGameScreen(
                 )
             }
         },
-        bottomBar = {
-            if (isFullTracking) {
-                CollapsiblePoolBar(
-                    state = state,
-                    pageIndex = localPlayerIndex,
-                    allDisplayChars = localDisplayChars,
-                    isTutorialActive = isTutorialActive,
-                    potBounds = potBounds,
-                    onTargetPositioned = onTargetPositioned,
-                    onDragStart = { offset ->
-                        draggingStoneSource = StoneSource.Pot
-                        dragPosition = (potBounds.value?.topLeft ?: Offset.Zero) + offset
-                    },
-                    onDrag = { dragPosition += it },
-                    onDragEnd = {
-                        if (!isTutorialActive) {
-                            characterBounds.entries.find { it.value.contains(dragPosition) }?.let { target ->
-                                val (tP, tC) = target.key.split("_").map { it.toInt() }
-                                val currentStones = stateRef.value.characterPlayStates[target.key]?.moonstones ?: 0
-                                if (currentStones < 7) viewModel.onEvent(CharacterEvent.UpdateCharacterMoonstones(tP, tC, currentStones + 1))
-                            }
-                        }
-                        draggingStoneSource = null
-                    },
-                    viewModel = viewModel
-                )
-            }
-        }
+        bottomBar = {}
     ) { padding ->
         Box(modifier = Modifier.fillMaxSize().padding(padding).onGloballyPositioned { rootLayoutCoordinates = it }) {
             LazyVerticalGrid(
@@ -311,57 +300,17 @@ fun ActiveGameScreen(
                                         trackingMode = trackingMode,
                                         summoner = gridItem.summoner,
                                         isEditable = !isTutorialActive,
-                                        onTap = { selectedCharInfo = Triple(pi, ci, char) },
-                                        onHpBadgeTap = {
-                                            if (!isTutorialActive) {
-                                                val newHp = max(0, ps.currentHealth - 1)
-                                                viewModel.onEvent(CharacterEvent.UpdateCharacterHealth(pi, ci, newHp))
-                                                if (newHp == 0 && ps.moonstones > 0) {
-                                                    viewModel.onEvent(CharacterEvent.UpdateCharacterMoonstones(pi, ci, 0))
-                                                }
-                                                recordDelta("${pi}_${ci}_hp", -1, "HP")
+                                        isDormant = gridItem.isDormant,
+                                        onTap = {
+                                            if (gridItem.isDormant && !isTutorialActive) {
+                                                val baseSize = state.activeTroupes.getOrNull(pi)?.characterIds?.size ?: 0
+                                                val currentSummons = state.activeSummons[pi] ?: emptyList()
+                                                val newCharIndex = baseSize + currentSummons.size
+                                                viewModel.onEvent(CharacterEvent.AddSummonedCharacter(pi, char.id, gridItem.summoner?.id))
+                                                selectedCharInfo = Triple(pi, newCharIndex, char)
+                                            } else {
+                                                selectedCharInfo = Triple(pi, ci, char)
                                             }
-                                        },
-                                        onEnergyBadgeTap = {
-                                            if (!isTutorialActive) {
-                                                viewModel.onEvent(CharacterEvent.UpdateCharacterEnergy(pi, ci, max(0, ps.currentEnergy - 1)))
-                                                recordDelta("${pi}_${ci}_en", -1, "Energy")
-                                            }
-                                        },
-                                        onMoonstoneBadgeTap = {
-                                            if (!isTutorialActive && ps.currentHealth > 0) {
-                                                viewModel.onEvent(CharacterEvent.UpdateCharacterMoonstones(pi, ci, ps.moonstones + 1))
-                                                recordDelta("${pi}_${ci}_ms", +1, "Stones")
-                                            }
-                                        },
-                                        onStoneDragStart = { index, pos ->
-                                            draggingStoneIndex = index
-                                            draggingStoneSource = StoneSource.Character(pi, ci)
-                                            dragPosition = pos
-                                        },
-                                        onStoneDrag = { dragPosition += it },
-                                        onStoneDragEnd = {
-                                            val source = draggingStoneSource as? StoneSource.Character
-                                            if (source != null && !isTutorialActive) {
-                                                if (potBounds.value?.contains(dragPosition) == true) {
-                                                    val s = stateRef.value.characterPlayStates["${source.playerIndex}_${source.charIndex}"]?.moonstones ?: 0
-                                                    if (s > 0) viewModel.onEvent(CharacterEvent.UpdateCharacterMoonstones(source.playerIndex, source.charIndex, s - 1))
-                                                } else {
-                                                    characterBounds.entries.find { it.value.contains(dragPosition) }?.let { target ->
-                                                        val (tP, tC) = target.key.split("_").map { it.toInt() }
-                                                        if (tP != source.playerIndex || tC != source.charIndex) {
-                                                            val sStones = stateRef.value.characterPlayStates["${source.playerIndex}_${source.charIndex}"]?.moonstones ?: 0
-                                                            val tStones = stateRef.value.characterPlayStates[target.key]?.moonstones ?: 0
-                                                            if (tStones < 7) {
-                                                                viewModel.onEvent(CharacterEvent.UpdateCharacterMoonstones(source.playerIndex, source.charIndex, sStones - 1))
-                                                                viewModel.onEvent(CharacterEvent.UpdateCharacterMoonstones(tP, tC, tStones + 1))
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                            draggingStoneSource = null
-                                            draggingStoneIndex = -1
                                         }
                                     )
                                 }
@@ -371,40 +320,6 @@ fun ActiveGameScreen(
                 }
             }
 
-            // Summon panel slides in from the start edge
-            AnimatedVisibility(
-                visible = isSummonPanelOpen,
-                enter = expandHorizontally(),
-                exit = shrinkHorizontally(),
-                modifier = Modifier.fillMaxHeight()
-            ) {
-                SummonPanel(
-                    allChars = state.characters,
-                    baseChars = localBaseChars,
-                    summonEntries = localSummonEntries,
-                    trackingMode = trackingMode,
-                    onAdd = { char ->
-                        handleSummonAdd(localPlayerIndex, char, localBaseChars, trackingMode, viewModel) {
-                            summonerPickerState = it
-                        }
-                    },
-                    onRemove = { char ->
-                        viewModel.onEvent(CharacterEvent.RemoveSummonedCharacter(localPlayerIndex, char.id))
-                    }
-                )
-            }
-
-            // Dragging stone overlay
-            if (draggingStoneSource != null) {
-                val localPos = rootLayoutCoordinates?.windowToLocal(dragPosition) ?: dragPosition
-                Box(
-                    modifier = Modifier
-                        .offset { IntOffset(localPos.x.roundToInt() - 20.dp.toPx().toInt(), localPos.y.roundToInt() - 20.dp.toPx().toInt()) }
-                        .zIndex(1000f)
-                ) {
-                    MoonstoneIcon(size = 40.dp)
-                }
-            }
 
             // Accumulating toast chip
             val toastData = visibleToastKey?.let { accMap[it] }
@@ -463,9 +378,17 @@ fun ActiveGameScreen(
                     playState = ps,
                     trackingMode = trackingMode,
                     isEditable = !isTutorialActive,
+                    allCharacters = state.characters,
+                    activeSummons = state.activeSummons[pi] ?: emptyList(),
+                    onHealthChange = { viewModel.onEvent(CharacterEvent.UpdateCharacterHealth(pi, ci, it)) },
                     onEnergyChange = { viewModel.onEvent(CharacterEvent.UpdateCharacterEnergy(pi, ci, it)) },
+                    onMoonstoneChange = { viewModel.onEvent(CharacterEvent.UpdateCharacterMoonstones(pi, ci, it)) },
+                    onToggleActivated = { viewModel.onEvent(CharacterEvent.ToggleActivated(pi, ci)) },
+                    onSetStatusToken = { token, value -> viewModel.onEvent(CharacterEvent.SetStatusToken(pi, ci, token, value)) },
                     onAbilityToggle = { name, used -> viewModel.onEvent(CharacterEvent.ToggleAbilityUsed(pi, ci, name, used)) },
                     onFlip = { viewModel.onEvent(CharacterEvent.ToggleCharacterFlipped(pi, ci, !ps.isFlipped)) },
+                    onAddSummon = { charId, summonerId -> viewModel.onEvent(CharacterEvent.AddSummonedCharacter(pi, charId, summonerId)) },
+                    onRemoveSummon = { charId -> viewModel.onEvent(CharacterEvent.RemoveSummonedCharacter(pi, charId)) },
                     onTransform = if (char.transformsInto != null) { targetId ->
                         viewModel.onEvent(CharacterEvent.TransformCharacter(pi, ci, targetId))
                         selectedCharInfo = null
@@ -640,19 +563,13 @@ private fun CharacterPortraitCell(
     trackingMode: GameTrackingMode,
     summoner: Character?,
     isEditable: Boolean,
-    onTap: () -> Unit,
-    onHpBadgeTap: () -> Unit,
-    onEnergyBadgeTap: () -> Unit,
-    onMoonstoneBadgeTap: () -> Unit,
-    onStoneDragStart: (Int, Offset) -> Unit,
-    onStoneDrag: (Offset) -> Unit,
-    onStoneDragEnd: () -> Unit
+    isDormant: Boolean = false,
+    onTap: () -> Unit
 ) {
     val theme = LocalAppThemeProperties.current
-    val isFullTracking = trackingMode == GameTrackingMode.FULL_TRACKING
-    val isDead = playState.currentHealth <= 0
+    val isDead = !isDormant && playState.currentHealth <= 0
     val moonstoneColor = theme.moonstoneColor
-    val stoneCoords = remember { mutableStateMapOf<Int, LayoutCoordinates>() }
+    val isCursed = !isDormant && playState.statusTokens["cursed"] == true
 
     val hasCombatModifiers = remember(character) {
         (character.slicingDamageBuff ?: 0) > 0 ||
@@ -672,7 +589,6 @@ private fun CharacterPortraitCell(
         animationSpec = tween(200),
         label = "combatOverlay"
     )
-    // Auto-dismiss after 3 s
     LaunchedEffect(showCombatProfile) {
         if (showCombatProfile) {
             delay(3000)
@@ -685,8 +601,12 @@ private fun CharacterPortraitCell(
         modifier = Modifier
             .fillMaxWidth()
             .clip(theme.cardShape)
+            .then(
+                if (isDormant) Modifier.border(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.5f), theme.cardShape)
+                else Modifier
+            )
     ) {
-        // ── Portrait area fills full cell width ──────────────────────────────
+        // ── Portrait area ────────────────────────────────────────────────────
         BoxWithConstraints(
             modifier = Modifier
                 .fillMaxWidth()
@@ -700,76 +620,80 @@ private fun CharacterPortraitCell(
                     .width(size)
                     .height(portraitHeight)
                     .portraitCrimpedEdge()
-                    .then(if (isDead) Modifier.alpha(0.4f) else Modifier)
+                    .then(if (isDead || isDormant) Modifier.alpha(0.4f) else Modifier)
             ) {
                 CharacterPortrait(character, size, shape = RectangleShape)
             }
 
-            if (isDead) {
+            if (isDormant) {
+                Box(
+                    modifier = Modifier
+                        .width(size)
+                        .height(portraitHeight)
+                        .background(Color(0xAA000000)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = "Dormant",
+                            color = Color.White.copy(alpha = 0.9f),
+                            fontSize = 10.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            letterSpacing = 1.sp
+                        )
+                        Spacer(Modifier.height(4.dp))
+                        Box(
+                            modifier = Modifier
+                                .size(24.dp)
+                                .clip(CircleShape)
+                                .background(Color.White.copy(alpha = 0.15f))
+                                .border(1.dp, Color.White.copy(alpha = 0.6f), CircleShape),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text("+", color = Color.White, fontSize = 16.sp, fontWeight = FontWeight.Bold)
+                        }
+                    }
+                }
+            } else if (isDead) {
                 Text(
                     "☠",
                     fontSize = (size.value * 0.38f).sp,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.align(Alignment.Center)
                 )
-            } else if (isFullTracking) {
-                // HP badge — bottom start, tap to decrement
-                StatBadge(
-                    value = playState.currentHealth,
-                    color = Color(0xFF2E7D32),
-                    modifier = Modifier
-                        .align(Alignment.BottomStart)
-                        .offset(4.dp, (-4).dp)
-                        .then(if (isEditable) Modifier.clickable(onClick = onHpBadgeTap) else Modifier)
-                )
-                // Energy badge — bottom end, tap to decrement
-                StatBadge(
-                    value = playState.currentEnergy,
-                    color = Color(0xFF1565C0),
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .offset((-4).dp, (-4).dp)
-                        .then(if (isEditable) Modifier.clickable(onClick = onEnergyBadgeTap) else Modifier)
-                )
-                // Moonstone badge — top center, tap to increment
-                if (playState.moonstones > 0 || isEditable) {
+            } else {
+                // ✓ activated badge — top-start
+                if (playState.isActivatedThisTurn) {
                     Box(
                         modifier = Modifier
-                            .align(Alignment.TopCenter)
-                            .offset(0.dp, 4.dp)
+                            .align(Alignment.TopStart)
+                            .offset(4.dp, 4.dp)
+                            .size(20.dp)
+                            .clip(CircleShape)
+                            .background(Color(0xCC2E7D32)),
+                        contentAlignment = Alignment.Center
                     ) {
-                        StatBadge(
-                            value = playState.moonstones,
-                            color = moonstoneColor,
-                            textColor = Color.Black,
-                            modifier = if (isEditable) Modifier.clickable(onClick = onMoonstoneBadgeTap) else Modifier
-                        )
-                        // Support drag-off for moonstone transfer to pool
-                        if (isEditable && playState.moonstones > 0) {
-                            repeat(playState.moonstones) { i ->
-                                Box(
-                                    modifier = Modifier
-                                        .size(1.dp)
-                                        .onGloballyPositioned { stoneCoords[i] = it }
-                                        .pointerInput(i) {
-                                            detectDragGestures(
-                                                onDragStart = { offset ->
-                                                    onStoneDragStart(i, (stoneCoords[i]?.boundsInWindow()?.topLeft ?: Offset.Zero) + offset)
-                                                },
-                                                onDrag = { change, amount -> change.consume(); onStoneDrag(amount) },
-                                                onDragEnd = { onStoneDragEnd() },
-                                                onDragCancel = { onStoneDragEnd() }
-                                            )
-                                        }
-                                )
-                            }
-                        }
+                        Text("✓", color = Color.White, fontSize = 11.sp, fontWeight = FontWeight.Bold)
+                    }
+                }
+                // ✦ curse badge — top-end
+                if (isCursed) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .offset((-4).dp, 4.dp)
+                            .size(20.dp)
+                            .clip(CircleShape)
+                            .background(Color(0xCC7B1FA2)),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text("✦", color = Color.White, fontSize = 10.sp)
                     }
                 }
             }
 
             // Combat profile overlay — fades in over portrait on stat bundle tap
-            if (overlayAlpha > 0f) {
+            if (overlayAlpha > 0f && !isDormant) {
                 Box(
                     modifier = Modifier
                         .width(size)
@@ -794,13 +718,14 @@ private fun CharacterPortraitCell(
             verticalArrangement = Arrangement.spacedBy(2.dp)
         ) {
             // Stat bundle pill — tappable if character has combat modifiers
+            val healthDisplay = if (isDormant) character.health else playState.currentHealth
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clip(MaterialTheme.shapes.small)
                     .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.7f))
                     .then(
-                        if (!isDead && hasCombatModifiers)
+                        if (!isDead && !isDormant && hasCombatModifiers)
                             Modifier.clickable { showCombatProfile = !showCombatProfile }
                         else Modifier
                     )
@@ -808,15 +733,32 @@ private fun CharacterPortraitCell(
                 contentAlignment = Alignment.Center
             ) {
                 Text(
-                    text = "⚔ ${character.melee}  ${character.meleeRange}\"  ✦ ${character.arcane}  💨 ${statSign(character.evade)}",
+                    text = "♥ $healthDisplay  ⚔ ${character.melee}  ${character.meleeRange}\"  ✦ ${character.arcane}  💨 ${statSign(character.evade)}",
                     style = MaterialTheme.typography.labelSmall,
                     fontSize = 10.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     textAlign = TextAlign.Center,
-                    color = if (isDead) MaterialTheme.colorScheme.outline
+                    color = if (isDead || isDormant) MaterialTheme.colorScheme.outline
                             else MaterialTheme.colorScheme.onSurfaceVariant
                 )
+            }
+
+            // Filled moonstone dots — only when active and tracking moonstones
+            if (!isDormant && playState.moonstones > 0) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(3.dp),
+                    modifier = Modifier.padding(top = 1.dp)
+                ) {
+                    repeat(playState.moonstones) {
+                        Box(
+                            modifier = Modifier
+                                .size(6.dp)
+                                .clip(CircleShape)
+                                .background(moonstoneColor)
+                        )
+                    }
+                }
             }
 
             // Character name
@@ -827,7 +769,7 @@ private fun CharacterPortraitCell(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 textAlign = TextAlign.Center,
-                color = if (isDead) MaterialTheme.colorScheme.outline else MaterialTheme.colorScheme.onSurface
+                color = if (isDead || isDormant) MaterialTheme.colorScheme.outline else MaterialTheme.colorScheme.onSurface
             )
 
             SummonerIndicator(summoner)
@@ -979,9 +921,17 @@ private fun GameCharacterCardModal(
     playState: CharacterPlayState,
     trackingMode: GameTrackingMode,
     isEditable: Boolean,
+    allCharacters: List<Character>,
+    activeSummons: List<SummonEntry>,
+    onHealthChange: (Int) -> Unit,
     onEnergyChange: (Int) -> Unit,
+    onMoonstoneChange: (Int) -> Unit,
+    onToggleActivated: () -> Unit,
+    onSetStatusToken: (String, Boolean) -> Unit,
     onAbilityToggle: (String, Boolean) -> Unit,
     onFlip: () -> Unit,
+    onAddSummon: (Int, Int?) -> Unit,
+    onRemoveSummon: (Int) -> Unit,
     onTransform: ((Int) -> Unit)? = null,
     onDismiss: () -> Unit
 ) {
@@ -1003,103 +953,155 @@ private fun GameCharacterCardModal(
 
         ThemedCard(
             modifier = Modifier
-                .align(Alignment.Center)
-                .fillMaxWidth(0.94f)
-                .fillMaxHeight(0.88f)
-                .clickable {} // Absorb touches so scrim doesn't dismiss
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .fillMaxHeight(0.93f)
+                .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
+                .clickable {}
         ) {
-            Box(modifier = Modifier.fillMaxSize()) {
-                Column(modifier = Modifier.fillMaxSize()) {
-                    // Energy controls row (FULL_TRACKING only)
-                    if (isFullTracking) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = theme.screenPadding, vertical = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(4.dp)
-                        ) {
-                            Text(
-                                "ENERGY",
-                                style = MaterialTheme.typography.labelSmall,
-                                fontWeight = FontWeight.Bold,
-                                modifier = Modifier.weight(1f)
-                            )
-                            IconButton(
-                                onClick = { if (playState.currentEnergy > 0) onEnergyChange(playState.currentEnergy - 1) },
-                                modifier = Modifier.size(32.dp),
-                                enabled = isEditable
-                            ) { Icon(Icons.Default.Remove, contentDescription = null, modifier = Modifier.size(18.dp)) }
-                            Text(
-                                text = playState.currentEnergy.toString(),
-                                style = MaterialTheme.typography.titleLarge,
-                                fontWeight = FontWeight.ExtraBold,
-                                color = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.widthIn(min = 28.dp),
-                                textAlign = TextAlign.Center
-                            )
-                            IconButton(
-                                onClick = { onEnergyChange(playState.currentEnergy + 1) },
-                                modifier = Modifier.size(32.dp),
-                                enabled = isEditable
-                            ) { Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(18.dp)) }
-                        }
-                        HorizontalDivider()
-                    }
-
-                    // Character name + keywords header
-                    Row(
+            Column(modifier = Modifier.fillMaxSize()) {
+                // Drag handle
+                Box(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Box(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = theme.screenPadding, vertical = 6.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                            .width(32.dp)
+                            .height(4.dp)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f))
+                    )
+                }
+
+                // Character name + keywords header
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = theme.screenPadding, vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(32.dp)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.surfaceVariant)
                     ) {
-                        Box(
-                            modifier = Modifier
-                                .size(32.dp)
-                                .clip(CircleShape)
-                                .background(MaterialTheme.colorScheme.surfaceVariant)
-                        ) {
-                            CharacterPortrait(character = character, size = 32.dp)
-                        }
-                        Column(modifier = Modifier.weight(1f)) {
+                        CharacterPortrait(character = character, size = 32.dp)
+                    }
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = character.name,
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.primary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        if (character.keywords.isNotEmpty()) {
                             Text(
-                                text = character.name,
-                                style = MaterialTheme.typography.titleSmall,
-                                fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.primary,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
+                                text = character.keywords.joinToString(", "),
+                                style = MaterialTheme.typography.labelSmall,
+                                fontStyle = FontStyle.Italic,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1
                             )
-                            if (character.keywords.isNotEmpty()) {
-                                Text(
-                                    text = character.keywords.joinToString(", "),
-                                    style = MaterialTheme.typography.labelSmall,
-                                    fontStyle = FontStyle.Italic,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    maxLines = 1
-                                )
-                            }
                         }
                     }
-                    HorizontalDivider()
+                }
+                HorizontalDivider()
 
-                    // Flip-animated card content (fills remaining space, pinned footer)
+                // Scrollable card content
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .verticalScroll(rememberScrollState())
+                ) {
                     CharacterCardContent(
                         character = character,
                         searchQuery = "",
                         isFlipped = playState.isFlipped,
                         onFlip = onFlip,
-                        modifier = Modifier.weight(1f).fillMaxWidth(),
+                        modifier = Modifier.fillMaxWidth(),
                         animateFlip = true,
                         showBackgroundImage = theme.showBackgroundImageOverlay,
                         showHealthTracker = true,
                         abilityUsedStates = if (isFullTracking && isEditable) playState.usedAbilities else null,
                         onAbilityUsedChange = if (isFullTracking && isEditable) onAbilityToggle else null,
-                        pinnedFooter = true,
-                        scrollable = true
+                        pinnedFooter = false,
+                        scrollable = false
                     )
+
+                    // Summons section
+                    if (isFullTracking && character.summonsCharacterIds.isNotEmpty()) {
+                        HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = theme.screenPadding, vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Box(modifier = Modifier.weight(1f).height(1.dp).background(MaterialTheme.colorScheme.outlineVariant))
+                            Text(
+                                "  SUMMONS  ",
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Box(modifier = Modifier.weight(1f).height(1.dp).background(MaterialTheme.colorScheme.outlineVariant))
+                        }
+                        character.summonsCharacterIds.forEach { summonId ->
+                            val summonChar = allCharacters.find { it.id == summonId } ?: return@forEach
+                            val isActive = activeSummons.any { it.characterId == summonId }
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = theme.screenPadding, vertical = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(36.dp)
+                                        .clip(CircleShape)
+                                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                                ) {
+                                    CharacterPortrait(summonChar, 36.dp)
+                                }
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        summonChar.name,
+                                        style = MaterialTheme.typography.labelMedium,
+                                        fontWeight = FontWeight.Bold,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                    Text(
+                                        "♥${summonChar.health}  ⚔${summonChar.melee}  ✦${summonChar.arcane}",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                                if (isActive) {
+                                    OutlinedButton(
+                                        onClick = { if (isEditable) onRemoveSummon(summonId) },
+                                        modifier = Modifier.height(30.dp),
+                                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+                                        enabled = isEditable
+                                    ) { Text("✓ Active", fontSize = 11.sp) }
+                                } else {
+                                    Button(
+                                        onClick = { if (isEditable) onAddSummon(summonId, character.id) },
+                                        modifier = Modifier.height(30.dp),
+                                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+                                        enabled = isEditable
+                                    ) { Text("Call to Battle", fontSize = 11.sp) }
+                                }
+                            }
+                        }
+                        Spacer(Modifier.height(8.dp))
+                    }
 
                     // Transform button
                     if (onTransform != null && character.transformsInto != null) {
@@ -1119,17 +1121,147 @@ private fun GameCharacterCardModal(
                     }
                 }
 
+                // Sticky tracking dock (FULL_TRACKING only)
+                if (isFullTracking) {
+                    HorizontalDivider()
+                    CharacterTrackingDock(
+                        character = character,
+                        playState = playState,
+                        isEditable = isEditable,
+                        onHealthChange = onHealthChange,
+                        onEnergyChange = onEnergyChange,
+                        onMoonstoneChange = onMoonstoneChange,
+                        onToggleActivated = onToggleActivated,
+                        onSetStatusToken = onSetStatusToken
+                    )
+                }
             }
         }
+    }
+}
 
-        Text(
-            text = "Tap outside to close",
-            style = MaterialTheme.typography.labelSmall,
-            color = Color.White.copy(alpha = 0.5f),
+@Composable
+private fun CharacterTrackingDock(
+    character: Character,
+    playState: CharacterPlayState,
+    isEditable: Boolean,
+    onHealthChange: (Int) -> Unit,
+    onEnergyChange: (Int) -> Unit,
+    onMoonstoneChange: (Int) -> Unit,
+    onToggleActivated: () -> Unit,
+    onSetStatusToken: (String, Boolean) -> Unit
+) {
+    val theme = LocalAppThemeProperties.current
+    val moonstoneColor = theme.moonstoneColor
+    var isExpanded by rememberSaveable { mutableStateOf(false) }
+
+    val summaryText = buildString {
+        append("♥ ${playState.currentHealth}/${character.health}")
+        if (playState.currentEnergy > 0) append("  ◆${playState.currentEnergy}")
+        if (playState.moonstones > 0) append("  ${"●".repeat(playState.moonstones)}")
+        if (playState.statusTokens["cursed"] == true) append("  cursed")
+        if (playState.isActivatedThisTurn) append("  used")
+    }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
             modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .padding(bottom = 12.dp)
-        )
+                .fillMaxWidth()
+                .clickable { isExpanded = !isExpanded }
+                .padding(horizontal = theme.screenPadding, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text("Tracking", style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.Bold, modifier = Modifier.widthIn(min = 70.dp))
+            Text(
+                summaryText,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.weight(1f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Icon(
+                imageVector = if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+
+        AnimatedVisibility(visible = isExpanded) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = theme.screenPadding)
+                    .padding(bottom = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                // Health stepper + progress bar
+                Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                        Text("♥ Health", style = MaterialTheme.typography.labelMedium, modifier = Modifier.weight(1f))
+                        IconButton(onClick = { if (playState.currentHealth > 0) onHealthChange(playState.currentHealth - 1) }, modifier = Modifier.size(32.dp), enabled = isEditable) {
+                            Icon(Icons.Default.Remove, null, Modifier.size(16.dp))
+                        }
+                        Text(
+                            "${playState.currentHealth} / ${character.health}",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.widthIn(min = 52.dp),
+                            textAlign = TextAlign.Center
+                        )
+                        IconButton(onClick = { if (playState.currentHealth < character.health) onHealthChange(playState.currentHealth + 1) }, modifier = Modifier.size(32.dp), enabled = isEditable) {
+                            Icon(Icons.Default.Add, null, Modifier.size(16.dp))
+                        }
+                    }
+                    LinearProgressIndicator(
+                        progress = { playState.currentHealth.toFloat() / character.health.coerceAtLeast(1) },
+                        modifier = Modifier.fillMaxWidth().height(3.dp).clip(CircleShape)
+                    )
+                }
+
+                // Energy stepper
+                Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    Text("◆ Energy", style = MaterialTheme.typography.labelMedium, modifier = Modifier.weight(1f))
+                    IconButton(onClick = { if (playState.currentEnergy > 0) onEnergyChange(playState.currentEnergy - 1) }, modifier = Modifier.size(32.dp), enabled = isEditable) {
+                        Icon(Icons.Default.Remove, null, Modifier.size(16.dp))
+                    }
+                    Text(playState.currentEnergy.toString(), style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Bold, modifier = Modifier.widthIn(min = 52.dp), textAlign = TextAlign.Center)
+                    IconButton(onClick = { onEnergyChange(playState.currentEnergy + 1) }, modifier = Modifier.size(32.dp), enabled = isEditable) {
+                        Icon(Icons.Default.Add, null, Modifier.size(16.dp))
+                    }
+                }
+
+                // Moonstones — 7 tappable circles
+                Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    Text("◉ Moonstones", style = MaterialTheme.typography.labelMedium, modifier = Modifier.weight(1f))
+                    Row(horizontalArrangement = Arrangement.spacedBy(5.dp)) {
+                        (1..7).forEach { i ->
+                            val filled = i <= playState.moonstones
+                            Box(
+                                modifier = Modifier
+                                    .size(20.dp)
+                                    .clip(CircleShape)
+                                    .background(if (filled) moonstoneColor else MaterialTheme.colorScheme.surfaceVariant)
+                                    .border(1.dp, moonstoneColor.copy(alpha = 0.6f), CircleShape)
+                                    .then(if (isEditable) Modifier.clickable { onMoonstoneChange(if (filled) i - 1 else i) } else Modifier)
+                            )
+                        }
+                    }
+                }
+
+                // Cursed toggle
+                Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    Text("✦ Cursed", style = MaterialTheme.typography.labelMedium, modifier = Modifier.weight(1f))
+                    Switch(checked = playState.statusTokens["cursed"] == true, onCheckedChange = { if (isEditable) onSetStatusToken("cursed", it) }, enabled = isEditable)
+                }
+
+                // Mark Used toggle
+                Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    Text("✓ Mark Used", style = MaterialTheme.typography.labelMedium, modifier = Modifier.weight(1f))
+                    Switch(checked = playState.isActivatedThisTurn, onCheckedChange = { if (isEditable) onToggleActivated() }, enabled = isEditable)
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
@@ -999,14 +999,14 @@ private fun GameCharacterCardModal(
             } // Column
         } // ThemedCard
 
-        // Tracking dock — always shown
+        // Tracking dock — always shown; card extends under the nav bar so
+        // the background fills the gesture region. Padding is applied inside.
         ThemedCard(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .fillMaxWidth()
                     .zIndex(200f)
                     .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
-                    .navigationBarsPadding()
                     .clickable {}
             ) {
                 CharacterTrackingDock(
@@ -1056,7 +1056,7 @@ private fun CharacterTrackingDock(
         if (activeSummonCount > 0) append("  ↳$activeSummonCount active")
     }
 
-    Column(modifier = Modifier.fillMaxWidth()) {
+    Column(modifier = Modifier.fillMaxWidth().navigationBarsPadding()) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
@@ -954,7 +954,7 @@ private fun GameCharacterCardModal(
         BoxWithConstraints(
             modifier = Modifier
                 .align(Alignment.Center)
-                .fillMaxWidth(0.94f)
+                .fillMaxWidth()
         ) {
             ThemedCard(
                 modifier = Modifier

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
@@ -1055,7 +1055,7 @@ private fun CharacterTrackingDock(
         if (activeSummonCount > 0) append("  ↳$activeSummonCount active")
     }
 
-    Column(modifier = Modifier.fillMaxWidth().navigationBarsPadding()) {
+    Column(modifier = Modifier.fillMaxWidth()) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -1215,6 +1215,9 @@ private fun CharacterTrackingDock(
                 }
             }
         }
+        // Fills the nav-bar inset so the card background extends behind the gesture bar
+        // without adding any visible gap above it.
+        Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
     }
 }
 

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
@@ -953,27 +953,12 @@ private fun GameCharacterCardModal(
 
         ThemedCard(
             modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .fillMaxWidth()
-                .fillMaxHeight(0.93f)
-                .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
+                .align(Alignment.Center)
+                .fillMaxWidth(0.94f)
+                .fillMaxHeight(0.88f)
                 .clickable {}
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
-                // Drag handle
-                Box(
-                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .width(32.dp)
-                            .height(4.dp)
-                            .clip(CircleShape)
-                            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f))
-                    )
-                }
-
                 // Character name + keywords header
                 Row(
                     modifier = Modifier
@@ -1121,20 +1106,29 @@ private fun GameCharacterCardModal(
                     }
                 }
 
-                // Sticky tracking dock (FULL_TRACKING only)
-                if (isFullTracking) {
-                    HorizontalDivider()
-                    CharacterTrackingDock(
-                        character = character,
-                        playState = playState,
-                        isEditable = isEditable,
-                        onHealthChange = onHealthChange,
-                        onEnergyChange = onEnergyChange,
-                        onMoonstoneChange = onMoonstoneChange,
-                        onToggleActivated = onToggleActivated,
-                        onSetStatusToken = onSetStatusToken
-                    )
-                }
+            }
+        }
+
+        // Tracking dock — floats over the card as a separate bottom sheet (FULL_TRACKING only)
+        if (isFullTracking) {
+            ThemedCard(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .zIndex(200f)
+                    .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
+                    .clickable {}
+            ) {
+                CharacterTrackingDock(
+                    character = character,
+                    playState = playState,
+                    isEditable = isEditable,
+                    onHealthChange = onHealthChange,
+                    onEnergyChange = onEnergyChange,
+                    onMoonstoneChange = onMoonstoneChange,
+                    onToggleActivated = onToggleActivated,
+                    onSetStatusToken = onSetStatusToken
+                )
             }
         }
     }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
@@ -188,9 +188,6 @@ fun ActiveGameScreen(
     val cols = adaptiveCols(totalChars)
     val portraitSize = adaptivePortraitSize(totalChars)
 
-    val trackingMode = state.gameTrackingMode
-    val isFullTracking = trackingMode == GameTrackingMode.FULL_TRACKING
-
     // Moonstone drag state
     var draggingStoneSource by remember { mutableStateOf<StoneSource?>(null) }
     var draggingStoneIndex by remember { mutableIntStateOf(-1) }
@@ -297,7 +294,6 @@ fun ActiveGameScreen(
                                     CharacterPortraitCell(
                                         character = char,
                                         playState = ps,
-                                        trackingMode = trackingMode,
                                         summoner = gridItem.summoner,
                                         isEditable = !isTutorialActive,
                                         isDormant = gridItem.isDormant,
@@ -347,8 +343,8 @@ fun ActiveGameScreen(
                 }
             }
 
-            // Melee combat reference FAB (LOW_DETAIL only — FULL_TRACKING has the pool bar)
-            if (!isFullTracking) {
+            // Melee combat reference FAB
+            run {
                 FloatingActionButton(
                     onClick = { showMeleeSheet = true },
                     modifier = Modifier
@@ -367,6 +363,7 @@ fun ActiveGameScreen(
             }
 
             // Card modal
+
             selectedCharInfo?.let { (pi, ci, char) ->
                 val ps = if (isTutorialActive) {
                     CharacterPlayState(currentHealth = char.health)
@@ -376,7 +373,6 @@ fun ActiveGameScreen(
                 GameCharacterCardModal(
                     character = char,
                     playState = ps,
-                    trackingMode = trackingMode,
                     isEditable = !isTutorialActive,
                     allCharacters = state.characters,
                     activeSummons = state.activeSummons[pi] ?: emptyList(),
@@ -439,26 +435,6 @@ fun ActiveGameScreen(
 }
 
 // ─── Summon helper ────────────────────────────────────────────────────────────
-
-private fun handleSummonAdd(
-    pageIndex: Int,
-    char: Character,
-    baseChars: List<Character>,
-    trackingMode: GameTrackingMode,
-    viewModel: CharacterViewModel,
-    onShowPicker: (SummonerPickerState) -> Unit
-) {
-    if (trackingMode == GameTrackingMode.LOW_DETAIL) {
-        viewModel.onEvent(CharacterEvent.AddSummonedCharacter(pageIndex, char.id, null))
-        return
-    }
-    val possibleSummoners = baseChars.filter { char.id in it.summonsCharacterIds }
-    when (possibleSummoners.size) {
-        0 -> viewModel.onEvent(CharacterEvent.AddSummonedCharacter(pageIndex, char.id, null))
-        1 -> viewModel.onEvent(CharacterEvent.AddSummonedCharacter(pageIndex, char.id, possibleSummoners[0].id))
-        else -> onShowPicker(SummonerPickerState(pageIndex, char, possibleSummoners))
-    }
-}
 
 // ─── Top bar ─────────────────────────────────────────────────────────────────
 
@@ -560,7 +536,6 @@ private fun ActiveGameTopBar(
 private fun CharacterPortraitCell(
     character: Character,
     playState: CharacterPlayState,
-    trackingMode: GameTrackingMode,
     summoner: Character?,
     isEditable: Boolean,
     isDormant: Boolean = false,
@@ -919,7 +894,6 @@ private fun GamePlayerSectionHeader(troupe: Troupe) {
 private fun GameCharacterCardModal(
     character: Character,
     playState: CharacterPlayState,
-    trackingMode: GameTrackingMode,
     isEditable: Boolean,
     allCharacters: List<Character>,
     activeSummons: List<SummonEntry>,
@@ -936,7 +910,6 @@ private fun GameCharacterCardModal(
     onDismiss: () -> Unit
 ) {
     val theme = LocalAppThemeProperties.current
-    val isFullTracking = trackingMode == GameTrackingMode.FULL_TRACKING
 
     Box(
         modifier = Modifier
@@ -1016,8 +989,8 @@ private fun GameCharacterCardModal(
                     animateFlip = true,
                     showBackgroundImage = theme.showBackgroundImageOverlay,
                     showHealthTracker = true,
-                    abilityUsedStates = if (isFullTracking && isEditable) playState.usedAbilities else null,
-                    onAbilityUsedChange = if (isFullTracking && isEditable) onAbilityToggle else null,
+                    abilityUsedStates = if (isEditable) playState.usedAbilities else null,
+                    onAbilityUsedChange = if (isEditable) onAbilityToggle else null,
                     pinnedFooter = true,
                     scrollable = true
                 )
@@ -1025,9 +998,8 @@ private fun GameCharacterCardModal(
             } // Column
         } // ThemedCard
 
-        // Tracking dock — shown when full-tracking active OR character has summons
-        if (isFullTracking || character.summonsCharacterIds.isNotEmpty()) {
-            ThemedCard(
+        // Tracking dock — always shown
+        ThemedCard(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .fillMaxWidth()
@@ -1039,7 +1011,6 @@ private fun GameCharacterCardModal(
                 CharacterTrackingDock(
                     character = character,
                     playState = playState,
-                    isFullTracking = isFullTracking,
                     isEditable = isEditable,
                     allCharacters = allCharacters,
                     activeSummons = activeSummons,
@@ -1052,7 +1023,6 @@ private fun GameCharacterCardModal(
                     onRemoveSummon = onRemoveSummon
                 )
             }
-        }
     }
 }
 
@@ -1060,7 +1030,6 @@ private fun GameCharacterCardModal(
 private fun CharacterTrackingDock(
     character: Character,
     playState: CharacterPlayState,
-    isFullTracking: Boolean,
     isEditable: Boolean,
     allCharacters: List<Character>,
     activeSummons: List<SummonEntry>,
@@ -1078,16 +1047,12 @@ private fun CharacterTrackingDock(
 
     val activeSummonCount = activeSummons.count { e -> character.summonsCharacterIds.contains(e.characterId) }
     val summaryText = buildString {
-        if (isFullTracking) {
-            append("♥ ${playState.currentHealth}/${character.health}")
-            if (playState.currentEnergy > 0) append("  ◆${playState.currentEnergy}")
-            if (playState.moonstones > 0) append("  ${"●".repeat(playState.moonstones)}")
-            if (playState.statusTokens["cursed"] == true) append("  cursed")
-            if (playState.isActivatedThisTurn) append("  used")
-            if (activeSummonCount > 0) append("  ↳$activeSummonCount active")
-        } else if (character.summonsCharacterIds.isNotEmpty()) {
-            append("↳ $activeSummonCount/${character.summonsCharacterIds.size} summoned")
-        }
+        append("♥ ${playState.currentHealth}/${character.health}")
+        if (playState.currentEnergy > 0) append("  ◆${playState.currentEnergy}")
+        if (playState.moonstones > 0) append("  ${"●".repeat(playState.moonstones)}")
+        if (playState.statusTokens["cursed"] == true) append("  cursed")
+        if (playState.isActivatedThisTurn) append("  used")
+        if (activeSummonCount > 0) append("  ↳$activeSummonCount active")
     }
 
     Column(modifier = Modifier.fillMaxWidth()) {
@@ -1114,7 +1079,7 @@ private fun CharacterTrackingDock(
             )
         }
 
-        if (isFullTracking) AnimatedVisibility(visible = isExpanded) {
+        AnimatedVisibility(visible = isExpanded) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -1194,7 +1159,7 @@ private fun CharacterTrackingDock(
         if (character.summonsCharacterIds.isNotEmpty()) {
             AnimatedVisibility(visible = isExpanded) {
                 Column(modifier = Modifier.fillMaxWidth()) {
-                    if (isFullTracking) HorizontalDivider(modifier = Modifier.padding(horizontal = theme.screenPadding))
+                    HorizontalDivider(modifier = Modifier.padding(horizontal = theme.screenPadding))
                     character.summonsCharacterIds.forEach { summonId ->
                         val summonChar = allCharacters.find { it.id == summonId } ?: return@forEach
                         val isActive = activeSummons.any { it.characterId == summonId }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
@@ -1052,7 +1052,6 @@ private fun CharacterTrackingDock(
         if (playState.currentEnergy > 0) append("  ◆${playState.currentEnergy}")
         if (playState.moonstones > 0) append("  ${"●".repeat(playState.moonstones)}")
         if (playState.statusTokens["cursed"] == true) append("  cursed")
-        if (playState.isActivatedThisTurn) append("  used")
         if (activeSummonCount > 0) append("  ↳$activeSummonCount active")
     }
 
@@ -1061,8 +1060,9 @@ private fun CharacterTrackingDock(
             modifier = Modifier
                 .fillMaxWidth()
                 .clickable { isExpanded = !isExpanded }
-                .padding(horizontal = theme.screenPadding, vertical = 10.dp),
-            verticalAlignment = Alignment.CenterVertically
+                .padding(horizontal = theme.screenPadding, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             Text("Tracking", style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.Bold, modifier = Modifier.widthIn(min = 70.dp))
             Text(
@@ -1072,6 +1072,13 @@ private fun CharacterTrackingDock(
                 modifier = Modifier.weight(1f),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
+            )
+            FilterChip(
+                selected = playState.isActivatedThisTurn,
+                onClick = { if (isEditable) onToggleActivated() },
+                label = { Text(if (playState.isActivatedThisTurn) "✓ Used" else "Used", fontSize = 11.sp) },
+                modifier = Modifier.height(28.dp),
+                enabled = isEditable
             )
             Icon(
                 imageVector = if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
@@ -1146,12 +1153,6 @@ private fun CharacterTrackingDock(
                 Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
                     Text("✦ Cursed", style = MaterialTheme.typography.labelMedium, modifier = Modifier.weight(1f))
                     Switch(checked = playState.statusTokens["cursed"] == true, onCheckedChange = { if (isEditable) onSetStatusToken("cursed", it) }, enabled = isEditable)
-                }
-
-                // Mark Used toggle
-                Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                    Text("✓ Mark Used", style = MaterialTheme.typography.labelMedium, modifier = Modifier.weight(1f))
-                    Switch(checked = playState.isActivatedThisTurn, onCheckedChange = { if (isEditable) onToggleActivated() }, enabled = isEditable)
                 }
             }
         }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
@@ -264,11 +264,17 @@ fun ActiveGameScreen(
         },
         bottomBar = {}
     ) { padding ->
-        Box(modifier = Modifier.fillMaxSize().padding(padding).onGloballyPositioned { rootLayoutCoordinates = it }) {
+        // Only apply top padding (status/action bar); leave bottom open so the modal and
+        // tracking dock can extend behind the navigation bar (edge-to-edge is enabled).
+        Box(modifier = Modifier.fillMaxSize().padding(top = padding.calculateTopPadding()).onGloballyPositioned { rootLayoutCoordinates = it }) {
             LazyVerticalGrid(
                 columns = GridCells.Fixed(cols),
                 state = gridState,
-                contentPadding = PaddingValues(theme.screenPadding),
+                contentPadding = PaddingValues(
+                    start = theme.screenPadding, end = theme.screenPadding,
+                    top = theme.screenPadding,
+                    bottom = theme.screenPadding + WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+                ),
                 verticalArrangement = Arrangement.spacedBy(theme.verticalSpacing),
                 horizontalArrangement = Arrangement.spacedBy(theme.verticalSpacing),
                 modifier = Modifier.fillMaxSize()

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
@@ -1065,6 +1065,7 @@ private fun CharacterTrackingDock(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f))
                 .clickable { isExpanded = !isExpanded }
                 .padding(horizontal = theme.screenPadding, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
@@ -951,14 +951,18 @@ private fun GameCharacterCardModal(
                 .clickable { onDismiss() }
         )
 
-        ThemedCard(
+        BoxWithConstraints(
             modifier = Modifier
                 .align(Alignment.Center)
                 .fillMaxWidth(0.94f)
-                .fillMaxHeight(0.88f)
-                .clickable {}
         ) {
-            Column(modifier = Modifier.fillMaxSize()) {
+            ThemedCard(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = maxHeight * 0.88f)
+                    .clickable {}
+            ) {
+            Column(modifier = Modifier.fillMaxWidth()) {
                 // Character name + keywords header
                 Row(
                     modifier = Modifier
@@ -1000,7 +1004,7 @@ private fun GameCharacterCardModal(
                 // Scrollable card content
                 Column(
                     modifier = Modifier
-                        .weight(1f)
+                        .fillMaxWidth()
                         .verticalScroll(rememberScrollState())
                 ) {
                     CharacterCardContent(
@@ -1106,8 +1110,9 @@ private fun GameCharacterCardModal(
                     }
                 }
 
-            }
-        }
+            } // Column
+            } // ThemedCard
+        } // BoxWithConstraints
 
         // Tracking dock — floats over the card as a separate bottom sheet (FULL_TRACKING only)
         if (isFullTracking) {
@@ -1117,6 +1122,7 @@ private fun GameCharacterCardModal(
                     .fillMaxWidth()
                     .zIndex(200f)
                     .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
+                    .navigationBarsPadding()
                     .clickable {}
             ) {
                 CharacterTrackingDock(

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
@@ -951,18 +951,14 @@ private fun GameCharacterCardModal(
                 .clickable { onDismiss() }
         )
 
-        BoxWithConstraints(
+        ThemedCard(
             modifier = Modifier
                 .align(Alignment.Center)
                 .fillMaxWidth()
+                .fillMaxHeight(0.88f)
+                .clickable {}
         ) {
-            ThemedCard(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(max = maxHeight * 0.88f)
-                    .clickable {}
-            ) {
-            Column(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.fillMaxSize()) {
                 // Character name + keywords header
                 Row(
                     modifier = Modifier
@@ -998,121 +994,91 @@ private fun GameCharacterCardModal(
                             )
                         }
                     }
+                    if (onTransform != null && character.transformsInto != null) {
+                        IconButton(
+                            onClick = { if (isEditable) onTransform(character.transformsInto) },
+                            modifier = Modifier.size(32.dp),
+                            enabled = isEditable
+                        ) {
+                            Icon(Icons.Default.AutoAwesome, contentDescription = "Transform", modifier = Modifier.size(16.dp), tint = MaterialTheme.colorScheme.primary)
+                        }
+                    }
                 }
                 HorizontalDivider()
 
-                // Scrollable card content
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .verticalScroll(rememberScrollState())
-                ) {
-                    CharacterCardContent(
-                        character = character,
-                        searchQuery = "",
-                        isFlipped = playState.isFlipped,
-                        onFlip = onFlip,
-                        modifier = Modifier.fillMaxWidth(),
-                        animateFlip = true,
-                        showBackgroundImage = theme.showBackgroundImageOverlay,
-                        showHealthTracker = true,
-                        abilityUsedStates = if (isFullTracking && isEditable) playState.usedAbilities else null,
-                        onAbilityUsedChange = if (isFullTracking && isEditable) onAbilityToggle else null,
-                        pinnedFooter = false,
-                        scrollable = false
-                    )
+                // Card content fills remaining space; background art expands naturally
+                CharacterCardContent(
+                    character = character,
+                    searchQuery = "",
+                    isFlipped = playState.isFlipped,
+                    onFlip = onFlip,
+                    modifier = Modifier.weight(1f).fillMaxWidth(),
+                    animateFlip = true,
+                    showBackgroundImage = theme.showBackgroundImageOverlay,
+                    showHealthTracker = true,
+                    abilityUsedStates = if (isFullTracking && isEditable) playState.usedAbilities else null,
+                    onAbilityUsedChange = if (isFullTracking && isEditable) onAbilityToggle else null,
+                    pinnedFooter = true,
+                    scrollable = true
+                )
 
-                    // Summons section
-                    if (isFullTracking && character.summonsCharacterIds.isNotEmpty()) {
-                        HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
+                // Summons section — compact strip pinned below card content
+                if (character.summonsCharacterIds.isNotEmpty()) {
+                    HorizontalDivider()
+                    character.summonsCharacterIds.forEach { summonId ->
+                        val summonChar = allCharacters.find { it.id == summonId } ?: return@forEach
+                        val isActive = activeSummons.any { it.characterId == summonId }
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(horizontal = theme.screenPadding, vertical = 6.dp),
-                            verticalAlignment = Alignment.CenterVertically
+                                .padding(horizontal = theme.screenPadding, vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
-                            Box(modifier = Modifier.weight(1f).height(1.dp).background(MaterialTheme.colorScheme.outlineVariant))
-                            Text(
-                                "  SUMMONS  ",
-                                style = MaterialTheme.typography.labelSmall,
-                                fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                            Box(modifier = Modifier.weight(1f).height(1.dp).background(MaterialTheme.colorScheme.outlineVariant))
-                        }
-                        character.summonsCharacterIds.forEach { summonId ->
-                            val summonChar = allCharacters.find { it.id == summonId } ?: return@forEach
-                            val isActive = activeSummons.any { it.characterId == summonId }
-                            Row(
+                            Box(
                                 modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = theme.screenPadding, vertical = 4.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                    .size(36.dp)
+                                    .clip(CircleShape)
+                                    .background(MaterialTheme.colorScheme.surfaceVariant)
                             ) {
-                                Box(
-                                    modifier = Modifier
-                                        .size(36.dp)
-                                        .clip(CircleShape)
-                                        .background(MaterialTheme.colorScheme.surfaceVariant)
-                                ) {
-                                    CharacterPortrait(summonChar, 36.dp)
-                                }
-                                Column(modifier = Modifier.weight(1f)) {
-                                    Text(
-                                        summonChar.name,
-                                        style = MaterialTheme.typography.labelMedium,
-                                        fontWeight = FontWeight.Bold,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis
-                                    )
-                                    Text(
-                                        "♥${summonChar.health}  ⚔${summonChar.melee}  ✦${summonChar.arcane}",
-                                        style = MaterialTheme.typography.labelSmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
-                                }
-                                if (isActive) {
-                                    OutlinedButton(
-                                        onClick = { if (isEditable) onRemoveSummon(summonId) },
-                                        modifier = Modifier.height(30.dp),
-                                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
-                                        enabled = isEditable
-                                    ) { Text("✓ Active", fontSize = 11.sp) }
-                                } else {
-                                    Button(
-                                        onClick = { if (isEditable) onAddSummon(summonId, character.id) },
-                                        modifier = Modifier.height(30.dp),
-                                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
-                                        enabled = isEditable
-                                    ) { Text("Call to Battle", fontSize = 11.sp) }
-                                }
+                                CharacterPortrait(summonChar, 36.dp)
+                            }
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    summonChar.name,
+                                    style = MaterialTheme.typography.labelMedium,
+                                    fontWeight = FontWeight.Bold,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                                Text(
+                                    "♥${summonChar.health}  ⚔${summonChar.melee}  ✦${summonChar.arcane}",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                            if (isActive) {
+                                OutlinedButton(
+                                    onClick = { if (isEditable) onRemoveSummon(summonId) },
+                                    modifier = Modifier.height(30.dp),
+                                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+                                    enabled = isEditable
+                                ) { Text("✓ Active", fontSize = 11.sp) }
+                            } else {
+                                Button(
+                                    onClick = { if (isEditable) onAddSummon(summonId, character.id) },
+                                    modifier = Modifier.height(30.dp),
+                                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+                                    enabled = isEditable
+                                ) { Text("Call to Battle", fontSize = 11.sp) }
                             }
                         }
-                        Spacer(Modifier.height(8.dp))
                     }
-
-                    // Transform button
-                    if (onTransform != null && character.transformsInto != null) {
-                        HorizontalDivider()
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clip(MaterialTheme.shapes.small)
-                                .clickable(enabled = isEditable) { onTransform(character.transformsInto) }
-                                .padding(vertical = 8.dp, horizontal = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Icon(Icons.Default.AutoAwesome, contentDescription = null, modifier = Modifier.size(16.dp), tint = MaterialTheme.colorScheme.primary)
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text("Transform", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
-                        }
-                    }
+                    Spacer(Modifier.height(4.dp))
                 }
 
             } // Column
-            } // ThemedCard
-        } // BoxWithConstraints
+        } // ThemedCard
 
         // Tracking dock — floats over the card as a separate bottom sheet (FULL_TRACKING only)
         if (isFullTracking) {

--- a/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/ActiveGameScreen.kt
@@ -1022,66 +1022,11 @@ private fun GameCharacterCardModal(
                     scrollable = true
                 )
 
-                // Summons section — compact strip pinned below card content
-                if (character.summonsCharacterIds.isNotEmpty()) {
-                    HorizontalDivider()
-                    character.summonsCharacterIds.forEach { summonId ->
-                        val summonChar = allCharacters.find { it.id == summonId } ?: return@forEach
-                        val isActive = activeSummons.any { it.characterId == summonId }
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = theme.screenPadding, vertical = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            Box(
-                                modifier = Modifier
-                                    .size(36.dp)
-                                    .clip(CircleShape)
-                                    .background(MaterialTheme.colorScheme.surfaceVariant)
-                            ) {
-                                CharacterPortrait(summonChar, 36.dp)
-                            }
-                            Column(modifier = Modifier.weight(1f)) {
-                                Text(
-                                    summonChar.name,
-                                    style = MaterialTheme.typography.labelMedium,
-                                    fontWeight = FontWeight.Bold,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis
-                                )
-                                Text(
-                                    "♥${summonChar.health}  ⚔${summonChar.melee}  ✦${summonChar.arcane}",
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
-                            if (isActive) {
-                                OutlinedButton(
-                                    onClick = { if (isEditable) onRemoveSummon(summonId) },
-                                    modifier = Modifier.height(30.dp),
-                                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
-                                    enabled = isEditable
-                                ) { Text("✓ Active", fontSize = 11.sp) }
-                            } else {
-                                Button(
-                                    onClick = { if (isEditable) onAddSummon(summonId, character.id) },
-                                    modifier = Modifier.height(30.dp),
-                                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
-                                    enabled = isEditable
-                                ) { Text("Call to Battle", fontSize = 11.sp) }
-                            }
-                        }
-                    }
-                    Spacer(Modifier.height(4.dp))
-                }
-
             } // Column
         } // ThemedCard
 
-        // Tracking dock — floats over the card as a separate bottom sheet (FULL_TRACKING only)
-        if (isFullTracking) {
+        // Tracking dock — shown when full-tracking active OR character has summons
+        if (isFullTracking || character.summonsCharacterIds.isNotEmpty()) {
             ThemedCard(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
@@ -1094,12 +1039,17 @@ private fun GameCharacterCardModal(
                 CharacterTrackingDock(
                     character = character,
                     playState = playState,
+                    isFullTracking = isFullTracking,
                     isEditable = isEditable,
+                    allCharacters = allCharacters,
+                    activeSummons = activeSummons,
                     onHealthChange = onHealthChange,
                     onEnergyChange = onEnergyChange,
                     onMoonstoneChange = onMoonstoneChange,
                     onToggleActivated = onToggleActivated,
-                    onSetStatusToken = onSetStatusToken
+                    onSetStatusToken = onSetStatusToken,
+                    onAddSummon = onAddSummon,
+                    onRemoveSummon = onRemoveSummon
                 )
             }
         }
@@ -1110,23 +1060,34 @@ private fun GameCharacterCardModal(
 private fun CharacterTrackingDock(
     character: Character,
     playState: CharacterPlayState,
+    isFullTracking: Boolean,
     isEditable: Boolean,
+    allCharacters: List<Character>,
+    activeSummons: List<SummonEntry>,
     onHealthChange: (Int) -> Unit,
     onEnergyChange: (Int) -> Unit,
     onMoonstoneChange: (Int) -> Unit,
     onToggleActivated: () -> Unit,
-    onSetStatusToken: (String, Boolean) -> Unit
+    onSetStatusToken: (String, Boolean) -> Unit,
+    onAddSummon: (Int, Int?) -> Unit,
+    onRemoveSummon: (Int) -> Unit
 ) {
     val theme = LocalAppThemeProperties.current
     val moonstoneColor = theme.moonstoneColor
     var isExpanded by rememberSaveable { mutableStateOf(false) }
 
+    val activeSummonCount = activeSummons.count { e -> character.summonsCharacterIds.contains(e.characterId) }
     val summaryText = buildString {
-        append("♥ ${playState.currentHealth}/${character.health}")
-        if (playState.currentEnergy > 0) append("  ◆${playState.currentEnergy}")
-        if (playState.moonstones > 0) append("  ${"●".repeat(playState.moonstones)}")
-        if (playState.statusTokens["cursed"] == true) append("  cursed")
-        if (playState.isActivatedThisTurn) append("  used")
+        if (isFullTracking) {
+            append("♥ ${playState.currentHealth}/${character.health}")
+            if (playState.currentEnergy > 0) append("  ◆${playState.currentEnergy}")
+            if (playState.moonstones > 0) append("  ${"●".repeat(playState.moonstones)}")
+            if (playState.statusTokens["cursed"] == true) append("  cursed")
+            if (playState.isActivatedThisTurn) append("  used")
+            if (activeSummonCount > 0) append("  ↳$activeSummonCount active")
+        } else if (character.summonsCharacterIds.isNotEmpty()) {
+            append("↳ $activeSummonCount/${character.summonsCharacterIds.size} summoned")
+        }
     }
 
     Column(modifier = Modifier.fillMaxWidth()) {
@@ -1153,7 +1114,7 @@ private fun CharacterTrackingDock(
             )
         }
 
-        AnimatedVisibility(visible = isExpanded) {
+        if (isFullTracking) AnimatedVisibility(visible = isExpanded) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -1225,6 +1186,65 @@ private fun CharacterTrackingDock(
                 Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
                     Text("✓ Mark Used", style = MaterialTheme.typography.labelMedium, modifier = Modifier.weight(1f))
                     Switch(checked = playState.isActivatedThisTurn, onCheckedChange = { if (isEditable) onToggleActivated() }, enabled = isEditable)
+                }
+            }
+        }
+
+        // Summons section — shown when expanded, gated by character having summons
+        if (character.summonsCharacterIds.isNotEmpty()) {
+            AnimatedVisibility(visible = isExpanded) {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    if (isFullTracking) HorizontalDivider(modifier = Modifier.padding(horizontal = theme.screenPadding))
+                    character.summonsCharacterIds.forEach { summonId ->
+                        val summonChar = allCharacters.find { it.id == summonId } ?: return@forEach
+                        val isActive = activeSummons.any { it.characterId == summonId }
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = theme.screenPadding, vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .size(36.dp)
+                                    .clip(CircleShape)
+                                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                            ) {
+                                CharacterPortrait(summonChar, 36.dp)
+                            }
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    summonChar.name,
+                                    style = MaterialTheme.typography.labelMedium,
+                                    fontWeight = FontWeight.Bold,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                                Text(
+                                    "♥${summonChar.health}  ⚔${summonChar.melee}  ✦${summonChar.arcane}",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                            if (isActive) {
+                                OutlinedButton(
+                                    onClick = { if (isEditable) onRemoveSummon(summonId) },
+                                    modifier = Modifier.height(30.dp),
+                                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+                                    enabled = isEditable
+                                ) { Text("✓ Active", fontSize = 11.sp) }
+                            } else {
+                                Button(
+                                    onClick = { if (isEditable) onAddSummon(summonId, character.id) },
+                                    modifier = Modifier.height(30.dp),
+                                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+                                    enabled = isEditable
+                                ) { Text("Call to Battle", fontSize = 11.sp) }
+                            }
+                        }
+                    }
+                    Spacer(Modifier.height(8.dp))
                 }
             }
         }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -1043,7 +1043,7 @@ fun CharacterCardContent(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clickable { onFlip() }
-                                .padding(top = 4.dp, bottom = 14.dp, start = 16.dp, end = 16.dp),
+                                .padding(top = 4.dp, bottom = 6.dp, start = 16.dp, end = 16.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Text(

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -1043,7 +1043,7 @@ fun CharacterCardContent(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clickable { onFlip() }
-                                .padding(vertical = 4.dp, horizontal = 16.dp),
+                                .padding(top = 4.dp, bottom = 14.dp, start = 16.dp, end = 16.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Text(

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -502,7 +502,7 @@ fun CommonStatBox(label: String, value: String, modifier: Modifier = Modifier, h
 fun CommonAbilityItem(name: String, description: String, searchQuery: String = "", oncePerTurn: Boolean = false, oncePerGame: Boolean = false, reloadable: Boolean = false, isUsed: Boolean = false, onUsedChange: ((Boolean) -> Unit)? = null, isEditable: Boolean = true, passive: Boolean = false, showColon: Boolean = true) {
     val theme = LocalAppThemeProperties.current
     if (passive) {
-        Row(modifier = Modifier.padding(vertical = theme.verticalSpacing / 4), verticalAlignment = Alignment.CenterVertically) {
+        Row(modifier = Modifier.padding(vertical = theme.verticalSpacing / 2), verticalAlignment = Alignment.CenterVertically) {
             Text(
                 text = buildAnnotatedString {
                     withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) { appendWithHighlight(name, searchQuery); append(": ") }
@@ -520,7 +520,7 @@ fun CommonAbilityItem(name: String, description: String, searchQuery: String = "
             }
         }
     } else {
-        Column(modifier = Modifier.padding(vertical = theme.verticalSpacing / 4)) {
+        Column(modifier = Modifier.padding(vertical = theme.verticalSpacing / 2)) {
             Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
                 val title = buildAnnotatedString {
                     withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
@@ -562,7 +562,7 @@ fun CharacterFront(
             CommonStatBox("Arcane", character.arcane.toString(), showDivider = true)
             CommonStatBox("Evade", character.evade.toString(), showDivider = true)
         }
-        Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+        Spacer(modifier = Modifier.height(theme.verticalSpacing))
         val passiveAbilities = character.abilities.filter { it.abilityType == "Passive" }
         val activeAbilities = character.abilities.filter { it.abilityType == "Active" }
         val arcaneAbilities = character.abilities.filter { it.abilityType == "Arcane" }
@@ -610,7 +610,7 @@ fun CharacterFront(
         }
         if (showSignatureLink) {
             character.signatureMove?.let { sigMove ->
-                Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+                Spacer(modifier = Modifier.height(theme.verticalSpacing))
                 Row(
                     modifier = Modifier.fillMaxWidth().clickable { onFlip() }.onGloballyPositioned { onFlipPositioned(it) },
                     verticalAlignment = Alignment.CenterVertically
@@ -618,7 +618,7 @@ fun CharacterFront(
                     Text(text = buildAnnotatedString { append(if (theme.showExpandedStatsHeader) "Signature Move on a " else "Signature Move: "); withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { appendWithHighlight(if (theme.showExpandedStatsHeader) sigMove.upgradeFor else sigMove.name, searchQuery) }; append(".") }, style = MaterialTheme.typography.bodyMedium, fontStyle = FontStyle.Italic, modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.secondary)
                     Icon(imageVector = Icons.Default.KeyboardArrowRight, contentDescription = "View signature move", modifier = Modifier.size(16.dp), tint = MaterialTheme.colorScheme.secondary)
                 }
-                Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
+                Spacer(modifier = Modifier.height(theme.verticalSpacing))
             }
         }
         if (showHealthTracker) {
@@ -1202,7 +1202,7 @@ fun CampaignCardUI(card: CampaignCard, searchQuery: String, isExpanded: Boolean,
 @Composable
 fun AbilityTypeSeparator() {
     val theme = LocalAppThemeProperties.current
-    Box(modifier = Modifier.fillMaxWidth().padding(vertical = theme.verticalSpacing / 4), contentAlignment = Alignment.Center) {
+    Box(modifier = Modifier.fillMaxWidth().padding(vertical = theme.verticalSpacing / 2), contentAlignment = Alignment.Center) {
         HorizontalDivider(modifier = Modifier.fillMaxWidth(0.6f), thickness = 1.dp, color = MaterialTheme.colorScheme.primary.copy(alpha = if (theme.showExpandedStatsHeader) 0.3f else 0.1f))
     }
 }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -1043,7 +1043,7 @@ fun CharacterCardContent(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clickable { onFlip() }
-                                .padding(top = 4.dp, bottom = 6.dp, start = 16.dp, end = 16.dp),
+                                .padding(top = 4.dp, bottom = 14.dp, start = 16.dp, end = 16.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Text(

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -537,7 +537,7 @@ fun CommonAbilityItem(name: String, description: String, searchQuery: String = "
                     }
                 }
             }
-            Text(text = parseAbilityDescription(description, searchQuery), style = MaterialTheme.typography.bodyMedium, inlineContent = getMoonstoneInlineContent())
+            Text(text = parseAbilityDescription(description, searchQuery), style = MaterialTheme.typography.bodySmall, inlineContent = getMoonstoneInlineContent())
         }
     }
 }
@@ -562,7 +562,6 @@ fun CharacterFront(
             CommonStatBox("Arcane", character.arcane.toString(), showDivider = true)
             CommonStatBox("Evade", character.evade.toString(), showDivider = true)
         }
-        Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
         val passiveAbilities = character.abilities.filter { it.abilityType == "Passive" }
         val activeAbilities = character.abilities.filter { it.abilityType == "Active" }
         val arcaneAbilities = character.abilities.filter { it.abilityType == "Arcane" }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -509,7 +509,7 @@ fun CommonAbilityItem(name: String, description: String, searchQuery: String = "
                     append(parseAbilityDescription(description, searchQuery))
                     if (oncePerGame) withStyle(style = SpanStyle(fontStyle = FontStyle.Italic)) { append(if (reloadable) " Once per game, unless reloaded." else " Once per game.") }
                 },
-                style = MaterialTheme.typography.bodySmall,
+                style = MaterialTheme.typography.bodyMedium,
                 modifier = Modifier.weight(1f),
                 inlineContent = getMoonstoneInlineContent()
             )
@@ -537,7 +537,7 @@ fun CommonAbilityItem(name: String, description: String, searchQuery: String = "
                     }
                 }
             }
-            Text(text = parseAbilityDescription(description, searchQuery), style = MaterialTheme.typography.bodySmall, inlineContent = getMoonstoneInlineContent())
+            Text(text = parseAbilityDescription(description, searchQuery), style = MaterialTheme.typography.bodyMedium, inlineContent = getMoonstoneInlineContent())
         }
     }
 }
@@ -562,7 +562,7 @@ fun CharacterFront(
             CommonStatBox("Arcane", character.arcane.toString(), showDivider = true)
             CommonStatBox("Evade", character.evade.toString(), showDivider = true)
         }
-        Spacer(modifier = Modifier.height(theme.verticalSpacing))
+        Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
         val passiveAbilities = character.abilities.filter { it.abilityType == "Passive" }
         val activeAbilities = character.abilities.filter { it.abilityType == "Active" }
         val arcaneAbilities = character.abilities.filter { it.abilityType == "Arcane" }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/CommonComponents.kt
@@ -499,7 +499,7 @@ fun CommonStatBox(label: String, value: String, modifier: Modifier = Modifier, h
 }
 
 @Composable
-fun CommonAbilityItem(name: String, description: String, searchQuery: String = "", oncePerTurn: Boolean = false, oncePerGame: Boolean = false, reloadable: Boolean = false, isUsed: Boolean = false, onUsedChange: ((Boolean) -> Unit)? = null, isEditable: Boolean = true, passive: Boolean = false, showColon: Boolean = true) {
+fun CommonAbilityItem(name: String, description: String, searchQuery: String = "", oncePerTurn: Boolean = false, oncePerGame: Boolean = false, reloadable: Boolean = false, isUsed: Boolean = false, onUsedChange: ((Boolean) -> Unit)? = null, isEditable: Boolean = true, passive: Boolean = false, showColon: Boolean = true, descriptionStyle: androidx.compose.ui.text.TextStyle = MaterialTheme.typography.bodySmall) {
     val theme = LocalAppThemeProperties.current
     if (passive) {
         Row(modifier = Modifier.padding(vertical = theme.verticalSpacing / 2), verticalAlignment = Alignment.CenterVertically) {
@@ -509,7 +509,7 @@ fun CommonAbilityItem(name: String, description: String, searchQuery: String = "
                     append(parseAbilityDescription(description, searchQuery))
                     if (oncePerGame) withStyle(style = SpanStyle(fontStyle = FontStyle.Italic)) { append(if (reloadable) " Once per game, unless reloaded." else " Once per game.") }
                 },
-                style = MaterialTheme.typography.bodyMedium,
+                style = descriptionStyle,
                 modifier = Modifier.weight(1f),
                 inlineContent = getMoonstoneInlineContent()
             )
@@ -537,7 +537,7 @@ fun CommonAbilityItem(name: String, description: String, searchQuery: String = "
                     }
                 }
             }
-            Text(text = parseAbilityDescription(description, searchQuery), style = MaterialTheme.typography.bodySmall, inlineContent = getMoonstoneInlineContent())
+            Text(text = parseAbilityDescription(description, searchQuery), style = descriptionStyle, inlineContent = getMoonstoneInlineContent())
         }
     }
 }
@@ -554,6 +554,8 @@ fun CharacterFront(
     onAbilityUsedChange: ((String, Boolean) -> Unit)? = null
 ) {
     val theme = LocalAppThemeProperties.current
+    val abilityDescStyle = if (character.abilities.sumOf { it.description.length } < 500)
+        MaterialTheme.typography.bodyMedium else MaterialTheme.typography.bodySmall
     Column {
         if (theme.showExpandedStatsHeader) MoonstoneStats(character)
         else Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
@@ -576,7 +578,8 @@ fun CharacterFront(
                 passive = true,
                 isUsed = abilityUsedStates?.get(ability.name) ?: false,
                 onUsedChange = if (abilityUsedStates != null) { used -> onAbilityUsedChange?.invoke(ability.name, used) } else null,
-                isEditable = abilityUsedStates != null
+                isEditable = abilityUsedStates != null,
+                descriptionStyle = abilityDescStyle
             )
         }
         if (activeAbilities.isNotEmpty()) {
@@ -589,7 +592,8 @@ fun CharacterFront(
                     showColon = false,
                     isUsed = abilityUsedStates?.get(ability.name) ?: false,
                     onUsedChange = if (abilityUsedStates != null) { used -> onAbilityUsedChange?.invoke(ability.name, used) } else null,
-                    isEditable = abilityUsedStates != null
+                    isEditable = abilityUsedStates != null,
+                    descriptionStyle = abilityDescStyle
                 )
             }
         }
@@ -603,7 +607,8 @@ fun CharacterFront(
                     showColon = false,
                     isUsed = abilityUsedStates?.get(ability.name) ?: false,
                     onUsedChange = if (abilityUsedStates != null) { used -> onAbilityUsedChange?.invoke(ability.name, used) } else null,
-                    isEditable = abilityUsedStates != null
+                    isEditable = abilityUsedStates != null,
+                    descriptionStyle = abilityDescStyle
                 )
             }
         }

--- a/app/src/main/java/io/github/garemat/lunachron/ui/SettingsScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/SettingsScreen.kt
@@ -20,7 +20,6 @@ import io.github.garemat.lunachron.ui.theme.ThemeRepository
 import io.github.garemat.lunachron.BuildConfig
 import io.github.garemat.lunachron.CharacterState
 import io.github.garemat.lunachron.CardDisplayMode
-import io.github.garemat.lunachron.GameTrackingMode
 import io.github.garemat.lunachron.ImageDownloadPreference
 import io.github.garemat.lunachron.InstallerSource
 import io.github.garemat.lunachron.LayoutDensity
@@ -165,37 +164,6 @@ fun SettingsScreen(
                         theme = theme
                     )
                 }
-            }
-
-            Spacer(modifier = Modifier.height(theme.verticalSpacing))
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-            Spacer(modifier = Modifier.height(theme.verticalSpacing))
-
-            Text("Game View", style = theme.titleStyle.copy(fontSize = 20.sp), color = MaterialTheme.colorScheme.primary)
-            Spacer(modifier = Modifier.height(theme.verticalSpacing / 2))
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable {
-                        val newMode = if (state.gameTrackingMode == GameTrackingMode.FULL_TRACKING)
-                            GameTrackingMode.LOW_DETAIL else GameTrackingMode.FULL_TRACKING
-                        onEvent(CharacterEvent.ChangeGameTrackingMode(newMode))
-                    }
-                    .padding(vertical = theme.verticalSpacing / 4),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text("Enable resource tracking", style = theme.headerStyle.copy(fontSize = 18.sp))
-                    Text("Track energy, moonstones, and ability used markers in the app.", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                }
-                Switch(
-                    checked = state.gameTrackingMode == GameTrackingMode.FULL_TRACKING,
-                    onCheckedChange = { enabled ->
-                        onEvent(CharacterEvent.ChangeGameTrackingMode(if (enabled) GameTrackingMode.FULL_TRACKING else GameTrackingMode.LOW_DETAIL))
-                    }
-                )
             }
 
             Spacer(modifier = Modifier.height(theme.verticalSpacing))


### PR DESCRIPTION
## Summary

- **Unified portrait grid** with adaptive column count (2-col for ≤8 chars, 3-col for 9+); removed `GameLayoutMode` distinction
- **Health in stat line** — `♥ HP` shown directly in every card's stat pill alongside attack/range/arcane/evade; adaptive spacing auto-selects wide or compact format based on available card width at runtime
- **Per-character tracking dock** — bottom-anchored sheet that slides up from any portrait tap; health/energy/moonstone counters, curse toggle, and a "Mark Used" chip in the header for one-tap access without expanding
- **Dormant summon cards** — summoner characters' summons appear as greyed-out dormant cards in the grid; tap to activate, auto-revert to dormant when HP hits 0
- **Edge-to-edge layout** — tracking dock extends behind the navigation bar with a `windowInsetsBottomHeight` spacer; grid bottom padding accounts for nav bar height
- **Removed tracking mode toggle from Settings** — full tracking is always on; `GameTrackingMode` enum retained but no longer switched
- **Quick Start crash fix** — `startNewGame` now resets `gameSession` and `poolResourceCounts`; navigate call uses `popUpTo` to clear stale back-stack entries

## Test plan

- [ ] Start a game with a troupe that includes a summoner (Boris) — summon cards appear dormant in the grid
- [ ] Tap a dormant summon card — activates and opens card modal
- [ ] Reduce summon HP to 0 — card reverts to dormant (no skull overlay)
- [ ] Tap any character — tracking dock appears collapsed; expand to show health/energy/moon/curse rows
- [ ] Tap "Used" chip in dock header without expanding — `✓` badge appears on grid card immediately
- [ ] Apply curse toggle — purple badge appears on grid card
- [ ] Advance turn — "Used" badges clear across all characters
- [ ] 7+ character game (6 base + 1 summon): stat lines readable without truncation; single-digit health cards use wide spacing, double-digit cards use compact spacing
- [ ] Quick Start from home screen with an existing game in progress — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)