### PR TITLE
fix: trigger Build and Test CI on bot-created data-bump PRs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,12 +3,15 @@ name: Build and Test
 on:
   pull_request:
     branches: [ "main" ]
+  # Allows CI to run on bot-created PRs (GITHUB_TOKEN can't trigger pull_request events)
+  push:
+    branches: [ "chore/data-*" ]
+  workflow_dispatch:
 
 jobs:
   build:
     uses: garemat/lunachron/.github/workflows/validate.yml@main
     with:
       pr_body: ${{ github.event.pull_request.body }}
-      # Dependabot generates its own PR body and cannot fill in the checklist.
-      # All other actors must pass validation — a blank body will fail the grep.
-      skip_pr_validation: ${{ github.actor == 'dependabot[bot]' }}
+      # Skip checklist validation for bots and non-PR triggers (no PR body available)
+      skip_pr_validation: ${{ github.actor == 'dependabot[bot]' || github.actor == 'github-actions[bot]' || github.event_name != 'pull_request' }}


### PR DESCRIPTION
## Summary
- Adds `push: branches: ['chore/data-*']` trigger so CI runs automatically when the bump-data workflow pushes a new data branch
- Adds `workflow_dispatch` for manual recovery if needed
- Extends `skip_pr_validation` to skip checklist checks for `github-actions[bot]` and non-PR events (no PR body available in those contexts)

**Root cause:** `GITHUB_TOKEN` cannot trigger other workflow runs — a GitHub security restriction to prevent loops. This means bot-created PRs never fire `pull_request` events, so `Build and Test` never ran.

## Checklist
- [x] Workflow change only, no app code changed
- [x] Tested trigger logic against existing validate.yml behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)