### PR TITLE
feat: submission status in machinations tab; full detail in admin panel

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/ui/MachinationsPhaseUI.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/MachinationsPhaseUI.kt
@@ -205,6 +205,39 @@ internal fun OnlineMachinationsTab(
             }
         }
 
+        // Submission status — visible to all, shows who has/hasn't submitted yet
+        item {
+            val submittedIds = remember(campaign.machinations) {
+                campaign.machinations.map { it.deviceId }.toSet()
+            }
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                approvedMembers.forEach { m ->
+                    val done = m.deviceId in submittedIds
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(3.dp)
+                    ) {
+                        Icon(
+                            if (done) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked,
+                            contentDescription = null,
+                            modifier = Modifier.size(11.dp),
+                            tint = if (done) SupportGreen
+                                   else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f)
+                        )
+                        Text(
+                            m.username,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (done) MaterialTheme.colorScheme.onSurface
+                                    else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f)
+                        )
+                    }
+                }
+            }
+        }
+
         if (myDeviceId.isNotEmpty() && eligibleTargets.isNotEmpty()) {
             // Opponent exclusion notice
             if (myNextOpponentId != null) {

--- a/app/src/main/java/io/github/garemat/lunachron/ui/MachinationsPhaseUI.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/MachinationsPhaseUI.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalLayoutApi::class)
+
 package io.github.garemat.lunachron.ui
 
 import androidx.compose.animation.AnimatedVisibility

--- a/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
@@ -2795,6 +2795,30 @@ private fun MachinationsOverviewSection(
                 )
             }
         }
+
+        // Per-player submission detail
+        if (machinations.any { it.choices.isNotEmpty() }) {
+            val memberByDeviceId = members.associateBy { it.deviceId }
+            HorizontalDivider(thickness = 0.5.dp, modifier = Modifier.padding(top = 2.dp))
+            Text("Submissions", style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 2.dp))
+            for (entry in machinations.filter { it.choices.isNotEmpty() }) {
+                Column(verticalArrangement = Arrangement.spacedBy(1.dp)) {
+                    Text(entry.username, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold)
+                    entry.choices.forEach { choice ->
+                        val targetName = memberByDeviceId[choice.targetDeviceId]?.username ?: "?"
+                        val choiceColor = if (choice.type == "SUPPORT") Color(0xFF4CAF50)
+                                          else MaterialTheme.colorScheme.error
+                        Text(
+                            "  ${choice.type} → $targetName",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = choiceColor
+                        )
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- **All members**: Machinations tab now shows a per-player submitted/waiting row (green check = submitted, faded = still waiting). The existing X/Y count in the header now reflects real data for non-hosts thanks to the paired backend change.
- **Host (admin panel)**: A "Submissions" detail list appears beneath the overview table, showing each player's choices (SUPPORT/SABOTAGE + target name) as they trickle in.

## Test plan

- [ ] Non-host sees submitted/waiting indicators in the Machinations tab — names, no choices
- [ ] Host admin panel shows summary table + per-player submission detail with correct target names and colours
- [ ] X/Y submitted count in header is accurate for non-host devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)