### PR TITLE
fix: transfer persistent device ID and session expiry in migration payload

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/Character.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/Character.kt
@@ -338,5 +338,7 @@ data class MigrationPayload(
     val gameResults: List<GameResult>,
     val sessionToken: String? = null,
     val backendDeviceId: String? = null,
+    val persistentDeviceId: String? = null,
+    val sessionExpiresAt: String? = null,
     val expiresAt: Long = 0,
 )

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -925,6 +925,8 @@ class CharacterViewModel(
                         gameResults = gameResults.value,
                         sessionToken = prefs.getString("api_session_token", null),
                         backendDeviceId = prefs.getString("api_backend_device_id", null),
+                        persistentDeviceId = prefs.getString("persistent_device_id", null),
+                        sessionExpiresAt = prefs.getString("api_session_expires", null),
                         expiresAt = System.currentTimeMillis() + 15 * 60 * 1000L
                     )
                     DataMigration.encode(payload)
@@ -961,6 +963,10 @@ class CharacterViewModel(
                         prefs.edit {
                             putString("api_session_token", payload.sessionToken)
                             putString("api_backend_device_id", payload.backendDeviceId)
+                            if (!payload.persistentDeviceId.isNullOrBlank())
+                                putString("persistent_device_id", payload.persistentDeviceId)
+                            if (!payload.sessionExpiresAt.isNullOrBlank())
+                                putString("api_session_expires", payload.sessionExpiresAt)
                         }
                         _state.update { it.copy(isRegistered = true, backendDeviceId = payload.backendDeviceId ?: "") }
                     }


### PR DESCRIPTION
## Summary

- `MigrationPayload` now includes `persistentDeviceId` and `sessionExpiresAt` alongside the existing `sessionToken` and `backendDeviceId`
- On import with **Transfer campaign registration** enabled, both values are written to SharedPreferences
- On next app start after migration, the startup token-refresh calls `login(persistentDeviceId)` with the correct registered UUID and gets a fresh token

## Root cause

The migration code transferred the raw session token and backend device UUID, but not the `persistent_device_id` UUID (a random UUID generated by the app, used as the key for `/auth/login`). On the new install (e.g. Play Store after GitHub), the UUID in prefs was freshly generated and never registered in the backend, so `login()` returned `DEVICE_NOT_FOUND` silently on every startup.

`api_session_expires` was also not transferred, meaning `isTokenExpiringSoon()` always returned `true` (null → treats as expiring) — the reason the broken refresh ran on every single startup rather than just near expiry.

The 30-day token worked fine until it expired, at which point there was no recovery path: every startup tried and failed to refresh, and the expired token was rejected by the server.

## Test plan

- [ ] Export migration code from a registered device
- [ ] Import on a fresh install with "Transfer campaign registration" enabled
- [ ] Force-close and reopen the app — confirm no "Session token has expired" error and campaigns load
- [ ] Confirm `persistent_device_id` in prefs on the new install matches the source device's value

🤖 Generated with [Claude Code](https://claude.com/claude-code)