### PR TITLE
feat: in-game campaign card MP and Wizard Chamberlain point adjustments

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
@@ -143,6 +143,15 @@ sealed interface CharacterEvent {
     data class UpdateOnlineRankings(val campaignId: String) : CharacterEvent
     data class AdvanceOnlineRound(val campaignId: String) : CharacterEvent
 
+    // LunaChron API — host point adjustment (Wizard Chamberlain)
+    data class AdjustPlayerPoints(
+        val campaignId: String,
+        val targetDeviceId: String,
+        val mpDelta: Int,
+        val vpDelta: Int,
+        val note: String
+    ) : CharacterEvent
+
     // LunaChron API — match result recording
     data class SubmitOnlineMatchResult(
         val campaignId: String,

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
@@ -151,7 +151,11 @@ data class OnlineCampaignMember(
     val victoryPoints: Int = 0,
     val matchPoints: Int = 0,
     val powerPoints: Int = 0,
-    val bonusMp: Int = 0
+    val bonusMp: Int = 0,
+    val inGameMp: Int = 0,
+    val vpAdjustment: Int = 0,
+    val mpAdjustment: Int = 0,
+    val lastAdjustmentNote: String? = null
 )
 
 /** Confirmed troupe snapshot for one player in a round. */
@@ -238,6 +242,8 @@ data class OnlinePlayerStat(
     val moonstones: Int = 0,
     /** VP adjustment from campaign cards (can be negative). */
     val campaignCardVp: Int = 0,
+    /** MP adjustment from campaign cards played during the game (can be negative). */
+    val campaignCardMp: Int = 0,
     /** Share codes of campaign cards used this game. */
     val campaignCardCodes: List<String> = emptyList()
 )
@@ -383,6 +389,9 @@ data class CharacterState(
 
     // Online machinations phase
     val isSubmittingMachination: Boolean = false,
+
+    // Online host point adjustment (Wizard Chamberlain)
+    val isAdjustingPoints: Boolean = false,
 
     // Online campaign deletion
     val isDeletingCampaign: Boolean = false,

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -516,6 +516,16 @@ class CharacterViewModel(
                     is ApiResult.Error -> _state.update { it.copy(isAdvancingRound = false, onlineCampaignError = r.message) }
                 }
             }
+            is CharacterEvent.AdjustPlayerPoints -> viewModelScope.launch {
+                _state.update { it.copy(isAdjustingPoints = true, onlineCampaignError = null) }
+                when (val r = apiClient.adjustPlayerPoints(event.campaignId, event.targetDeviceId, event.mpDelta, event.vpDelta, event.note)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isAdjustingPoints = false) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isAdjustingPoints = false, onlineCampaignError = r.message) }
+                }
+            }
             is CharacterEvent.SubmitOnlineMatchResult -> viewModelScope.launch {
                 _state.update { it.copy(isSubmittingMatchResult = true, onlineCampaignError = null) }
                 when (val r = apiClient.submitMatchResult(event.campaignId, event.roundNumber, event.gameNumber, event.playerStats, event.winnerId)) {

--- a/app/src/main/java/io/github/garemat/lunachron/api/LunaChronApi.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/api/LunaChronApi.kt
@@ -91,6 +91,22 @@ private data class MatchResultRequest(
 )
 
 @Serializable
+private data class AdjustPointsRequest(
+    val targetDeviceId: String,
+    val mpDelta: Int,
+    val vpDelta: Int,
+    val note: String
+)
+
+@Serializable
+data class AdjustPointsResponse(
+    val deviceId: String,
+    val vpAdjustment: Int,
+    val mpAdjustment: Int,
+    val powerPoints: Int
+)
+
+@Serializable
 private data class ApiErrorBody(
     val error: String = "Unknown error",
     val code: String = "UNKNOWN",
@@ -433,6 +449,32 @@ class LunaChronApi(
         val text = response.bodyAsText()
         when (response.status.value) {
             200 -> ApiResult.Success(Unit)
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    } }
+
+    /** Apply a manual MP/VP delta to a member (host/Wizard Chamberlain only). */
+    suspend fun adjustPlayerPoints(
+        campaignId: String,
+        targetDeviceId: String,
+        mpDelta: Int,
+        vpDelta: Int,
+        note: String
+    ): ApiResult<AdjustPointsResponse> = withSession { try {
+        val body = json.encodeToString(AdjustPointsRequest(targetDeviceId, mpDelta, vpDelta, note))
+        val response = http.post("$BASE_URL/campaigns/$campaignId/adjust-points") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            200 -> ApiResult.Success(json.decodeFromString<AdjustPointsResponse>(text))
             else -> {
                 val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
                 ApiResult.Error(err.code, err.message)

--- a/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
@@ -1253,6 +1253,9 @@ private fun RecordResultCard(
     // Campaign card VP modifiers
     var myCardVp by remember { mutableIntStateOf(0) }
     var opponentCardVp by remember { mutableIntStateOf(0) }
+    // Campaign card MP modifiers (in-game grants/deductions)
+    var myCardMp by remember { mutableIntStateOf(0) }
+    var opponentCardMp by remember { mutableIntStateOf(0) }
     // Campaign cards used (set of share codes)
     var myUsedCardCodes by remember { mutableStateOf(setOf<String>()) }
     var opponentUsedCardCodes by remember { mutableStateOf(setOf<String>()) }
@@ -1366,6 +1369,17 @@ private fun RecordResultCard(
                         VpModifierSide(opponentMember?.username ?: "Opponent", opponentCardVp, { opponentCardVp = it }, Modifier.weight(1f))
                     }
 
+                    // ── Campaign card MP modifier ─────────────────────────────
+                    Text("Campaign card MP modifier", style = MaterialTheme.typography.labelMedium)
+                    Text("Adjust MP for campaign cards that grant or deduct mission points during the game.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        VpModifierSide(myMember?.username ?: "You", myCardMp, { myCardMp = it }, Modifier.weight(1f))
+                        Spacer(Modifier.width(8.dp))
+                        VpModifierSide(opponentMember?.username ?: "Opponent", opponentCardMp, { opponentCardMp = it }, Modifier.weight(1f))
+                    }
+
                     HorizontalDivider()
 
                     // ── Winner preview (auto-calculated from VP) ──────────────
@@ -1396,9 +1410,9 @@ private fun RecordResultCard(
                             }
                             val playerStats = listOf(
                                 OnlinePlayerStat(myDeviceId, myMember?.username ?: "",
-                                    myStones, myCardVp, myUsedCardCodes.toList()),
+                                    myStones, myCardVp, myCardMp, myUsedCardCodes.toList()),
                                 OnlinePlayerStat(opponentMember?.deviceId ?: "", opponentMember?.username ?: "",
-                                    opponentStones, opponentCardVp, opponentUsedCardCodes.toList())
+                                    opponentStones, opponentCardVp, opponentCardMp, opponentUsedCardCodes.toList())
                             )
                             onEvent(CharacterEvent.SubmitOnlineMatchResult(campaignId, roundNumber, gameNumber, playerStats, winnerId))
                         },
@@ -2162,7 +2176,107 @@ private fun AdminPanelSheet(
                 }
             }
 
+            // ── Adjust Player Points (Wizard Chamberlain correction) ──────
+            val approvedMembers = campaign.members.filter { it.status == "APPROVED" }
+            if (approvedMembers.isNotEmpty()) {
+                item { HorizontalDivider() }
+                item {
+                    AdjustPointsSection(
+                        campaignId = campaign.id,
+                        members = approvedMembers,
+                        isAdjusting = state.isAdjustingPoints,
+                        onEvent = onEvent,
+                        theme = theme
+                    )
+                }
+            }
+
             item { Spacer(Modifier.height(8.dp)) }
+        }
+    }
+}
+
+@Composable
+private fun AdjustPointsSection(
+    campaignId: String,
+    members: List<OnlineCampaignMember>,
+    isAdjusting: Boolean,
+    onEvent: (CharacterEvent) -> Unit,
+    theme: io.github.garemat.lunachron.ui.theme.AppThemeProperties
+) {
+    var selectedMember by remember(members) { mutableStateOf(members.first()) }
+    var dropdownOpen   by remember { mutableStateOf(false) }
+    var mpDelta        by remember { mutableIntStateOf(0) }
+    var vpDelta        by remember { mutableIntStateOf(0) }
+    var note           by remember { mutableStateOf("") }
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text("Adjust Player Points", style = MaterialTheme.typography.labelMedium)
+        Text("Correct a player's VP or MP totals (e.g. campaign card effect or scoring error).",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant)
+
+        // Player picker
+        Box {
+            OutlinedTextField(
+                value = selectedMember.username,
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Player") },
+                trailingIcon = { Icon(Icons.Default.ArrowDropDown, null) },
+                modifier = Modifier.fillMaxWidth().clickable { dropdownOpen = true }
+            )
+            DropdownMenu(expanded = dropdownOpen, onDismissRequest = { dropdownOpen = false }) {
+                members.forEach { m ->
+                    DropdownMenuItem(
+                        text = { Text(m.username) },
+                        onClick = { selectedMember = m; dropdownOpen = false }
+                    )
+                }
+            }
+        }
+
+        // MP delta
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("MP adjustment", style = MaterialTheme.typography.bodySmall, modifier = Modifier.weight(1f))
+            IconButton(onClick = { mpDelta-- }) { Icon(Icons.Default.Remove, null) }
+            Text(if (mpDelta >= 0) "+$mpDelta" else "$mpDelta",
+                style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Bold)
+            IconButton(onClick = { mpDelta++ }) { Icon(Icons.Default.Add, null) }
+        }
+
+        // VP delta
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("VP adjustment", style = MaterialTheme.typography.bodySmall, modifier = Modifier.weight(1f))
+            IconButton(onClick = { vpDelta-- }) { Icon(Icons.Default.Remove, null) }
+            Text(if (vpDelta >= 0) "+$vpDelta" else "$vpDelta",
+                style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Bold)
+            IconButton(onClick = { vpDelta++ }) { Icon(Icons.Default.Add, null) }
+        }
+
+        // Optional note
+        OutlinedTextField(
+            value = note,
+            onValueChange = { note = it },
+            label = { Text("Note (optional)") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Button(
+            onClick = {
+                onEvent(CharacterEvent.AdjustPlayerPoints(campaignId, selectedMember.deviceId, mpDelta, vpDelta, note.trim()))
+                mpDelta = 0; vpDelta = 0; note = ""
+            },
+            enabled = !isAdjusting && (mpDelta != 0 || vpDelta != 0),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            if (isAdjusting) {
+                CircularProgressIndicator(Modifier.size(16.dp), strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.onPrimary)
+            } else {
+                Text("Apply")
+            }
         }
     }
 }
@@ -2298,6 +2412,8 @@ private fun AdminLocalGameCard(
     var opponentStones    by remember { mutableIntStateOf(0) }
     var localCardVp       by remember { mutableIntStateOf(0) }
     var opponentCardVp    by remember { mutableIntStateOf(0) }
+    var localCardMp       by remember { mutableIntStateOf(0) }
+    var opponentCardMp    by remember { mutableIntStateOf(0) }
     var localUsedCards    by remember { mutableStateOf(setOf<String>()) }
     var opponentUsedCards by remember { mutableStateOf(setOf<String>()) }
 
@@ -2374,6 +2490,14 @@ private fun AdminLocalGameCard(
                 VpModifierSide(opponentMember?.username ?: "Opponent", opponentCardVp, { opponentCardVp = it }, Modifier.weight(1f))
             }
 
+            // MP modifiers
+            Text("Campaign card MP modifier", style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                VpModifierSide(localMember?.username ?: "Local", localCardMp,    { localCardMp = it },    Modifier.weight(1f))
+                VpModifierSide(opponentMember?.username ?: "Opponent", opponentCardMp, { opponentCardMp = it }, Modifier.weight(1f))
+            }
+
             // Winner preview
             HorizontalDivider()
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
@@ -2394,9 +2518,9 @@ private fun AdminLocalGameCard(
                 onClick = {
                     val stats = listOf(
                         OnlinePlayerStat(localPlayerId, localMember?.username ?: "",
-                            localStones, localCardVp, localUsedCards.toList()),
+                            localStones, localCardVp, localCardMp, localUsedCards.toList()),
                         OnlinePlayerStat(opponentId, opponentMember?.username ?: "",
-                            opponentStones, opponentCardVp, opponentUsedCards.toList())
+                            opponentStones, opponentCardVp, opponentCardMp, opponentUsedCards.toList())
                     )
                     onEvent(CharacterEvent.SubmitOnlineMatchResult(campaignId, roundNumber, gameNumber, stats, winnerId))
                 },


### PR DESCRIPTION
## Summary

- `OnlinePlayerStat` gains `campaignCardMp` (signed int); submitted alongside `campaignCardVp` in match results.
- Both `RecordResultCard` and `AdminLocalGameCard` now show a "Campaign card MP modifier" stepper matching the existing VP one.
- `OnlineCampaignMember` gains `inGameMp`, `vpAdjustment`, `mpAdjustment`, `lastAdjustmentNote` to reflect new backend columns.
- New `AdjustPlayerPoints` event → `CharacterViewModel` handler → `LunaChronApi.adjustPlayerPoints()` → `POST /campaigns/:id/adjust-points`.
- `AdminPanelSheet` ("Chamberlain Admin") gains an "Adjust Player Points" section: player dropdown, ±MP/±VP steppers, optional note field, Apply button.

## Test plan

- [ ] `./gradlew assembleGithubDebug` — builds cleanly
- [ ] Submit a match result with non-zero `campaignCardMp` — confirm rankings reflect `powerPoints` update after round verification
- [ ] Host opens campaign → admin panel → "Adjust Player Points" section visible with player dropdown
- [ ] Enter ±MP/±VP, optional note, tap Apply → `powerPoints` updates for target player; form resets
- [ ] Confirm Apply button disabled when both deltas are 0
- [ ] Non-host opens same campaign → admin panel button not shown in top bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)