### PR TITLE
fix: sort machination target list by powerPoints not matchPoints

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/ui/MachinationsPhaseUI.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/MachinationsPhaseUI.kt
@@ -78,10 +78,7 @@ internal fun OnlineMachinationsTab(
     val attacksEnabled = campaign.settings?.attacksEnabled == true
 
     val rankedMembers = remember(approvedMembers) {
-        approvedMembers.sortedWith(
-            compareByDescending<OnlineCampaignMember> { it.matchPoints }
-                .thenByDescending { it.victoryPoints }
-        )
+        approvedMembers.sortedByDescending { it.powerPoints }
     }
     val rankOf = remember(rankedMembers) {
         rankedMembers.mapIndexed { i, m -> m.deviceId to i + 1 }.toMap()


### PR DESCRIPTION
## Summary

- The machination submission screen ranked players by `matchPoints` then `victoryPoints`, ignoring `mpAdjustment` and `inGameMp`.
- Any player with host-applied point corrections (`mpAdjustment`) or in-game MP (`inGameMp`) would appear at the wrong rank, causing both the rank badge and the tier-based impact hints (TOP/MIDDLE/BOTTOM) to be wrong.
- Fix: sort by `powerPoints` (the pre-computed total already stored on the member: `VP + vpAdj + MP + mpAdj + igmp`).

## Test plan

- [ ] Open machination submission screen for a campaign where players have `mpAdjustment` or `inGameMp` values — confirm rank badges reflect full power points standings
- [ ] Confirm SUPPORT/SABOTAGE tier hints (TOP/MIDDLE/BOTTOM) match the actual campaign leaderboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)