### PR TITLE
feat: adopt-device recovery for cross-install migrations

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/Character.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/Character.kt
@@ -338,5 +338,7 @@ data class MigrationPayload(
     val gameResults: List<GameResult>,
     val sessionToken: String? = null,
     val backendDeviceId: String? = null,
+    val persistentDeviceId: String? = null,
+    val sessionExpiresAt: String? = null,
     val expiresAt: Long = 0,
 )

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -159,12 +159,21 @@ class CharacterViewModel(
         nearbyManager.setPayloadListener { endpointId, message -> handleSessionMessage(endpointId, message) }
         // Silently refresh token on startup: backfills backendDeviceId for old registrations
         // and proactively renews tokens within 10 days of expiry.
+        // If login returns DEVICE_NOT_FOUND, the persistent device ID changed between installs
+        // (e.g. GitHub → Play Store migration) — fall back to adopt-device, which accepts the
+        // stored (expired) token as proof of identity and re-keys the account to this device.
         if (_state.value.isRegistered &&
             (_state.value.backendDeviceId.isEmpty() || apiClient.isTokenExpiringSoon())) {
             viewModelScope.launch {
                 val result = apiClient.login(persistentDeviceId)
-                if (result is ApiResult.Success && result.data.deviceId != null) {
-                    _state.update { it.copy(backendDeviceId = result.data.deviceId) }
+                when {
+                    result is ApiResult.Success && result.data.deviceId != null ->
+                        _state.update { it.copy(backendDeviceId = result.data.deviceId) }
+                    result is ApiResult.Error && result.code == "DEVICE_NOT_FOUND" -> {
+                        val adopt = apiClient.adoptDevice(persistentDeviceId)
+                        if (adopt is ApiResult.Success && adopt.data.deviceId != null)
+                            _state.update { it.copy(backendDeviceId = adopt.data.deviceId) }
+                    }
                 }
             }
         }

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -925,6 +925,8 @@ class CharacterViewModel(
                         gameResults = gameResults.value,
                         sessionToken = prefs.getString("api_session_token", null),
                         backendDeviceId = prefs.getString("api_backend_device_id", null),
+                        persistentDeviceId = prefs.getString("persistent_device_id", null),
+                        sessionExpiresAt = prefs.getString("api_session_expires", null),
                         expiresAt = System.currentTimeMillis() + 15 * 60 * 1000L
                     )
                     DataMigration.encode(payload)
@@ -961,6 +963,10 @@ class CharacterViewModel(
                         prefs.edit {
                             putString("api_session_token", payload.sessionToken)
                             putString("api_backend_device_id", payload.backendDeviceId)
+                            if (!payload.persistentDeviceId.isNullOrBlank())
+                                putString("persistent_device_id", payload.persistentDeviceId)
+                            if (!payload.sessionExpiresAt.isNullOrBlank())
+                                putString("api_session_expires", payload.sessionExpiresAt)
                         }
                         _state.update { it.copy(isRegistered = true, backendDeviceId = payload.backendDeviceId ?: "") }
                     }

--- a/app/src/main/java/io/github/garemat/lunachron/api/LunaChronApi.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/api/LunaChronApi.kt
@@ -222,6 +222,27 @@ class LunaChronApi(
         ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
     }
 
+    /**
+     * Transfers this account to [newDeviceId] using the stored (possibly expired)
+     * session token as proof of identity. Called automatically when [login] returns
+     * DEVICE_NOT_FOUND — which happens when the persistent device ID changed between
+     * installs (e.g. GitHub APK → Play Store) and the old token has since expired.
+     *
+     * On success the backend updates the device ID hash and issues a fresh token,
+     * which [handleAuthResponse] persists via [saveToken].
+     */
+    suspend fun adoptDevice(newDeviceId: String): ApiResult<AuthResponse> = try {
+        val body = """{"newDeviceId":"$newDeviceId"}"""
+        val response = http.post("$BASE_URL/auth/adopt-device") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+        handleAuthResponse(response, onDeviceExists = null)
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    }
+
     // ── Campaign endpoints ────────────────────────────────────────────────────
 
     /** Create a new campaign and return its ID and 6-char join code. */
@@ -677,8 +698,12 @@ class LunaChronApi(
         val result = block()
         if (result is ApiResult.Error && result.code == "AUTH_EXPIRED") {
             val deviceId = prefs.getString(KEY_ANDROID_DEVICE_ID, null) ?: return result
-            if (login(deviceId) is ApiResult.Error) return result
-            return block()
+            val loginResult = login(deviceId)
+            if (loginResult is ApiResult.Success) return block()
+            if (loginResult is ApiResult.Error && loginResult.code == "DEVICE_NOT_FOUND") {
+                if (adoptDevice(deviceId) is ApiResult.Success) return block()
+            }
+            return result
         }
         return result
     }


### PR DESCRIPTION
## Summary

- Adds `adoptDevice()` to `LunaChronApi` — calls `POST /auth/adopt-device` with the stored (possibly expired) token as proof of identity
- On startup: if `login()` returns `DEVICE_NOT_FOUND`, automatically falls back to `adoptDevice()` to re-key the account to the current device
- In `withSession`: same fallback, covering any mid-session `AUTH_EXPIRED` → `DEVICE_NOT_FOUND` path

## Why

When someone migrates GitHub APK → Play Store, the `persistent_device_id` differs between installs. Login keeps failing with `DEVICE_NOT_FOUND` against the new device ID. Eventually the 30-day token expires with no recovery path and the user sees "Session token has expired."

With this change, the app silently calls `adopt-device` on the next launch after updating — their account is re-keyed to the Play Store device ID, a fresh token is issued, and all campaign history is preserved.

Depends on the `feat: add POST /auth/adopt-device endpoint` backend change, which is already live on the API.

## Test plan

- [ ] Register on a debug build, copy the `persistent_device_id` SharedPref to a different value, let the token expire — confirm app silently recovers on next launch
- [ ] Confirm campaigns and history remain intact after recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)