### PR TITLE
fix: include mp_adjustment and in_game_mp in displayed MP total

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
@@ -691,8 +691,9 @@ private fun OnlineRankingCard(
                     maxLines = 1, overflow = TextOverflow.Ellipsis)
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     Text("${member.victoryPoints} VP", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                    if (member.matchPoints > 0) {
-                        Text("+${member.matchPoints} MP", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.tertiary)
+                    val totalMp = member.matchPoints + member.mpAdjustment + member.inGameMp
+                    if (totalMp != 0) {
+                        Text("${if (totalMp > 0) "+" else ""}$totalMp MP", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.tertiary)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- The `+X MP` label in the campaign leaderboard row previously only showed `matchPoints`, making host point adjustments (`mpAdjustment`) and campaign card MP (`inGameMp`) invisible
- Now sums all three so the displayed MP matches what's actually contributing to a player's PP
- Negative totals (e.g. a penalty adjustment) render without a `+` prefix

## Test plan
- [ ] Player with only match points: label shows `+N MP` as before
- [ ] Player with a host MP adjustment applied: label reflects the adjusted total
- [ ] Player with no MP at all: label hidden
- [ ] Player with a negative net MP: label shows `-N MP`

🤖 Generated with [Claude Code](https://claude.com/claude-code)