### PR TITLE
feat: host can force-verify pending match results

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterEvent.kt
@@ -174,6 +174,8 @@ sealed interface CharacterEvent {
 
     // LunaChron API — match result verification (opponent approves or contests)
     data class VerifyMatchResult(val campaignId: String, val resultId: String, val agree: Boolean) : CharacterEvent
+    // LunaChron API — host force-verifies a pending result without opponent confirmation
+    data class OverrideMatchResult(val campaignId: String, val resultId: String) : CharacterEvent
 
     // LunaChron API — round troupe confirmation (before a match, mutual reveal)
     data class ConfirmRoundTroupe(

--- a/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterViewModel.kt
@@ -575,6 +575,16 @@ class CharacterViewModel(
                     is ApiResult.Error -> _state.update { it.copy(isVerifyingMatchResult = false, onlineCampaignError = r.message) }
                 }
             }
+            is CharacterEvent.OverrideMatchResult -> viewModelScope.launch {
+                _state.update { it.copy(isVerifyingMatchResult = true, onlineCampaignError = null) }
+                when (val r = apiClient.overrideMatchResult(event.campaignId, event.resultId)) {
+                    is ApiResult.Success -> {
+                        _state.update { it.copy(isVerifyingMatchResult = false) }
+                        onEvent(CharacterEvent.LoadOnlineCampaign(event.campaignId))
+                    }
+                    is ApiResult.Error -> _state.update { it.copy(isVerifyingMatchResult = false, onlineCampaignError = r.message) }
+                }
+            }
             is CharacterEvent.ConfirmRoundTroupe -> viewModelScope.launch {
                 _state.update { it.copy(isConfirmingRoundTroupe = true, onlineCampaignError = null) }
                 when (val r = apiClient.confirmRoundTroupe(event.campaignId, event.roundNumber, event.troupeData, event.targetDeviceId)) {

--- a/app/src/main/java/io/github/garemat/lunachron/api/LunaChronApi.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/api/LunaChronApi.kt
@@ -564,6 +564,26 @@ class LunaChronApi(
         ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
     } }
 
+    /** Host-only: force-verify a pending match result without opponent confirmation. */
+    suspend fun overrideMatchResult(campaignId: String, resultId: String): ApiResult<Unit> = withSession { try {
+        val body = """{"resultId":"$resultId"}"""
+        val response = http.post("$BASE_URL/campaigns/$campaignId/override-result") {
+            authorize()
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+        val text = response.bodyAsText()
+        when (response.status.value) {
+            200 -> ApiResult.Success(Unit)
+            else -> {
+                val err = runCatching { json.decodeFromString<ApiErrorBody>(text) }.getOrDefault(ApiErrorBody())
+                ApiResult.Error(err.code, err.message)
+            }
+        }
+    } catch (e: Exception) {
+        ApiResult.Error("NETWORK_ERROR", e.message ?: "Network error")
+    } }
+
     /** Add a named local (unattended) player to a campaign (host only). */
     suspend fun addLocalMember(campaignId: String, name: String): ApiResult<AddLocalMemberResponse> = withSession { try {
         val body = """{"name":${json.encodeToString(name)}}"""

--- a/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
@@ -540,7 +540,9 @@ private fun ActiveCampaignHome(
                 onDecodeTroupe = onDecodeTroupe)
             ActiveTab.SCHEDULE    -> OnlineScheduleTabContent(
                 campaign = campaign,
-                showCurrentRoundScores = inMachinationsPhase
+                showCurrentRoundScores = inMachinationsPhase,
+                isHost = isHost,
+                onEvent = onEvent
             )
             ActiveTab.MACHINATIONS -> if (inMachinationsPhase) {
                 OnlineMachinationsTab(campaign = campaign, state = state, onEvent = onEvent, onDecodeTroupe = onDecodeTroupe)
@@ -837,7 +839,12 @@ private fun TroupeDetailSheet(
 // ── Schedule tab ──────────────────────────────────────────────────────────────
 
 @Composable
-private fun OnlineScheduleTabContent(campaign: OnlineCampaignDetail, showCurrentRoundScores: Boolean = false) {
+private fun OnlineScheduleTabContent(
+    campaign: OnlineCampaignDetail,
+    showCurrentRoundScores: Boolean = false,
+    isHost: Boolean = false,
+    onEvent: ((CharacterEvent) -> Unit)? = null
+) {
     val theme = LocalAppThemeProperties.current
     val schedule = campaign.schedule
     if (schedule == null) {
@@ -900,7 +907,7 @@ private fun OnlineScheduleTabContent(campaign: OnlineCampaignDetail, showCurrent
                                 val p1Name = campaign.members.find { it.deviceId == p1Id }?.username ?: "?"
                                 val p2Name = campaign.members.find { it.deviceId == p2Id }?.username ?: "?"
                                 val roundComplete = roundNum < campaign.currentRound ||
-                                    (roundNum == campaign.currentRound && showCurrentRoundScores)
+                                    (roundNum == campaign.currentRound && (showCurrentRoundScores || isHost))
                                 val result = if (roundComplete) campaign.matchResults.firstOrNull {
                                     it.roundNumber == roundNum && it.gameNumber == gameNum
                                 } else null
@@ -909,7 +916,10 @@ private fun OnlineScheduleTabContent(campaign: OnlineCampaignDetail, showCurrent
                                     p2Name = p2Name,
                                     result = result,
                                     p1Id = p1Id,
-                                    p2Id = p2Id
+                                    p2Id = p2Id,
+                                    isHost = isHost,
+                                    campaignId = campaign.id,
+                                    onEvent = onEvent
                                 )
                             }
                         }
@@ -926,7 +936,10 @@ private fun GameResultRow(
     p2Name: String,
     result: OnlineMatchResult?,
     p1Id: String?,
-    p2Id: String?
+    p2Id: String?,
+    isHost: Boolean = false,
+    campaignId: String? = null,
+    onEvent: ((CharacterEvent) -> Unit)? = null
 ) {
     if (result == null) {
         Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
@@ -1012,6 +1025,15 @@ private fun GameResultRow(
                     style = MaterialTheme.typography.labelSmall,
                     color = statusColor
                 )
+            }
+            if (isHost && result.verifyStatus == "PENDING" && campaignId != null && onEvent != null) {
+                TextButton(
+                    onClick = { onEvent(CharacterEvent.OverrideMatchResult(campaignId, result.id)) },
+                    modifier = Modifier.align(Alignment.End).height(28.dp),
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp)
+                ) {
+                    Text("Force verify", style = MaterialTheme.typography.labelSmall)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Adds `OverrideMatchResult` event → `apiClient.overrideMatchResult()` → `POST /campaigns/:id/override-result`
- Schedule tab now shows current-round results to the host even before machinations phase
- PENDING results in the Schedule tab show a "Force verify" button for the host

## Test plan
- [ ] Non-host sees no "Force verify" button
- [ ] Host sees current round results in Schedule tab before machinations phase
- [ ] "Force verify" button appears on PENDING games, not VERIFIED/DISPUTED
- [ ] Tapping it verifies the result and refreshes the campaign

🤖 Generated with [Claude Code](https://claude.com/claude-code)