### PR TITLE
fix: scope host previousRoundMachinations to a single round

### DIFF
--- a/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/CharacterState.kt
@@ -211,6 +211,9 @@ data class OnlineMachinationAttack(
 data class OnlineMachinationEntry(
     val deviceId: String,
     val username: String,
+    // Only sent (as >0) for hosts, whose previousRoundMachinations spans every
+    // past round rather than just the previous one. Defaults to 0 for member
+    // responses, which the server already scopes to a single round.
     val roundNumber: Int = 0,
     val choices: List<OnlineMachinationChoice> = emptyList(),
     val attack: OnlineMachinationAttack? = null

--- a/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
+++ b/app/src/main/java/io/github/garemat/lunachron/ui/OnlineCampaignDetailScreen.kt
@@ -1281,10 +1281,13 @@ private fun PreviousRoundMachinationsSection(
         val drawCount: Int
     )
 
-    val results = remember(machinations, members) {
+    val results = remember(machinations, members, previousRound) {
         val supportersOf = mutableMapOf<String, MutableList<String>>()
         val sabotageCountOf = mutableMapOf<String, Int>()
+        // Hosts receive every past round's submissions (tagged with roundNumber > 0);
+        // members receive only the previous round, where roundNumber defaults to 0.
         for (entry in machinations) {
+            if (entry.roundNumber > 0 && entry.roundNumber != previousRound) continue
             for (choice in entry.choices) {
                 if (choice.type == "SUPPORT") {
                     supportersOf.getOrPut(choice.targetDeviceId) { mutableListOf() }.add(entry.username)


### PR DESCRIPTION
## Description
Backend PR #15 in lunachron-backend changed the host-only `previousRoundMachinations` query to return every past round's submissions (tagged with a new `roundNumber` field) instead of just the previous round. The app never picked up the new field, so `PreviousRoundMachinationsSection` flattened all past rounds together, inflating "Supported by" lists with duplicate names for hosts only — member responses stayed correctly scoped server-side and were unaffected.

This adds `roundNumber: Int?` to `OnlineMachinationEntry` (null when absent, i.e. for member responses) and filters entries by `roundNumber == previousRound` before aggregating supporters/sabotages, so hosts see the same single-round data as everyone else.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (N/A for now)
- [x] New and existing unit tests pass locally with my changes (N/A for now)