### PR TITLE
fix: ExposedDropdownMenuBox for Chamberlain adjust-points player picker

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
@@ -2196,6 +2196,7 @@ private fun AdminPanelSheet(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun AdjustPointsSection(
     campaignId: String,

--- a/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
@@ -2217,16 +2217,22 @@ private fun AdjustPointsSection(
             color = MaterialTheme.colorScheme.onSurfaceVariant)
 
         // Player picker
-        Box {
+        ExposedDropdownMenuBox(
+            expanded = dropdownOpen,
+            onExpandedChange = { dropdownOpen = it }
+        ) {
             OutlinedTextField(
                 value = selectedMember.username,
                 onValueChange = {},
                 readOnly = true,
                 label = { Text("Player") },
-                trailingIcon = { Icon(Icons.Default.ArrowDropDown, null) },
-                modifier = Modifier.fillMaxWidth().clickable { dropdownOpen = true }
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = dropdownOpen) },
+                modifier = Modifier.fillMaxWidth().menuAnchor()
             )
-            DropdownMenu(expanded = dropdownOpen, onDismissRequest = { dropdownOpen = false }) {
+            ExposedDropdownMenu(
+                expanded = dropdownOpen,
+                onDismissRequest = { dropdownOpen = false }
+            ) {
                 members.forEach { m ->
                     DropdownMenuItem(
                         text = { Text(m.username) },


### PR DESCRIPTION
## Summary

- Replaces `Box { OutlinedTextField(.clickable) + DropdownMenu }` with `ExposedDropdownMenuBox` + `.menuAnchor()` in `AdjustPointsSection`
- `OutlinedTextField` absorbs pointer events, so the `.clickable` modifier never fired — player selection was broken
- Pattern matches existing dropdown usage in `CampaignDetailsScreen.kt`

## Test plan

- [ ] Host opens campaign admin panel → "Adjust Player Points" section
- [ ] Tap the Player field → dropdown opens with all approved members listed
- [ ] Select a different player → field updates, Apply targets the correct player

🤖 Generated with [Claude Code](https://claude.com/claude-code)